### PR TITLE
CP-309535: Dynamic control of firewalld service - part 4

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -10704,6 +10704,7 @@ let emergency_calls =
   ; (Datamodel_host.t, Datamodel_host.emergency_disable_tls_verification)
   ; (Datamodel_host.t, Datamodel_host.emergency_reenable_tls_verification)
   ; (Datamodel_host.t, Datamodel_host.emergency_clear_mandatory_guidance)
+  ; (Datamodel_host.t, Datamodel_host.update_firewalld_service_status)
   ]
 
 (** Whitelist of calls that will not get forwarded from the slave to master via the unix domain socket *)

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -2487,6 +2487,14 @@ let set_ssh_auto_mode =
       ]
     ~allowed_roles:_R_POOL_ADMIN ()
 
+let update_firewalld_service_status =
+  call ~name:"update_firewalld_service_status" ~flags:[`Session] ~lifecycle:[]
+    ~pool_internal:true ~hide_from_docs:true
+    ~doc:
+      "Update firewalld services based on the corresponding xapi services \
+       status."
+    ~allowed_roles:_R_POOL_OP ()
+
 let latest_synced_updates_applied_state =
   Enum
     ( "latest_synced_updates_applied_state"
@@ -2649,6 +2657,7 @@ let t =
       ; set_ssh_enabled_timeout
       ; set_console_idle_timeout
       ; set_ssh_auto_mode
+      ; update_firewalld_service_status
       ]
     ~contents:
       ([

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -223,6 +223,8 @@ let prototyped_of_message = function
       Some "22.26.0"
   | "VTPM", "create" ->
       Some "22.26.0"
+  | "host", "update_firewalld_service_status" ->
+      Some "25.30.0-next"
   | "host", "set_ssh_auto_mode" ->
       Some "25.27.0"
   | "host", "set_console_idle_timeout" ->

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -2922,6 +2922,19 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= [Neverforward]
       }
     )
+  ; ( "host-update-firewalld-service-status"
+    , {
+        reqd= []
+      ; optn= []
+      ; help=
+          "Update firewalld services status based the corresponding xapi \
+           services status."
+      ; implementation=
+          No_fd_local_session
+            Cli_operations.host_update_firewalld_service_status
+      ; flags= [Neverforward]
+      }
+    )
   ; ( "diagnostic-compact"
     , {
         reqd= []

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -5450,6 +5450,9 @@ let host_retrieve_wlb_evacuate_recommendations printer rpc session_id params =
 let host_shutdown_agent _printer rpc session_id _params =
   ignore (Client.Host.shutdown_agent ~rpc ~session_id)
 
+let host_update_firewalld_service_status _printer rpc session_id _params =
+  ignore (Client.Host.update_firewalld_service_status ~rpc ~session_id)
+
 let vdi_import fd _printer rpc session_id params =
   let filename = List.assoc "filename" params in
   let vdi =

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -259,7 +259,9 @@
     System_domains
     Xapi_psr
     Xapi_services
-    Xapi_udhcpd))))
+    Xapi_udhcpd)
+   ((pps ppx_deriving.enum)
+    Firewall))))
 
 (library
  (name xapi_internal_server_only)

--- a/ocaml/xapi/firewall.ml
+++ b/ocaml/xapi/firewall.ml
@@ -16,7 +16,7 @@ module D = Debug.Make (struct let name = __MODULE__ end)
 
 open D
 
-type service_type = Dlm | Nbd | Ssh | Vxlan | Http | Xenha
+type service_type = Dlm | Nbd | Ssh | Vxlan | Http | Xenha [@@deriving enum]
 
 type status = Enabled | Disabled
 
@@ -37,6 +37,12 @@ type service_info = {
   ; protocol: protocol
   ; dynamic_control_iptables_port: bool
 }
+
+let all_service_types =
+  let length = max_service_type - min_service_type + 1 in
+  List.init length (fun i ->
+      service_type_of_enum (min_service_type + i) |> Option.get
+  )
 
 let status_to_string = function Enabled -> "enabled" | Disabled -> "disabled"
 

--- a/ocaml/xapi/firewall.mli
+++ b/ocaml/xapi/firewall.mli
@@ -16,6 +16,8 @@ type service_type = Dlm | Nbd | Ssh | Vxlan | Http | Xenha
 
 type status = Enabled | Disabled
 
+val all_service_types : service_type list
+
 module type FIREWALL = sig
   val update_firewall_status :
     ?interfaces:string list -> service_type -> status -> unit

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -4114,6 +4114,10 @@ functor
         let local_fn = Local.Host.set_ssh_auto_mode ~self ~value in
         let remote_fn = Client.Host.set_ssh_auto_mode ~self ~value in
         do_op_on ~local_fn ~__context ~host:self ~remote_fn
+
+      let update_firewalld_service_status ~__context =
+        info "Host.update_firewalld_service_status" ;
+        Local.Host.update_firewalld_service_status ~__context
     end
 
     module Host_crashdump = struct

--- a/ocaml/xapi/network_event_loop.ml
+++ b/ocaml/xapi/network_event_loop.ml
@@ -44,26 +44,9 @@ let _watch_networks_for_nbd_changes __context ~update_firewall
     let token, allowed_interfaces =
       try
         let token = wait_for_network_change ~token in
-        let pifs = Db.Host.get_PIFs ~__context ~self:localhost in
-        let allowed_connected_networks =
-          (* We use Valid_ref_list to continue processing the list in case some network refs are null or invalid *)
-          Valid_ref_list.filter_map
-            (fun pif ->
-              let network = Db.PIF.get_network ~__context ~self:pif in
-              let purpose = Db.Network.get_purpose ~__context ~self:network in
-              if List.mem `nbd purpose || List.mem `insecure_nbd purpose then
-                Some network
-              else
-                None
-            )
-            pifs
-        in
         let interfaces =
-          List.map
-            (fun network -> Db.Network.get_bridge ~__context ~self:network)
-            allowed_connected_networks
+          Xapi_host.get_nbd_interfaces ~__context ~self:localhost
         in
-        let interfaces = Xapi_stdext_std.Listext.List.setify interfaces in
         let needs_firewall_update =
           match allowed_interfaces with
           | Some allowed_interfaces ->

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -1504,6 +1504,10 @@ let server_init () =
                 Xapi_host.write_uefi_certificates_to_disk ~__context
                   ~host:(Helpers.get_localhost ~__context)
             )
+          ; ( "Update firewalld service status"
+            , [Startup.NoExnRaising]
+            , fun () -> Xapi_host.update_firewalld_service_status ~__context
+            )
           ; ( "writing init complete"
             , []
             , fun () -> Helpers.touch_file !Xapi_globs.init_complete

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -589,3 +589,16 @@ val schedule_disable_ssh_job :
 
 val set_ssh_auto_mode :
   __context:Context.t -> self:API.ref_host -> value:bool -> unit
+
+val get_nbd_interfaces : __context:Context.t -> self:API.ref_host -> string list
+
+val update_firewalld_service_status : __context:Context.t -> unit
+(* Update the status of all the firewalld services to match the state of the
+   corresponding services.
+   This function is used in 2 scenarios:
+   1. When xapi starts, to ensure that all the firewalld services are in the
+      correct state.
+   2. When the firewalld restarts, all firewalld services are reset to the
+      default status. This function should be called to update these firewalld
+      services to the correct status. Xapi will expose an xe command line for
+      this scenario. *)

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -68,6 +68,7 @@ install:
 	$(IDATA) wsproxy.service $(DESTDIR)/usr/lib/systemd/system/wsproxy.service
 	$(IDATA) wsproxy.socket $(DESTDIR)/usr/lib/systemd/system/wsproxy.socket
 	$(IDATA) varstored-guard.service $(DESTDIR)/usr/lib/systemd/system/varstored-guard.service
+	$(IDATA) update-xapi-firewalld.service $(DESTDIR)/usr/lib/systemd/system/update-xapi-firewalld.service
 	$(IDATA) network-init.service $(DESTDIR)/usr/lib/systemd/system/network-init.service
 	$(IDATA) control-domain-params-init.service $(DESTDIR)/usr/lib/systemd/system/control-domain-params-init.service
 	$(IDATA) xapi-nbd.service $(DESTDIR)/usr/lib/systemd/system/xapi-nbd.service

--- a/scripts/update-xapi-firewalld.service
+++ b/scripts/update-xapi-firewalld.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Update firewalld service for xapi
+PartOf=firewalld.service
+After=firewalld.service xapi.service xapi-init-complete.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'xe host-update-firewalld-service-status'
+RemainAfterExit=yes
+Restart=on-failure
+RestartSec=5
+StartLimitBurst=3
+StartLimitInterval=30s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Update the status of all the firewalld services to match the state of the corresponding services. There are 2 scenarios:
1. When xapi starts, to ensure that all the firewalld services are in the correct state.
2. When the firewalld restarts, all firewalld services are reset to the default status. This function should be called to update these firewalld services to the correct status. Xapi will expose an xe command line for this scenario.