### PR TITLE
CP-54216: Add a new pool level field to set guest console idle timeout

### DIFF
--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -137,6 +137,8 @@ let prototyped_of_field = function
       Some "23.18.0"
   | "VM", "actions__after_softreboot" ->
       Some "23.1.0"
+  | "pool", "vm_console_idle_timeout" ->
+      Some "25.30.0-next"
   | "pool", "limit_console_sessions" ->
       Some "25.30.0-next"
   | "pool", "ha_reboot_vm_on_internal_shutdown" ->

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -2256,6 +2256,13 @@ let t =
              accepted. Otherwise every connection for a VM/host's console is \
              accepted. Note: when true, connection attempts via websocket will \
              be rejected."
+        ; field ~writer_roles:_R_POOL_OP ~qualifier:RW ~lifecycle:[] ~ty:Int
+            ~default_value:(Some (VInt 0L)) "vm_console_idle_timeout"
+            "The maximum time (in seconds) that a VM's console can be idle \
+             before it is automatically disconnected. The default value 0 \
+             means never timeout. This setting applies only to VM consoles; \
+             for host consoles, use the separate parameter \
+             'host.console_idle_timeout'."
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "cf1c1e26b4288dd53cf6da5a4d6ad13c"
+let last_known_schema_hash = "dcb73e162d2189e13c5d308181520f04"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -306,7 +306,7 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ?(update_sync_day = 0L) ?(update_sync_enabled = false)
     ?(recommendations = []) ?(license_server = [])
     ?(ha_reboot_vm_on_internal_shutdown = true)
-    ?(limit_console_sessions = false) () =
+    ?(limit_console_sessions = false) ?(vm_console_idle_timeout = 0L) () =
   let pool_ref = Ref.make () in
   Db.Pool.create ~__context ~ref:pool_ref ~uuid:(make_uuid ()) ~name_label
     ~name_description ~master ~default_SR ~suspend_image_SR ~crash_dump_SR
@@ -327,7 +327,8 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~ext_auth_cache_enabled:false ~ext_auth_cache_size:50L
     ~ext_auth_cache_expiry:300L ~update_sync_frequency ~update_sync_day
     ~update_sync_enabled ~recommendations ~license_server
-    ~ha_reboot_vm_on_internal_shutdown ~limit_console_sessions ;
+    ~ha_reboot_vm_on_internal_shutdown ~limit_console_sessions
+    ~vm_console_idle_timeout ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1602,6 +1602,15 @@ let pool_record rpc session_id pool =
               ~value:(safe_bool_of_string "limit-console-sessions" x)
           )
           ()
+      ; make_field ~name:"vm-console-idle-timeout"
+          ~get:(fun () ->
+            (x ()).API.pool_vm_console_idle_timeout |> Int64.to_string
+          )
+          ~set:(fun x ->
+            Client.Pool.set_vm_console_idle_timeout ~rpc ~session_id ~self:pool
+              ~value:(safe_i64_of_string "vm-console-idle-timeout" x)
+          )
+          ()
       ]
   }
 

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -55,7 +55,7 @@ let create_pool_record ~__context =
       ~ext_auth_max_threads:1L ~ext_auth_cache_enabled:false
       ~ext_auth_cache_size:50L ~ext_auth_cache_expiry:300L ~recommendations:[]
       ~license_server:[] ~ha_reboot_vm_on_internal_shutdown:true
-      ~limit_console_sessions:false
+      ~limit_console_sessions:false ~vm_console_idle_timeout:0L
 
 let set_master_ip ~__context =
   let ip =


### PR DESCRIPTION
The field sets the maximum time (in seconds) that a VM's console can be idle before it is automatically disconnected. The default value 0 means never timeout. This setting applies only to VM consoles;
for host consoles, use the separate parameter 'host.console_idle_timeout'.

Tested:
```
[root@eu1-dt094 bin]# xe pool-param-get uuid=72ed1057-0ed5-2195-3bec-2e00e6e74fe5 param-name=vm-console-idle-timeout
0
[root@eu1-dt094 bin]# xe pool-param-set uuid=72ed1057-0ed5-2195-3bec-2e00e6e74fe5 vm-console-idle-timeout=36000
[root@eu1-dt094 bin]# xe pool-param-get uuid=72ed1057-0ed5-2195-3bec-2e00e6e74fe5 param-name=vm-console-idle-timeout
36000
[root@eu1-dt094 bin]# xe pool-param-set uuid=72ed1057-0ed5-2195-3bec-2e00e6e74fe5 vm-console-idle-timeout=de
Error: Failed to parse parameter 'vm-console-idle-timeout': expecting an integer
```