### PR TITLE
ocaml: allow xapi to compile under OCaml 5.3

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -578,8 +578,8 @@ let get_deprecated lifecycle =
   with Not_found -> None
 
 let call ~name ?(doc = "") ?(in_oss_since = Some "3.0.3") ?result
-    ?(flags = [`Session; `Async]) ?(effect = true) ?(tag = Custom) ?(errs = [])
-    ?(custom_marshaller = false) ?(db_only = false)
+    ?(flags = [`Session; `Async]) ?(has_effect = true) ?(tag = Custom)
+    ?(errs = []) ?(custom_marshaller = false) ?(db_only = false)
     ?(no_current_operations = false) ?(secret = false) ?(hide_from_docs = false)
     ?(pool_internal = false) ~allowed_roles ?(map_keys_roles = [])
     ?(params = []) ?versioned_params ?lifecycle ?(doc_tags = []) ?forward_to ()
@@ -633,7 +633,7 @@ let call ~name ?(doc = "") ?(in_oss_since = Some "3.0.3") ?result
   ; msg_db_only= db_only
   ; msg_release= call_release
   ; msg_lifecycle= Lifecycle.from lifecycle
-  ; msg_has_effect= effect
+  ; msg_has_effect= has_effect
   ; msg_tag= tag
   ; msg_obj_name= ""
   ; msg_force_custom= None
@@ -659,8 +659,8 @@ let operation_enum x =
 (** Make an object field record *)
 let field ?(in_oss_since = Some "3.0.3") ?(internal_only = false)
     ?(ignore_foreign_key = false) ?(writer_roles = None) ?(reader_roles = None)
-    ?(qualifier = RW) ?(ty = String) ?(effect = false) ?(default_value = None)
-    ?(persist = true) ?(map_keys_roles = [])
+    ?(qualifier = RW) ?(ty = String) ?(has_effect = false)
+    ?(default_value = None) ?(persist = true) ?(map_keys_roles = [])
     ?(* list of (key_name,(writer_roles)) for a map field *)
      lifecycle ?(doc_tags = []) name desc =
   let lifecycle =
@@ -695,7 +695,7 @@ let field ?(in_oss_since = Some "3.0.3") ?(internal_only = false)
     ; full_name= [name]
     ; field_description= desc
     ; field_persist= persist
-    ; field_has_effect= effect
+    ; field_has_effect= has_effect
     ; field_ignore_foreign_key= ignore_foreign_key
     ; field_setter_roles= writer_roles
     ; field_getter_roles= reader_roles

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -2620,7 +2620,7 @@ let t =
                 )
               ]
             "Creators of VMs and templates may store version information here."
-        ; field ~effect:true ~ty:Bool "is_a_template"
+        ; field ~has_effect:true ~ty:Bool "is_a_template"
             ~lifecycle:
               [
                 ( Published
@@ -2815,7 +2815,7 @@ let t =
             ~ty:String "recommendations"
             "An XML specification of recommended values and ranges for \
              properties of this VM"
-        ; field ~effect:true ~in_oss_since:None
+        ; field ~has_effect:true ~in_oss_since:None
             ~ty:(Map (String, String))
             ~lifecycle:
               [

--- a/ocaml/libs/timeslice/timeslice.ml
+++ b/ocaml/libs/timeslice/timeslice.ml
@@ -65,7 +65,8 @@ let periodic =
 let set ?(sampling_rate = 1e-4) interval =
   Atomic.set yield_interval
     (Mtime.Span.of_float_ns @@ (interval *. 1e9) |> Option.get) ;
-  Gc.Memprof.start ~sampling_rate ~callstack_size:0 periodic
+  let _ = Gc.Memprof.start ~sampling_rate ~callstack_size:0 periodic in
+  ()
 
 let clear () =
   Gc.Memprof.stop () ;


### PR DESCRIPTION
This removes using effect as a label because now it's a reserved word, and changes how the memprof is used to be compatible both with 4.14 and 5.3, by ignoring the value it returns.

I also see a storm of warning about not linking against the unix library explicitly. We'll deal with that later on