### PR TITLE
CA-417366 make_xen_livepatch_list can not Parse the Output of xen-livepatch

### DIFF
--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -48,11 +48,11 @@ type host_info = {
 
 (** The format of the response looks like
  *  # xen-livepatch list
- *   ID                                     | status
- *  ----------------------------------------+------------
- *  hp_1_1                                  | CHECKED
- *  hp_2_1                                  | APPLIED
- *  hp_3_2                                  | APPLIED *)
+ *   ID                                     | status     | metadata
+ *  ----------------------------------------+------------+---------------
+ *  hp_1_1                                  | CHECKED    |
+ *  hp_2_1                                  | APPLIED    |
+ *  hp_3_2                                  | APPLIED    | *)
 let make_xen_livepatch_list () =
   let lines =
     try
@@ -63,8 +63,8 @@ let make_xen_livepatch_list () =
   let patches =
     List.fold_left
       (fun acc l ->
-        match List.map String.trim (Xstringext.String.split ~limit:2 '|' l) with
-        | [key; "APPLIED"] ->
+        match List.map String.trim (String.split_on_char '|' l) with
+        | key :: "APPLIED" :: _ ->
             key :: acc
         | _ ->
             acc


### PR DESCRIPTION
The current `make_xen_livepatch_list` function expects exactly 2 parts after splitting, but the output has 3 parts: ID, status, and metadata. When split with ~limit:2, it creates [ID; "status | metadata"], which doesn't match the pattern [key; "APPLIED"], and prevents it from correctly parsing the latest output of `xen-livepatch list `: ~xen-livepatch list
```
 ID                                     | status     | metadata
----------------------------------------+------------+---------------
hp_1_1                                  | CHECKED    |
hp_2_1                                  | APPLIED    |
hp_3_2                                  | APPLIED    |
```