### PR TITLE
xenopsd: Drop unused variables in `domain.ml`

### DIFF
--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -1214,8 +1214,8 @@ let correct_shadow_allocation xc domid uuid shadow_mib =
   )
 
 (* puts value in store after the domain build succeed *)
-let build_post ~xc ~xs ~vcpus:_ ~static_max_mib ~target_mib domid domain_type
-    store_mfn store_port ents vments =
+let build_post ~xc ~xs ~static_max_mib ~target_mib domid domain_type store_mfn
+    store_port ents vments =
   let uuid = get_uuid ~xc domid in
   let dom_path = xs.Xs.getdomainpath domid in
   (* Unit conversion. *)
@@ -1350,8 +1350,8 @@ let build (task : Xenops_task.task_handle) ~xc ~xs ~store_domid ~console_domid
         )
   in
   let local_stuff = console_keys console_port console_mfn in
-  build_post ~xc ~xs ~vcpus ~target_mib ~static_max_mib domid domain_type
-    store_mfn store_port local_stuff vm_stuff
+  build_post ~xc ~xs ~target_mib ~static_max_mib domid domain_type store_mfn
+    store_port local_stuff vm_stuff
 
 type suspend_flag = Live | Debug
 
@@ -1452,8 +1452,7 @@ let consume_qemu_record fd limit domid uuid =
     (fun () -> Unix.close fd2)
 
 let restore_common (task : Xenops_task.task_handle) ~xc ~xs
-    ~(dm : Device.Profile.t) ~domain_type ~store_port ~store_domid:_
-    ~console_port ~console_domid:_ ~no_incr_generationid:_ ~vcpus:_ ~extras
+    ~(dm : Device.Profile.t) ~domain_type ~store_port ~console_port ~extras
     ~vtpm ~numa_placements manager_path domid main_fd vgpu_fd =
   let module DD = Debug.Make (struct let name = "mig64" end) in
   let open DD in
@@ -1719,9 +1718,8 @@ let restore_common (task : Xenops_task.task_handle) ~xc ~xs
         (Uuidx.to_string uuid) domid e ;
       raise Suspend_image_failure
 
-let restore (task : Xenops_task.task_handle) ~xc ~xs ~dm ~store_domid
-    ~console_domid ~no_incr_generationid ~timeoffset ~extras info ~manager_path
-    ~vtpm domid fd vgpu_fd =
+let restore (task : Xenops_task.task_handle) ~xc ~xs ~dm ~timeoffset ~extras
+    info ~manager_path ~vtpm domid fd vgpu_fd =
   let static_max_kib = info.memory_max in
   let target_kib = info.memory_target in
   let vcpus = info.vcpus in
@@ -1766,16 +1764,15 @@ let restore (task : Xenops_task.task_handle) ~xc ~xs ~dm ~store_domid
     build_pre ~xc ~xs ~memory ~vcpus ~hard_affinity:info.hard_affinity domid
   in
   let store_mfn, console_mfn =
-    restore_common task ~xc ~xs ~dm ~domain_type ~store_port ~store_domid
-      ~console_port ~console_domid ~no_incr_generationid ~vcpus ~extras ~vtpm
-      ~numa_placements manager_path domid fd vgpu_fd
+    restore_common task ~xc ~xs ~dm ~domain_type ~store_port ~console_port
+      ~extras ~vtpm ~numa_placements manager_path domid fd vgpu_fd
   in
   let local_stuff = console_keys console_port console_mfn in
   (* And finish domain's building *)
-  build_post ~xc ~xs ~vcpus ~target_mib ~static_max_mib domid domain_type
-    store_mfn store_port local_stuff vm_stuff
+  build_post ~xc ~xs ~target_mib ~static_max_mib domid domain_type store_mfn
+    store_port local_stuff vm_stuff
 
-let suspend_emu_manager ~(task : Xenops_task.task_handle) ~xc:_ ~xs ~domain_type
+let suspend_emu_manager ~(task : Xenops_task.task_handle) ~xs ~domain_type
     ~is_uefi ~vtpm ~dm ~manager_path ~domid ~uuid ~main_fd ~vgpu_fd ~flags
     ~progress_callback ~qemu_domid ~do_suspend_callback =
   let open Suspend_image in
@@ -1987,9 +1984,9 @@ let suspend (task : Xenops_task.task_handle) ~xc ~xs ~domain_type ~is_uefi ~dm
     write_header main_fd (Xenops, Int64.of_int xenops_rec_len) >>= fun () ->
     debug "Writing Xenops record contents" ;
     Io.write main_fd xenops_record ;
-    suspend_emu_manager ~task ~xc ~xs ~domain_type ~is_uefi ~vtpm ~dm
-      ~manager_path ~domid ~uuid ~main_fd ~vgpu_fd ~flags ~progress_callback
-      ~qemu_domid ~do_suspend_callback
+    suspend_emu_manager ~task ~xs ~domain_type ~is_uefi ~vtpm ~dm ~manager_path
+      ~domid ~uuid ~main_fd ~vgpu_fd ~flags ~progress_callback ~qemu_domid
+      ~do_suspend_callback
     >>= fun () ->
     ( if is_uefi then
         write_varstored_record task ~xs domid main_fd >>= fun () ->

--- a/ocaml/xenopsd/xc/domain.mli
+++ b/ocaml/xenopsd/xc/domain.mli
@@ -247,9 +247,6 @@ val restore :
   -> xc:Xenctrl.handle
   -> xs:Ezxenstore_core.Xenstore.Xs.xsh
   -> dm:Device.Profile.t
-  -> store_domid:int
-  -> console_domid:int
-  -> no_incr_generationid:bool
   -> timeoffset:string
   -> extras:string list
   -> build_info

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -2628,7 +2628,6 @@ module VM = struct
             in
             ({x with Domain.memory_target= initial_target}, timeoffset)
       in
-      let no_incr_generationid = false in
       let vtpm = vtpm_of ~vm in
       ( try
           with_data ~xc ~xs task data false @@ fun fd ->
@@ -2644,9 +2643,8 @@ module VM = struct
                 None
           in
           let manager_path = choose_emu_manager vm.Vm.platformdata in
-          Domain.restore task ~xc ~xs ~dm:(dm_of ~vm) ~store_domid
-            ~console_domid ~no_incr_generationid ~timeoffset ~extras build_info
-            ~manager_path ~vtpm domid fd vgpu_fd
+          Domain.restore task ~xc ~xs ~dm:(dm_of ~vm) ~timeoffset ~extras
+            build_info ~manager_path ~vtpm domid fd vgpu_fd
         with e ->
           error "VM %s: restore failed: %s" vm.Vm.id (Printexc.to_string e) ;
           (* As of xen-unstable.hg 779c0ef9682 libxenguest will destroy


### PR DESCRIPTION
Some of these were passed through several layers of functions only to be unused in the end. Drop them, improving the legibility of the code.