### PR TITLE
CA-417390: No RRD metric for vGPU migration with local storage

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2624,7 +2624,7 @@ functor
                   assert_can_migrate ~__context ~vm ~dest ~live ~vdi_map
                     ~vif_map ~vgpu_map ~options
               ) ;
-              if vgpu_map <> [] then
+              if Db.VM.get_VGPUs ~__context ~self:vm <> [] then
                 Xapi_stats.incr_pool_vgpu_migration_count () ;
               forward_migrate_send ()
           )


### PR DESCRIPTION
The "vgpu_map" can be empty for an intra-pool migration. This was missed previously because XenCenter indeed prepares non-empty "vgpu_map" for intra-pool migration with shared storage. But it prepares empty "vgpu_map" for intra-pool migration with local storage.