### PR TITLE
CP-54393: VNC Console Idle Timeout

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
@@ -124,9 +124,20 @@ val open_connection_unix_fd : string -> Unix.file_descr
 
 exception Process_still_alive
 
+type vnc_console_state = {
+    is_idle_timeout_set: bool
+  ; is_idle: bool
+  ; poll_event_timeout_ms: int
+}
+
 val kill_and_wait : ?signal:int -> ?timeout:float -> int -> unit
 
-val proxy : Unix.file_descr -> Unix.file_descr -> unit
+val proxy :
+     ?console_init_state:vnc_console_state
+  -> ?vnc_console_idle_timeout_callback:(bytes option -> vnc_console_state)
+  -> Unix.file_descr
+  -> Unix.file_descr
+  -> unit
 
 val really_read : Unix.file_descr -> bytes -> int -> int -> unit
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -450,6 +450,13 @@ let xha_timeout = "timeout"
 
 let message_limit = ref 10000
 
+(* The timeout (in milliseconds) for event polling in the proxy loop.
+   It is not set by default, which means that the poll will block indefinitely
+   until an event occurs.
+   If set to a positive value, the poll will wake up periodically,
+   which is useful for implementing features like idle timeout or periodic inspection of proxy buffers. *)
+let proxy_poll_event_timeout_ms = ref 5000
+
 let xapi_message_script = ref "mail-alarm"
 
 (* Emit a warning if more than this amount of clock skew detected *)
@@ -1782,6 +1789,11 @@ let other_options =
     , Arg.Set_float vm_sysprep_wait
     , (fun () -> string_of_float !vm_sysprep_wait)
     , "Time in seconds to wait for VM to recognise inserted CD"
+    )
+  ; ( "proxy_poll_event_timeout_ms"
+    , Arg.Set_int proxy_poll_event_timeout_ms
+    , (fun () -> string_of_int !proxy_poll_event_timeout_ms)
+    , "Timeout (in milliseconds) for event polling in the proxy loop."
     )
   ]
 


### PR DESCRIPTION
**Note that this is a draft PR for initial review**, though I've tested it with both dom0 and vm console, as:
1. This change is substantial and requires unit tests
2. Before investing time in comprehensive unit tests, I want to ensure the implementation approach is generally correct
3. Added logs for testing and will be removed

Tested:
<img width="894" height="508" alt="image" src="https://github.com/user-attachments/assets/a9dbb671-5cb7-4148-9b15-15c0509f63f1" />


Key Features
- RFB_msg_type_parser Module 
-- A simple parser: For each newly received data, only parses the message type to detect user activity 
-- Activity detection: Identifies KeyEvent (4) and PointerEvent (5) messages as user activity 
-- Unknown message handling: Skips parsing for unknown message types and continues processing

- Console_idle_monitor Module 
-- Monitors console sessions for idle timeout based on configuration, using RFB_msg_type_parser for activity detection

- Integration
-- Hooks into Unixext.proxy via a closure callback mechanism
-- No breaking changes to existing console functionalit