### PR TITLE
CP-54393: A simple RFB protocol parser for VNC console connections

### DIFF
--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -70,4 +70,5 @@ let () =
     @ Test_session.tests
     @ Test_xapi_cmd_result.tests
     @ Test_extauth_plugin_ADwinbind.tests
+    @ Test_rfb_client_msgtype_parser.tests
     )

--- a/ocaml/tests/test_rfb_client_msgtype_parser.ml
+++ b/ocaml/tests/test_rfb_client_msgtype_parser.ml
@@ -1,0 +1,722 @@
+(*
+ * Copyright (C) Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Rfb_client_msgtype_parser
+
+(* Helper function to create binary data from byte values *)
+let int_list_to_string ints =
+  List.to_seq ints |> Seq.map Char.chr |> String.of_seq
+
+(* Helper function to create test data for different message types *)
+module TestData = struct
+  (* Valid RFB protocol version string: "RFB 003.003\n" *)
+  let protocol_version = "RFB 003.003\n"
+
+  (* Invalid protocol versions for negative testing *)
+  let invalid_protocol_version = "VNC 003.003\n"
+
+  let invalid_protocol_version_rfb_004 = "RFB 003.004\n"
+
+  let incomplete_protocol_version = "RFB 003.003" (* 11 bytes, incomplete *)
+
+  (* ClientInit messages: 1 byte (shared flag) *)
+  let client_init = int_list_to_string [1] (* Shared access *)
+
+  let client_init_exclusive = int_list_to_string [0] (* Exclusive access *)
+
+  let client_init_invalid = int_list_to_string [2] (* Invalid value *)
+
+  let client_init_invalid_255 = int_list_to_string [255]
+  (* Another invalid value *)
+
+  (* SetPixelFormat: message-type(0) + padding(3) + pixel-format(16) *)
+  let set_pixel_format =
+    int_list_to_string ([0; 0; 0; 0] @ List.init 16 (fun _ -> 0))
+
+  (* SetEncodings: message-type(2) + padding(1) + num-encodings(2) + encodings(4*n) *)
+  let set_encodings_simple = int_list_to_string [2; 0; 0; 1; 0; 0; 0; 1]
+  (* 1 encoding *)
+
+  let set_encodings_multiple =
+    int_list_to_string ([2; 0; 0; 2] @ [0; 0; 0; 1; 0; 0; 0; 2])
+  (* 2 encodings *)
+
+  (* FramebufferUpdateRequest: message-type(3) + incremental(1) + x(2) + y(2) + width(2) + height(2) *)
+  let framebuffer_update_request =
+    int_list_to_string [3; 0; 0; 0; 0; 0; 1; 0; 1; 0]
+
+  (* KeyEvent: message-type(4) + down-flag(1) + padding(2) + key(4) *)
+  let key_event = int_list_to_string [4; 1; 0; 0; 0; 0; 0; 65]
+
+  (* PointerEvent: message-type(5) + button-mask(1) + x(2) + y(2) *)
+  let pointer_event = int_list_to_string [5; 1; 0; 100; 0; 50]
+
+  (* ClientCutText: message-type(6) + padding(3) + length(4) + text *)
+  let client_cut_text =
+    int_list_to_string
+      ([6; 0; 0; 0; 0; 0; 0; 5] @ List.map Char.code ['H'; 'e'; 'l'; 'l'; 'o'])
+
+  (* QEMUClientMessage: message-type(255) + data(11) *)
+  let qemu_client_message =
+    int_list_to_string ([255] @ List.init 11 (fun _ -> 0))
+
+  (* Invalid/unsupported message types *)
+  let unsupported_message = int_list_to_string [99]
+  (* unsupported message type *)
+end
+
+(* Test individual message type parsing functions *)
+module MessageParsingTests = struct
+  let test_protocol_version_parsing () =
+    let parser = create () in
+    let result = parser (TestData.protocol_version ^ TestData.client_init) in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Complete handshake parsed correctly" ["Handshake"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  let test_invalid_protocol_version () =
+    let parser = create () in
+    let result =
+      parser (TestData.invalid_protocol_version ^ TestData.client_init)
+    in
+    match result with
+    | Error msg ->
+        Alcotest.(check bool)
+          "Invalid protocol version returns error" true
+          (String.starts_with ~prefix:"Parse error: BadHandshake:" msg)
+    | Ok _ ->
+        Alcotest.fail
+          "Expected Error but got Ok - invalid handshake should fail"
+
+  let test_invalid_protocol_version_rfb_004 () =
+    let parser = create () in
+    let result =
+      parser (TestData.invalid_protocol_version_rfb_004 ^ TestData.client_init)
+    in
+    match result with
+    | Error msg ->
+        Alcotest.(check bool)
+          "RFB 003.004 version returns error" true
+          (String.starts_with ~prefix:"Parse error: BadHandshake:" msg)
+    | Ok _ ->
+        Alcotest.fail
+          "Expected Error but got Ok - invalid handshake should fail"
+
+  let test_incomplete_protocol_version () =
+    let parser = create () in
+    let result = parser TestData.incomplete_protocol_version in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Incomplete protocol version returns empty (partial)" []
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  let test_client_init_shared () =
+    let parser = create () in
+    let result = parser (TestData.protocol_version ^ TestData.client_init) in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Complete handshake with shared ClientInit parsed correctly"
+          ["Handshake"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  let test_client_init_exclusive () =
+    let parser = create () in
+    let result =
+      parser (TestData.protocol_version ^ TestData.client_init_exclusive)
+    in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Complete handshake with exclusive ClientInit parsed correctly"
+          ["Handshake"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  let test_client_init_invalid () =
+    let parser = create () in
+    let result =
+      parser (TestData.protocol_version ^ TestData.client_init_invalid)
+    in
+    match result with
+    | Error msg ->
+        Alcotest.(check bool)
+          "Invalid ClientInit returns error" true
+          (String.starts_with ~prefix:"Parse error: BadHandshake:" msg)
+    | Ok _ ->
+        Alcotest.fail
+          "Expected Error but got Ok - invalid handshake should fail"
+
+  let test_client_init_invalid_255 () =
+    let parser = create () in
+    let result =
+      parser (TestData.protocol_version ^ TestData.client_init_invalid_255)
+    in
+    match result with
+    | Error msg ->
+        Alcotest.(check bool)
+          "Invalid ClientInit (255) returns error" true
+          (String.starts_with ~prefix:"Parse error: BadHandshake:" msg)
+    | Ok _ ->
+        Alcotest.fail
+          "Expected Error but got Ok - invalid handshake should fail"
+
+  let test_client_init_parsing () =
+    let parser = create () in
+    let result = parser (TestData.protocol_version ^ TestData.client_init) in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Complete handshake parsed correctly" ["Handshake"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  let test_set_pixel_format_parsing () =
+    let parser = create () in
+    (* Complete handshake first *)
+    let _ = parser (TestData.protocol_version ^ TestData.client_init) in
+    let result = parser TestData.set_pixel_format in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "SetPixelFormat parsed correctly" ["SetPixelFormat"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  let test_set_encodings_parsing () =
+    let parser = create () in
+    (* Complete handshake first *)
+    let _ = parser (TestData.protocol_version ^ TestData.client_init) in
+    let result = parser TestData.set_encodings_simple in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "SetEncodings parsed correctly" ["SetEncodings"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  let test_multiple_encodings_parsing () =
+    let parser = create () in
+    (* Complete handshake first *)
+    let _ = parser (TestData.protocol_version ^ TestData.client_init) in
+    let result = parser TestData.set_encodings_multiple in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Multiple encodings parsed correctly" ["SetEncodings"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  let test_framebuffer_update_request_parsing () =
+    let parser = create () in
+    (* Complete handshake first *)
+    let _ = parser (TestData.protocol_version ^ TestData.client_init) in
+    let result = parser TestData.framebuffer_update_request in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "FramebufferUpdateRequest parsed correctly"
+          ["FramebufferUpdateRequest"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  let test_key_event_parsing () =
+    let parser = create () in
+    (* Complete handshake first *)
+    let _ = parser (TestData.protocol_version ^ TestData.client_init) in
+    let result = parser TestData.key_event in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "KeyEvent parsed correctly" ["KeyEvent"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  let test_pointer_event_parsing () =
+    let parser = create () in
+    (* Complete handshake first *)
+    let _ = parser (TestData.protocol_version ^ TestData.client_init) in
+    let result = parser TestData.pointer_event in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "PointerEvent parsed correctly" ["PointerEvent"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  let test_client_cut_text_parsing () =
+    let parser = create () in
+    (* Complete handshake first *)
+    let _ = parser (TestData.protocol_version ^ TestData.client_init) in
+    let result = parser TestData.client_cut_text in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "ClientCutText parsed correctly" ["ClientCutText"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  let test_qemu_client_message_parsing () =
+    let parser = create () in
+    (* Complete handshake first *)
+    let _ = parser (TestData.protocol_version ^ TestData.client_init) in
+    let result = parser TestData.qemu_client_message in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "QEMUClientMessage parsed correctly" ["QEMUClientMessage"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+end
+
+(* Test protocol state transitions *)
+module StateTransitionTests = struct
+  let test_protocol_state_progression () =
+    let parser = create () in
+
+    (* Complete handshake should return Handshake *)
+    let result1 = parser (TestData.protocol_version ^ TestData.client_init) in
+    ( match result1 with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Handshake state: complete handshake" ["Handshake"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+    ) ;
+
+    (* Should now accept client messages *)
+    let result2 = parser TestData.key_event in
+    match result2 with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Post-handshake state: KeyEvent" ["KeyEvent"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  let test_incomplete_message_in_state () =
+    let parser = create () in
+    (* Send incomplete handshake data (less than 13 bytes total) *)
+    let result1 = parser "VNC 003" in
+    ( match result1 with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Incomplete handshake returns empty list" []
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+    ) ;
+
+    (* Complete with wrong protocol but valid client init *)
+    let result2 = parser (".003\n" ^ TestData.client_init) in
+    match result2 with
+    | Error msg ->
+        Alcotest.(check bool)
+          "Completed wrong handshake returns error" true
+          (String.starts_with ~prefix:"Parse error: BadHandshake:" msg)
+    | Ok _ ->
+        Alcotest.fail
+          "Expected Error but got Ok - invalid handshake should fail"
+
+  let test_complete_wrong_message_in_state () =
+    let parser = create () in
+    (* Send wrong handshake data *)
+    let wrong_handshake_data = "VNC 003.003\n" ^ TestData.client_init in
+    let result = parser wrong_handshake_data in
+    match result with
+    | Error msg ->
+        Alcotest.(check bool)
+          "Complete wrong handshake returns error" true
+          (String.starts_with ~prefix:"Parse error: BadHandshake:" msg)
+    | Ok _ ->
+        Alcotest.fail
+          "Expected Error but got Ok - invalid handshake should fail"
+
+  let test_multiple_messages_in_sequence () =
+    let parser = create () in
+    (* Send protocol version and client init *)
+    let _ = parser TestData.protocol_version in
+    let _ = parser TestData.client_init in
+
+    (* Send multiple client messages *)
+    let result1 = parser TestData.key_event in
+    let result2 = parser TestData.pointer_event in
+    let result3 = parser TestData.framebuffer_update_request in
+
+    ( match result1 with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "First client message" ["KeyEvent"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+    ) ;
+    ( match result2 with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Second client message" ["PointerEvent"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+    ) ;
+    match result3 with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Third client message"
+          ["FramebufferUpdateRequest"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+end
+
+(* Test error handling and edge cases *)
+module ErrorHandlingTests = struct
+  let test_unsupported_message_handling () =
+    let parser = create () in
+    (* Complete handshake first *)
+    let _ = parser (TestData.protocol_version ^ TestData.client_init) in
+    let result = parser TestData.unsupported_message in
+    match result with
+    | Error msg ->
+        Alcotest.(check bool)
+          "unsupported message returns error" true
+          (String.starts_with ~prefix:"Parse error: UnsupportedMsg:" msg)
+    | Ok _ ->
+        Alcotest.fail
+          "Expected Error but got Ok - unsupported message should fail"
+
+  let test_partial_message_handling () =
+    let parser = create () in
+    (* Send only part of handshake *)
+    let result1 = parser "RFB 003" in
+    ( match result1 with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Partial message returns empty" []
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+    ) ;
+
+    (* Complete the handshake *)
+    let result2 = parser (".003\n" ^ TestData.client_init) in
+    match result2 with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Completed handshake parses correctly" ["Handshake"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  let test_empty_data_handling () =
+    let parser = create () in
+    let result = parser "" in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Empty data returns empty list" []
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  let test_very_large_data_handling () =
+    let parser = create () in
+    (* Complete handshake first *)
+    let _ = parser (TestData.protocol_version ^ TestData.client_init) in
+
+    (* Create a very large ClientCutText message *)
+    let large_text_length = 1000 in
+    let large_text_header = int_list_to_string [6; 0; 0; 0; 0; 0; 3; 232] in
+    let large_text_data = String.make large_text_length 'A' in
+    let large_message = large_text_header ^ large_text_data in
+
+    let result = parser large_message in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Large message parsed correctly" ["ClientCutText"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+end
+
+(* Test parser lifecycle and helper functions *)
+module UtilityTests = struct
+  let test_parser_creation () =
+    let parser1 = create () in
+    let parser2 = create () in
+    (* Verify that different parser instances are independent *)
+    let _ = parser1 (TestData.protocol_version ^ TestData.client_init) in
+    let result = parser2 (TestData.protocol_version ^ TestData.client_init) in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "New parser starts fresh" ["Handshake"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  (* Note: string_of_message_type function is now internal to the module *)
+end
+
+(* Test concatenated messages and complex scenarios *)
+module IntegrationTests = struct
+  let test_concatenated_messages () =
+    let parser = create () in
+    (* Send protocol version and client init in one chunk *)
+    let combined_data = TestData.protocol_version ^ TestData.client_init in
+    let result = parser combined_data in
+    match result with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Concatenated handshake parsed correctly" ["Handshake"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+
+  let test_mixed_valid_invalid_messages () =
+    let parser = create () in
+    (* Complete handshake first *)
+    let _ = parser (TestData.protocol_version ^ TestData.client_init) in
+
+    (* Send valid message followed by invalid *)
+    let _ = parser TestData.key_event in
+    let result = parser TestData.unsupported_message in
+    match result with
+    | Error msg ->
+        Alcotest.(check bool)
+          "Invalid message after valid returns error" true
+          (String.starts_with ~prefix:"Parse error: UnsupportedMsg:" msg)
+    | Ok _ ->
+        Alcotest.fail
+          "Expected Error but got Ok - unsupported message should fail"
+
+  let test_complete_protocol_flow () =
+    let parser = create () in
+
+    (* Complete protocol handshake *)
+    let result1 = parser (TestData.protocol_version ^ TestData.client_init) in
+
+    (* Send various client messages *)
+    let result2 = parser TestData.set_pixel_format in
+    let result3 = parser TestData.set_encodings_simple in
+    let result4 = parser TestData.framebuffer_update_request in
+    let result5 = parser TestData.key_event in
+    let result6 = parser TestData.pointer_event in
+
+    ( match result1 with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Complete handshake" ["Handshake"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+    ) ;
+    ( match result2 with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Set pixel format" ["SetPixelFormat"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+    ) ;
+    ( match result3 with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Set encodings" ["SetEncodings"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+    ) ;
+    ( match result4 with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Framebuffer update request"
+          ["FramebufferUpdateRequest"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+    ) ;
+    ( match result5 with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Key event" ["KeyEvent"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+    ) ;
+    match result6 with
+    | Ok messages ->
+        Alcotest.(check (list string))
+          "Pointer event" ["PointerEvent"]
+          (List.map string_of_msg messages)
+    | Error msg ->
+        Alcotest.fail ("Expected Ok but got Error: " ^ msg)
+end
+
+(* Alcotest test suite *)
+let tests =
+  [
+    ( "Message Parsing"
+    , [
+        ( "test_protocol_version_parsing"
+        , `Quick
+        , MessageParsingTests.test_protocol_version_parsing
+        )
+      ; ( "test_invalid_protocol_version"
+        , `Quick
+        , MessageParsingTests.test_invalid_protocol_version
+        )
+      ; ( "test_invalid_protocol_version_rfb_004"
+        , `Quick
+        , MessageParsingTests.test_invalid_protocol_version_rfb_004
+        )
+      ; ( "test_incomplete_protocol_version"
+        , `Quick
+        , MessageParsingTests.test_incomplete_protocol_version
+        )
+      ; ( "test_client_init_shared"
+        , `Quick
+        , MessageParsingTests.test_client_init_shared
+        )
+      ; ( "test_client_init_exclusive"
+        , `Quick
+        , MessageParsingTests.test_client_init_exclusive
+        )
+      ; ( "test_client_init_invalid"
+        , `Quick
+        , MessageParsingTests.test_client_init_invalid
+        )
+      ; ( "test_client_init_invalid_255"
+        , `Quick
+        , MessageParsingTests.test_client_init_invalid_255
+        )
+      ; ( "test_client_init_parsing"
+        , `Quick
+        , MessageParsingTests.test_client_init_parsing
+        )
+      ; ( "test_set_pixel_format_parsing"
+        , `Quick
+        , MessageParsingTests.test_set_pixel_format_parsing
+        )
+      ; ( "test_set_encodings_parsing"
+        , `Quick
+        , MessageParsingTests.test_set_encodings_parsing
+        )
+      ; ( "test_multiple_encodings_parsing"
+        , `Quick
+        , MessageParsingTests.test_multiple_encodings_parsing
+        )
+      ; ( "test_framebuffer_update_request_parsing"
+        , `Quick
+        , MessageParsingTests.test_framebuffer_update_request_parsing
+        )
+      ; ( "test_key_event_parsing"
+        , `Quick
+        , MessageParsingTests.test_key_event_parsing
+        )
+      ; ( "test_pointer_event_parsing"
+        , `Quick
+        , MessageParsingTests.test_pointer_event_parsing
+        )
+      ; ( "test_client_cut_text_parsing"
+        , `Quick
+        , MessageParsingTests.test_client_cut_text_parsing
+        )
+      ; ( "test_qemu_client_message_parsing"
+        , `Quick
+        , MessageParsingTests.test_qemu_client_message_parsing
+        )
+      ]
+    )
+  ; ( "State Transitions"
+    , [
+        ( "test_protocol_state_progression"
+        , `Quick
+        , StateTransitionTests.test_protocol_state_progression
+        )
+      ; ( "test_incomplete_message_in_state"
+        , `Quick
+        , StateTransitionTests.test_incomplete_message_in_state
+        )
+      ; ( "test_complete_wrong_message_in_state"
+        , `Quick
+        , StateTransitionTests.test_complete_wrong_message_in_state
+        )
+      ; ( "test_multiple_messages_in_sequence"
+        , `Quick
+        , StateTransitionTests.test_multiple_messages_in_sequence
+        )
+      ]
+    )
+  ; ( "Error Handling"
+    , [
+        ( "test_unsupported_message_handling"
+        , `Quick
+        , ErrorHandlingTests.test_unsupported_message_handling
+        )
+      ; ( "test_partial_message_handling"
+        , `Quick
+        , ErrorHandlingTests.test_partial_message_handling
+        )
+      ; ( "test_empty_data_handling"
+        , `Quick
+        , ErrorHandlingTests.test_empty_data_handling
+        )
+      ; ( "test_very_large_data_handling"
+        , `Quick
+        , ErrorHandlingTests.test_very_large_data_handling
+        )
+      ]
+    )
+  ; ( "Utility Functions"
+    , [("test_parser_creation", `Quick, UtilityTests.test_parser_creation)]
+    )
+  ; ( "Integration Tests"
+    , [
+        ( "test_concatenated_messages"
+        , `Quick
+        , IntegrationTests.test_concatenated_messages
+        )
+      ; ( "test_mixed_valid_invalid_messages"
+        , `Quick
+        , IntegrationTests.test_mixed_valid_invalid_messages
+        )
+      ; ( "test_complete_protocol_flow"
+        , `Quick
+        , IntegrationTests.test_complete_protocol_flow
+        )
+      ]
+    )
+  ]

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -135,6 +135,7 @@
   astring
   cstruct
   base64
+  bigstringaf
   clock
   cohttp
   cohttp_posix

--- a/ocaml/xapi/rfb_client_msgtype_parser.ml
+++ b/ocaml/xapi/rfb_client_msgtype_parser.ml
@@ -1,0 +1,223 @@
+(*
+ * Copyright (C) Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** RFB (Remote Framebuffer) Protocol Parser for VNC Console Connections
+    
+    This module provides a stateful parser only for RFB client-to-server messages,
+    aiming to identify message types from clients.
+*)
+
+open Angstrom
+
+type msg =
+  | Handshake
+  | SetPixelFormat
+  | SetEncodings
+  | FramebufferUpdateRequest
+  | KeyEvent
+  | PointerEvent
+  | ClientCutText
+  | QEMUClientMessage
+
+(* Helper function to format binary data as hex string, up to max_bytes *)
+let hex_dump_data data max_bytes =
+  let len = min (String.length data) max_bytes in
+  let hex_chars = ref [] in
+  for i = 0 to len - 1 do
+    hex_chars := Printf.sprintf "%02x" (Char.code data.[i]) :: !hex_chars
+  done ;
+  let hex_str = String.concat " " (List.rev !hex_chars) in
+  if String.length data > max_bytes then
+    String.concat "" [hex_str; "..."]
+  else
+    hex_str
+
+let string_of_msg = function
+  | Handshake ->
+      "Handshake"
+  | SetPixelFormat ->
+      "SetPixelFormat"
+  | SetEncodings ->
+      "SetEncodings"
+  | FramebufferUpdateRequest ->
+      "FramebufferUpdateRequest"
+  | KeyEvent ->
+      "KeyEvent"
+  | PointerEvent ->
+      "PointerEvent"
+  | ClientCutText ->
+      "ClientCutText"
+  | QEMUClientMessage ->
+      "QEMUClientMessage"
+
+(*
+    https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#client-to-server-messages
+    Currently, only supports RFB version 3.3, and parses the most common used messages.
+    Can be extended to support more message types as needed.
+  *)
+
+(* Parse ProtocolVersion: "RFB 003.003\n" (12 bytes) *)
+let parse_protocol_version =
+  take 12 >>= fun data ->
+  if data = "RFB 003.003\n" then
+    return (Ok ())
+  else
+    let hex_data = hex_dump_data data 12 in
+    return (Error hex_data)
+
+(* Parse ClientInit: 1 byte shared-flag (0 or 1) *)
+let parse_client_init =
+  any_uint8 >>= fun shared_flag ->
+  if shared_flag = 0 || shared_flag = 1 then
+    return (Ok ())
+  else
+    let hex_data = Printf.sprintf "%02x" shared_flag in
+    return (Error hex_data)
+
+(* Combine protocol_version and client_init to one parser *)
+let parse_handshake =
+  both parse_protocol_version parse_client_init
+  >>= fun (proto_result, init_result) ->
+  match (proto_result, init_result) with
+  | Ok (), Ok () ->
+      return Handshake
+  | Error proto_data, Ok () ->
+      fail (String.concat "" ["BadHandshake: "; proto_data])
+  | Ok (), Error init_data ->
+      fail (String.concat "" ["BadHandshake: "; init_data])
+  | Error proto_data, Error init_data ->
+      let failed_data = String.concat "" [proto_data; init_data] in
+      fail (String.concat "" ["BadHandshake: "; failed_data])
+
+(* Parse SetPixelFormat: message-type(1) + padding(3) + pixel-format(16) = 20 bytes *)
+let parse_set_pixel_format =
+  any_uint8 >>= fun msg_type ->
+  if msg_type = 0 then
+    take 19 >>| fun _ -> SetPixelFormat
+  else
+    fail __FUNCTION__
+
+(* Parse SetEncodings: message-type(1) + padding(1) + num-encodings(2) + encodings(4*n) *)
+let parse_set_encodings =
+  any_uint8 >>= fun msg_type ->
+  if msg_type = 2 then
+    take 1 >>= fun _ ->
+    Angstrom.BE.any_uint16 >>= fun num_encodings ->
+    take (num_encodings * 4) >>| fun _ -> SetEncodings
+  else
+    fail __FUNCTION__
+
+(* Parse FramebufferUpdateRequest: message-type(1) + incremental(1) + x(2) + y(2) + width(2) + height(2) = 10 bytes *)
+let parse_framebuffer_update_request =
+  any_uint8 >>= fun msg_type ->
+  if msg_type = 3 then
+    take 9 >>| fun _ -> FramebufferUpdateRequest
+  else
+    fail __FUNCTION__
+
+(* Parse KeyEvent: message-type(1) + down-flag(1) + padding(2) + key(4) = 8 bytes *)
+let parse_key_event =
+  any_uint8 >>= fun msg_type ->
+  if msg_type = 4 then
+    take 7 >>| fun _ -> KeyEvent
+  else
+    fail __FUNCTION__
+
+(* Parse PointerEvent: message-type(1) + button-mask(1) + x(2) + y(2) = 6 bytes *)
+let parse_pointer_event =
+  any_uint8 >>= fun msg_type ->
+  if msg_type = 5 then
+    take 5 >>| fun _ -> PointerEvent
+  else
+    fail __FUNCTION__
+
+(* Parse ClientCutText: message-type(1) + padding(3) + length(4) + text(length) *)
+let parse_client_cut_text =
+  any_uint8 >>= fun msg_type ->
+  if msg_type = 6 then
+    take 3 >>= fun _ ->
+    Angstrom.BE.any_int32 >>= fun text_length ->
+    take (Int32.to_int text_length) >>| fun _ -> ClientCutText
+  else
+    fail __FUNCTION__
+
+(* Parse QEMU Client Message: message-type(1) + submessage-type(1) + data(10) = 12 bytes *)
+let parse_qemu_client_message =
+  any_uint8 >>= fun msg_type ->
+  if msg_type = 255 then
+    take 11 >>| fun _ -> QEMUClientMessage
+  else
+    fail __FUNCTION__
+
+(* Fallback parser for unknown messages *)
+let parse_unsupported_message =
+  any_uint8 >>= fun msg_type ->
+  let hex_data = Printf.sprintf "%02x" msg_type in
+  (* Use commit to prevent backtracking, so we can fail and get the error message *)
+  commit *> fail (String.concat "" ["UnsupportedMsg: "; hex_data])
+
+let handshake_parser = parse_handshake
+
+let message_parser =
+  (* Put the most likely parsers first *)
+  choice
+    [
+      parse_framebuffer_update_request
+    ; parse_pointer_event
+    ; parse_key_event
+    ; parse_client_cut_text
+    ; parse_qemu_client_message
+    ; parse_set_pixel_format
+    ; parse_set_encodings
+    ; parse_unsupported_message (* Fallback *)
+    ]
+
+(* Create RFB parser with closure-based state encapsulation *)
+let create () =
+  (* Private state hidden in closure *)
+  let state = ref (Angstrom.Buffered.parse handshake_parser) in
+
+  (* Helper to get unconsumed data as string *)
+  let unconsumed_to_string {Angstrom.Buffered.buf; off; len} =
+    Bigstringaf.substring buf ~off ~len
+  in
+
+  let rec check_parsing_result acc =
+    let open Angstrom.Buffered in
+    Result.bind acc @@ fun (parser_state, msgs) ->
+    match parser_state with
+    | Done (unconsumed, parsed_result) ->
+        let msgs = parsed_result :: msgs in
+        if unconsumed.len > 0 then
+          let new_parser = parse message_parser in
+          let fed_parser =
+            feed new_parser (`String (unconsumed_to_string unconsumed))
+          in
+          check_parsing_result (Ok (fed_parser, msgs))
+        else
+          Ok (parse message_parser, msgs)
+    | Partial _ ->
+        Ok (parser_state, msgs)
+    | Fail (_unconsumed, _, error_msg) ->
+        Error (String.concat "" ["Parse error: "; error_msg])
+  in
+
+  (* Return the data processing function *)
+  fun data_chunk ->
+    let new_parser = Angstrom.Buffered.feed !state (`String data_chunk) in
+    check_parsing_result (Ok (new_parser, []))
+    |> Result.map (fun (final_parser, messages) ->
+           state := final_parser ;
+           List.rev messages
+       )

--- a/ocaml/xapi/rfb_client_msgtype_parser.mli
+++ b/ocaml/xapi/rfb_client_msgtype_parser.mli
@@ -1,0 +1,69 @@
+(*
+ * Copyright (C) Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** RFB (Remote Framebuffer) Protocol Parser for VNC Console Connections
+    
+    This module provides a stateful parser only for RFB client-to-server messages,
+    aiming to identify message types from clients.
+*)
+
+type msg =
+  | Handshake
+  | SetPixelFormat
+  | SetEncodings
+  | FramebufferUpdateRequest
+  | KeyEvent
+  | PointerEvent
+  | ClientCutText
+  | QEMUClientMessage
+
+val string_of_msg : msg -> string
+(** Convert a message type to its string representation *)
+
+val create : unit -> string -> (msg list, string) result
+(** Create a new RFB parser instance.
+    
+    Returns a function that processes incoming data chunks and returns
+    either a list of parsed messages or an error string.
+    
+    Usage:
+    {[
+      let parser = create () in
+      match parser data_chunk with
+      | Ok messages -> 
+          List.iter (fun msg -> 
+            Printf.printf "Parsed: %s\n" (string_of_msg msg)
+          ) messages
+      | Error error_msg -> 
+          Printf.printf "Parse error: %s\n" error_msg
+    ]}
+    
+   
+    Supported message types:
+    - Handshake - Successful RFB handshake (ProtocolVersion + ClientInit)
+    - SetPixelFormat - Set pixel format (20 bytes)
+    - SetEncodings - Set encodings (variable length)
+    - FramebufferUpdateRequest - Request framebuffer update (10 bytes)
+    - KeyEvent - Keyboard input (8 bytes)
+    - PointerEvent - Mouse/pointer input (6 bytes)
+    - ClientCutText - Clipboard text (variable length)
+    - QEMUClientMessage - QEMU-specific message (12 bytes)
+    
+    Error handling:
+    - Returns Error "BadHandshake: ..." for failed handshake
+    - Returns Error "UnsupportedMsg: ..." for unrecognized message types
+    - Returns Error "Parse error: ..." for malformed data
+    
+    @return function of type (string -> (msg list, string) result) that processes data chunks
+*)


### PR DESCRIPTION
The parser only parses the message types for client-to-server messsages, aiming to identify message types from clients.