### PR TITLE
CP-308798: Dynamic control of firewalld service - part 3

### DIFF
--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -134,11 +134,6 @@ let refresh_localhost_info ~__context info =
   ) else
     Db.Host.remove_from_other_config ~__context ~self:host
       ~key:Xapi_globs.host_no_local_storage ;
-  let module F =
-    ( val Firewall.firewall_provider !Xapi_globs.firewall_backend
-        : Firewall.FIREWALL
-      )
-  in
   let status =
     match Db.Host.get_https_only ~__context ~self:host with
     | true ->
@@ -151,7 +146,7 @@ let refresh_localhost_info ~__context info =
         : Firewall.FIREWALL
       )
   in
-  Fw.update_firewall_status ~service:Firewall.Http ~status
+  Fw.update_firewall_status Firewall.Http status
 (*************** update database tools ******************)
 
 (** Record host memory properties in database *)

--- a/ocaml/xapi/firewall.ml
+++ b/ocaml/xapi/firewall.ml
@@ -87,11 +87,12 @@ let service_type_to_service_info = function
       }
 
 module type FIREWALL = sig
-  val update_firewall_status : service:service_type -> status:status -> unit
+  val update_firewall_status :
+    ?interfaces:string list -> service_type -> status -> unit
 end
 
 module Firewalld : FIREWALL = struct
-  let update_firewall_status ~service ~status =
+  let update_firewall_status ?(interfaces = []) service status =
     if !Xapi_globs.dynamic_control_firewalld_service then (
       let service_option =
         match status with
@@ -101,6 +102,16 @@ module Firewalld : FIREWALL = struct
             "--remove-service"
       in
       let service_info = service_type_to_service_info service in
+      ( match interfaces with
+      | _ :: _ when service = Nbd ->
+          let interface_list = String.concat ", " interfaces in
+          debug
+            "%s: Enable NBD service as the following interfaces are used for \
+             NBD: [%s]"
+            __FUNCTION__ interface_list
+      | _ ->
+          ()
+      ) ;
       try
         Helpers.call_script !Xapi_globs.firewall_cmd
           [service_option; service_info.name]
@@ -116,19 +127,29 @@ module Firewalld : FIREWALL = struct
 end
 
 module Iptables : FIREWALL = struct
-  let update_firewall_status ~service ~status =
-    let op = match status with Enabled -> "open" | Disabled -> "close" in
+  let update_firewall_status ?(interfaces = []) service status =
     let service_info = service_type_to_service_info service in
     if service_info.dynamic_control_iptables_port then (
       try
-        Helpers.call_script
-          !Xapi_globs.firewall_port_config_script
-          [
-            op
-          ; string_of_int service_info.port
-          ; protocol_to_string service_info.protocol
-          ]
-        |> ignore
+        match service with
+        | Dlm | Ssh | Vxlan | Http | Xenha ->
+            let op =
+              match status with Enabled -> "open" | Disabled -> "close"
+            in
+            Helpers.call_script
+              !Xapi_globs.firewall_port_config_script
+              [
+                op
+              ; string_of_int service_info.port
+              ; protocol_to_string service_info.protocol
+              ]
+            |> ignore
+        | Nbd ->
+            (* For legacy iptables, NBD port needs to be precisely controlled on
+               each interface *)
+            let args = "set" :: interfaces in
+            Helpers.call_script !Xapi_globs.nbd_firewall_config_script args
+            |> ignore
       with e ->
         error
           "%s: Failed to update firewall service (%s) to (%s) with error: %s"

--- a/ocaml/xapi/firewall.mli
+++ b/ocaml/xapi/firewall.mli
@@ -17,7 +17,16 @@ type service_type = Dlm | Nbd | Ssh | Vxlan | Http | Xenha
 type status = Enabled | Disabled
 
 module type FIREWALL = sig
-  val update_firewall_status : service:service_type -> status:status -> unit
+  val update_firewall_status :
+    ?interfaces:string list -> service_type -> status -> unit
+  (** [update_firewall_status] updates the firewalld service status based on the
+      status of the corresponding service.
+
+      [interfaces]  is a list of bridge names of the Network objects whose
+      purpose is `nbd` or `insecure_nbd`. [interfaces] is only used to controll
+      the NBD iptables port dynamically, to specify which interfaces are
+      permitted for NBD connections.
+  *)
 end
 
 module Firewalld : FIREWALL

--- a/ocaml/xapi/network_event_loop.ml
+++ b/ocaml/xapi/network_event_loop.ml
@@ -110,11 +110,20 @@ let _watch_networks_for_nbd_changes __context ~update_firewall
   loop ~token:"" ~allowed_interfaces
 
 let update_firewall interfaces_allowed_for_nbd =
-  let args = "set" :: interfaces_allowed_for_nbd in
-  Forkhelpers.execute_command_get_output
-    !Xapi_globs.nbd_firewall_config_script
-    args
-  |> ignore
+  let module Fw =
+    ( val Firewall.firewall_provider !Xapi_globs.firewall_backend
+        : Firewall.FIREWALL
+      )
+  in
+  let status =
+    match interfaces_allowed_for_nbd with
+    | [] ->
+        Firewall.Disabled
+    | _ ->
+        Firewall.Enabled
+  in
+  Fw.update_firewall_status ~interfaces:interfaces_allowed_for_nbd Firewall.Nbd
+    status
 
 let watch_networks_for_nbd_changes () =
   Server_helpers.exec_with_new_task "watching networks for NBD-related changes"

--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -790,8 +790,7 @@ let bring_pif_up ~__context ?(management_interface = false) (pif : API.ref_PIF)
                         : Firewall.FIREWALL
                       )
                   in
-                  Fw.update_firewall_status ~service:Firewall.Vxlan
-                    ~status:Firewall.Enabled
+                  Fw.update_firewall_status Firewall.Vxlan Firewall.Enabled
               | `gre ->
                   ()
             )
@@ -854,8 +853,7 @@ let bring_pif_down ~__context ?(force = false) (pif : API.ref_PIF) =
                         : Firewall.FIREWALL
                       )
                   in
-                  Fw.update_firewall_status ~service:Firewall.Vxlan
-                    ~status:Firewall.Disabled
+                  Fw.update_firewall_status Firewall.Vxlan Firewall.Disabled
                 )
             | `gre ->
                 ()

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -260,7 +260,7 @@ module Daemon = struct
               : Firewall.FIREWALL
             )
         in
