### PR TITLE
CA-416959 Copy bonds and sriov from master using device position

### DIFF
--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -45,9 +45,6 @@ let bridge_naming_convention (device : string) (pos_opt : int option) =
   | None ->
       "br" ^ device
 
-let n_of_xenbrn_opt bridge =
-  try Scanf.sscanf bridge "xenbr%d%!" Option.some with _ -> None
-
 type tables = {
     device_to_position_table: (string * int) list
   ; device_to_mac_table: (string * string) list
@@ -81,10 +78,7 @@ let get_physical_pif_device ~__context ~interface_tables ~pif_rec =
       )
   in
   if pif_rec.API.pIF_physical then (
-    let bridge =
-      Db.Network.get_bridge ~__context ~self:pif_rec.API.pIF_network
-    in
-    match n_of_xenbrn_opt bridge with
+    match Xapi_pif_helpers.get_pif_position ~__context ~pif_rec with
     | Some position ->
         find_name_by_position position pif_rec.API.pIF_device
     | None ->

--- a/ocaml/xapi/xapi_pif_helpers.ml
+++ b/ocaml/xapi/xapi_pif_helpers.ml
@@ -265,3 +265,10 @@ let get_primary_address ~__context ~pif =
   )
   | `IPv6 ->
       List.nth_opt (get_non_link_ipv6 ~__context ~pif) 0
+
+let get_pif_position ~__context ~pif_rec =
+  let n_of_xenbrn_opt bridge =
+    try Scanf.sscanf bridge "xenbr%d%!" Option.some with _ -> None
+  in
+  let bridge = Db.Network.get_bridge ~__context ~self:pif_rec.API.pIF_network in
+  n_of_xenbrn_opt bridge


### PR DESCRIPTION
For pool join procedure, the slave host will go through
1 pre_join_check
2 update_non_vm_metadata: in this step, create pif objects for physical pifs of slave host on master host db.
3 on slave xapi start: copy_bonds_from_master, copy_network_sriovs_from_master, copy_vlans_from_master, copy_tunnels_from_master

This issue happens on step 3 when copy bonds from master.
for every bond on master
- get the bond master pif on master
- get the bond slave pifs on master
- confirm the primary bond slaves via comparing the bond master pif mac
- find the corresponding pifs on slave host
- decide if create bond on slave host

In `find the corresponding pifs on slave host`, the previous method is to compare the pif.device on master and slave hosts. Now we should compare the position of pif device. Because the network device name is no longer renamed to ethx, which x is actually the position.

It's similar for copy_network_sriovs_from_master.
For vlans and tunnels, they are based the underneath network, no pif.device compare. So, this issue doesn't exist.