-        Fw.update_firewall_status ~service:Firewall.Dlm ~status
+        Fw.update_firewall_status Firewall.Dlm status
 
   let service = "xapi-clusterd"
 

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -972,7 +972,7 @@ let ha_start_daemon () =
         : Firewall.FIREWALL
       )
   in
-  Fw.update_firewall_status ~service:Firewall.Xenha ~status:Firewall.Enabled ;
+  Fw.update_firewall_status Firewall.Xenha Firewall.Enabled ;
   let (_ : string) = call_script ha_start_daemon [] in
   ()
 
@@ -1139,7 +1139,7 @@ let ha_stop_daemon __context _localhost =
       )
   in
   Monitor.stop () ;
-  Fw.update_firewall_status ~service:Firewall.Xenha ~status:Firewall.Disabled ;
+  Fw.update_firewall_status Firewall.Xenha Firewall.Disabled ;
 
   let (_ : string) = call_script ha_stop_daemon [] in
   ()

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -3126,7 +3126,7 @@ let set_https_only ~__context ~self ~value =
             : Firewall.FIREWALL
           )
       in
-      Fw.update_firewall_status ~service:Firewall.Http ~status ;
+      Fw.update_firewall_status Firewall.Http status ;
       Db.Host.set_https_only ~__context ~self ~value
   | true when value = Db.Host.get_https_only ~__context ~self ->
       (* the new value is the same as the old value *)
@@ -3165,7 +3165,7 @@ let set_ssh_auto_mode ~__context ~self ~value =
        (e.g., when XAPI is down) to allow administrative access for troubleshooting. *)
     if value then (
       (* Ensure SSH is always enabled when SSH auto mode is on*)
-      Fw.update_firewall_status ~service:Firewall.Ssh ~status:Firewall.Enabled ;
+      Fw.update_firewall_status Firewall.Ssh Firewall.Enabled ;
       Xapi_systemctl.enable ~wait_until_success:false !Xapi_globs.ssh_service ;
       Xapi_systemctl.enable ~wait_until_success:false
         !Xapi_globs.ssh_monitor_service ;
@@ -3176,7 +3176,7 @@ let set_ssh_auto_mode ~__context ~self ~value =
         !Xapi_globs.ssh_monitor_service ;
       Xapi_systemctl.disable ~wait_until_success:false
         !Xapi_globs.ssh_monitor_service ;
-      Fw.update_firewall_status ~service:Firewall.Ssh ~status:Firewall.Disabled
+      Fw.update_firewall_status Firewall.Ssh Firewall.Disabled
     )
   with e ->
     error "Failed to configure SSH auto mode: %s" (Printexc.to_string e) ;
@@ -3194,7 +3194,7 @@ let disable_ssh_internal ~__context ~self =
           : Firewall.FIREWALL
         )
     in
-    Fw.update_firewall_status ~service:Firewall.Ssh ~status:Firewall.Disabled ;
+    Fw.update_firewall_status Firewall.Ssh Firewall.Disabled ;
     Db.Host.set_ssh_enabled ~__context ~self ~value:false
   with e ->
     error "Failed to disable SSH for host %s: %s" (Ref.string_of self)
@@ -3254,7 +3254,7 @@ let enable_ssh ~__context ~self =
           : Firewall.FIREWALL
         )
     in
-    Fw.update_firewall_status ~service:Firewall.Ssh ~status:Firewall.Enabled ;
+    Fw.update_firewall_status Firewall.Ssh Firewall.Enabled ;
     Xapi_systemctl.enable ~wait_until_success:false !Xapi_globs.ssh_service ;
     Xapi_systemctl.start ~wait_until_success:false !Xapi_globs.ssh_service ;
 

--- a/ocaml/xapi/xapi_periodic_scheduler_init.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler_init.ml
@@ -101,8 +101,7 @@ let register ~__context =
               : Firewall.FIREWALL
             )
         in
-        Fw.update_firewall_status ~service:Firewall.Ssh
-          ~status:Firewall.Disabled ;
+        Fw.update_firewall_status Firewall.Ssh Firewall.Disabled ;
         Xapi_host.disable_ssh ~__context ~self ;
         Xapi_host.set_ssh_auto_mode ~__context ~self ~value:true
       )


### PR DESCRIPTION
This PR is for dynamic control NBD firewalld service.
Also, changed labeled arguments to fixed arguments for the function `update_firewall_status` to support the optional argument `interfaces`.