### PR TITLE
CP-54473 Configure max-cstate by XAPI

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -2505,6 +2505,21 @@ let latest_synced_updates_applied_state =
       ]
     )
 
+let set_max_cstate =
+  call ~name:"set_max_cstate" ~lifecycle:[]
+    ~doc:
+      "Sets xen's max-cstate on a host. See: \
+       https://xenbits.xen.org/docs/unstable/misc/xen-command-line.html#max_cstate-x86. \
+       \"\" means unlimited; \"N\" means limit to CN; \"N,M\" means limit to \
+       CN with max sub cstate M. Note: Only C0, C1, unlimited are supported \
+       currently."
+    ~params:
+      [
+        (Ref _host, "self", "The host")
+      ; (String, "value", "The max_cstate to apply to a host")
+      ]
+    ~allowed_roles:_R_POOL_OP ()
+
 (** Hosts *)
 let t =
   create_obj ~in_db:true
@@ -2649,6 +2664,7 @@ let t =
       ; set_ssh_enabled_timeout
       ; set_console_idle_timeout
       ; set_ssh_auto_mode
+      ; set_max_cstate
       ]
     ~contents:
       ([
@@ -3108,6 +3124,11 @@ let t =
             ~default_value:(Some (VBool Constants.default_ssh_auto_mode))
             "ssh_auto_mode"
             "Reflects whether SSH auto mode is enabled for the host"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:String
+            ~default_value:(Some (VString "")) "max_cstate"
+            "The maximum C-state that the host is allowed to enter, \"\" means \
+             unlimited; \"N\" means limit to CN; \"N,M\" means limit to CN \
+             with max sub cstate M."
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "7586cb039918e573594fc358e90b0f04"
+let last_known_schema_hash = "79dc1d985749f6ec31d4460ec49b9029"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -219,7 +219,8 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown
     ~pending_guidances_recommended:[] ~pending_guidances_full:[]
     ~last_update_hash:"" ~ssh_enabled:true ~ssh_enabled_timeout:0L
-    ~ssh_expiry:Date.epoch ~console_idle_timeout:0L ~ssh_auto_mode:false ;
+    ~ssh_expiry:Date.epoch ~console_idle_timeout:0L ~ssh_auto_mode:false
+    ~max_cstate:"" ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -3393,6 +3393,12 @@ let host_record rpc session_id host =
               ~value:(safe_bool_of_string "ssh-auto-mode" value)
           )
           ()
+      ; make_field ~name:"max-cstate"
+          ~get:(fun () -> (x ()).API.host_max_cstate)
+          ~set:(fun value ->
+            Client.Host.set_max_cstate ~rpc ~session_id ~self:host ~value
+          )
+          ()
       ]
   }
 

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -408,5 +408,8 @@ let update_env __context sync_keys =
         Xapi_host.set_console_idle_timeout ~__context ~self:localhost
           ~value:console_timeout
   ) ;
+  switched_sync Xapi_globs.sync_max_cstate (fun () ->
+      Xapi_host.sync_max_cstate ~__context ~host:localhost
+  ) ;
 
   remove_pending_guidances ~__context

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -4114,6 +4114,14 @@ functor
         let local_fn = Local.Host.set_ssh_auto_mode ~self ~value in
         let remote_fn = Client.Host.set_ssh_auto_mode ~self ~value in
         do_op_on ~local_fn ~__context ~host:self ~remote_fn
+
+      let set_max_cstate ~__context ~self ~value =
+        info "Host.set_max_cstate: host='%s' value='%s'"
+          (host_uuid ~__context self)
+          value ;
+        let local_fn = Local.Host.set_max_cstate ~self ~value in
+        let remote_fn = Client.Host.set_max_cstate ~self ~value in
+        do_op_on ~local_fn ~__context ~host:self ~remote_fn
     end
 
     module Host_crashdump = struct

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -374,6 +374,8 @@ let sync_chipset_info = "sync_chipset_info"
 
 let sync_ssh_status = "sync_ssh_status"
 
+let sync_max_cstate = "sync_max_cstate"
+
 let sync_pci_devices = "sync_pci_devices"
 
 let sync_gpus = "sync_gpus"

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -920,6 +920,8 @@ let systemctl = ref "/usr/bin/systemctl"
 
 let xen_cmdline_script = ref "/opt/xensource/libexec/xen-cmdline"
 
+let xenpm_bin = ref "/usr/sbin/xenpm"
+
 let alert_certificate_check = ref "alert-certificate-check"
 
 let sr_health_check_task_label = "SR Recovering"

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -589,3 +589,8 @@ val schedule_disable_ssh_job :
 
 val set_ssh_auto_mode :
   __context:Context.t -> self:API.ref_host -> value:bool -> unit
+
+val set_max_cstate :
+  __context:Context.t -> self:API.ref_host -> value:string -> unit
+
+val sync_max_cstate : __context:Context.t -> host:API.ref_host -> unit

--- a/ocaml/xapi/xapi_host_max_cstate.ml
+++ b/ocaml/xapi/xapi_host_max_cstate.ml
@@ -1,0 +1,192 @@
+(*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+exception Invalid_cstate of (int option * int option)
+
+exception Invalid_cstate_string of string
+
+exception Parse_cmd_output_failure of string
+
+exception Command_failure of string
+
+let ( let* ) = Option.bind
+
+let valid cstate = Option.fold ~none:true ~some:(fun v -> v >= 0) cstate
+
+let raise_parse_fail s e =
+  let msg = Printf.sprintf "output: %s; error: %s" s (Printexc.to_string e) in
+  raise (Parse_cmd_output_failure msg)
+
+let to_string (cstate, sub_cstate) =
+  match (cstate, sub_cstate) with
+  | None, _ ->
+      ""
+  | Some v, None when v >= 0 ->
+      Int.to_string v
+  | Some v, Some sub_v when v >= 0 && sub_v >= 0 ->
+      Printf.sprintf "%d,%d" v sub_v
+  | _ ->
+      raise (Invalid_cstate (cstate, sub_cstate))
+
+let of_string s =
+  let cstate, sub_cstate =
+    match String.split_on_char ',' s with
+    | [""] ->
+        (None, None)
+    | [state] -> (
+      try (Some (int_of_string state), None)
+      with _ -> raise (Invalid_cstate_string s)
+    )
+    | [state; sub_state] -> (
+      try (Some (int_of_string state), Some (int_of_string sub_state))
+      with _ -> raise (Invalid_cstate_string s)
+    )
+    | _ ->
+        raise (Invalid_cstate_string s)
+  in
+  if valid cstate && valid sub_cstate then
+    (cstate, sub_cstate)
+  else
+    raise (Invalid_cstate_string s)
+
+let parse_xenpm_response resp =
+  let parse_max_cstate_line line =
+    let line = String.trim line in
+    let* cstate_word =
+      try Scanf.sscanf line "max C-state set to %s" Option.some
+      with e -> raise_parse_fail resp e
+    in
+    match cstate_word with
+    | "unlimited" ->
+        None
+    | s -> (
+      try Scanf.sscanf s "C%d" Option.some with e -> raise_parse_fail resp e
+    )
+  in
+  let parse_sub_cstate_line line =
+    let line = String.trim line in
+    let* sub_cstate_word =
+      try Scanf.sscanf line "max C-substate set to %s succeeded" Option.some
+      with e -> raise_parse_fail resp e
+    in
+    match sub_cstate_word with
+    | "unlimited" ->
+        None
+    | s -> (
+      try Some (int_of_string s) with e -> raise_parse_fail resp e
+    )
+  in
+  match String.split_on_char '\n' resp with
+  | [] | [""] ->
+      raise (Parse_cmd_output_failure resp)
+  | cstate_line :: [] | [cstate_line; ""] ->
+      (parse_max_cstate_line cstate_line, None)
+  | cstate_line :: sub_cstate_line :: _ ->
+      (parse_max_cstate_line cstate_line, parse_sub_cstate_line sub_cstate_line)
+
+let parse_xencmdline_response resp =
+  (* the response may be
+     "" -> unlimited
+     "max_cstate=N" -> max cstate N
+     "max_cstate=N,M" -> max cstate N, max c-sub-state M *)
+  let resp = String.trim resp in
+  match Astring.String.fields ~is_sep:(fun c -> c = '=' || c = ',') resp with
+  | [""] ->
+      (None, None)
+  | ["max_cstate"; state] -> (
+    try (Some (int_of_string state), None) with e -> raise_parse_fail resp e
+  )
+  | ["max_cstate"; state; sub_state] -> (
+    try (Some (int_of_string state), Some (int_of_string sub_state))
+    with e -> raise_parse_fail resp e
+  )
+  | _ ->
+      raise (Parse_cmd_output_failure resp)
+
+(* xenpm examples:
+   # xenpm set-max-cstate 0 0
+   max C-state set to C0
+   max C-substate set to 0 succeeded
+   # xenpm set-max-cstate 0
+   max C-state set to C0
+   max C-substate set to unlimited succeeded
+   # xenpm set-max-cstate unlimited
+   max C-state set to unlimited
+   # xenpm set-max-cstate -1
+   Missing, excess, or invalid argument(s)
+*)
+let xenpm_set cstate sub_cstate =
+  let args =
+    match (cstate, sub_cstate) with
+    | None, _ ->
+        ["set-max-cstate"; "unlimited"]
+    | Some v, None when v >= 0 ->
+        ["set-max-cstate"; string_of_int v]
+    | Some v, Some sub_v when v >= 0 && sub_v >= 0 ->
+        ["set-max-cstate"; string_of_int v; string_of_int sub_v]
+    | _ ->
+        raise (Invalid_cstate (cstate, sub_cstate))
+  in
+  let resp =
+    try Helpers.call_script !Xapi_globs.xenpm_bin args
+    with e ->
+      raise
+        (Command_failure
+           (Printf.sprintf "xenpm_set failed: %s" (Printexc.to_string e))
+        )
+  in
+  match parse_xenpm_response resp with
+  | None, _ ->
+      if cstate <> None then
+        raise
+          (Command_failure
+             (Printf.sprintf "get unmatched value in xenpm output %s" resp)
+          )
+  | cstate_in_resp, sub_cstate_in_resp ->
+      if (cstate_in_resp, sub_cstate_in_resp) <> (cstate, sub_cstate) then
+        raise
+          (Command_failure
+             (Printf.sprintf "get unmatched value in xenpm output %s" resp)
+          )
+
+let xen_cmdline_set cstate sub_cstate =
+  let args =
+    match (cstate, sub_cstate) with
+    | None, _ ->
+        ["--delete-xen"; "max_cstate"]
+    | Some v, None when v >= 0 ->
+        ["--set-xen"; Printf.sprintf "max_cstate=%d" v]
+    | Some v, Some sub_v when v >= 0 && sub_v >= 0 ->
+        ["--set-xen"; Printf.sprintf "max_cstate=%d,%d" v sub_v]
+    | _ ->
+        raise (Invalid_cstate (cstate, sub_cstate))
+  in
+  try Helpers.call_script !Xapi_globs.xen_cmdline_script args |> ignore
+  with e ->
+    raise
+      (Command_failure
+         (Printf.sprintf "xen_cmdline_set failed: %s" (Printexc.to_string e))
+      )
+
+let xen_cmdline_get () =
+  let args = ["--get-xen"; "max_cstate"] in
+  let resp =
+    try Helpers.call_script !Xapi_globs.xen_cmdline_script args
+    with e ->
+      raise
+        (Command_failure
+           (Printf.sprintf "xen_cmdline_get failed: %s" (Printexc.to_string e))
+        )
+  in
+  parse_xencmdline_response resp

--- a/ocaml/xapi/xapi_host_max_cstate.mli
+++ b/ocaml/xapi/xapi_host_max_cstate.mli
@@ -1,0 +1,81 @@
+(*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** Host CPU C-state management functions.
+
+    C-states are power management states for CPUs where higher numbered states
+    represent deeper sleep modes with lower power consumption but higher wake-up
+    latency. The max_cstate parameter controls the deepest C-state that CPUs
+    are allowed to enter.
+
+    Common C-state values:
+    - C0: CPU is active (not a sleep state)
+    - C1: CPU is halted but can wake up almost instantly
+    - C2: CPU caches are flushed, slightly longer wake-up time
+    - C3+: Deeper sleep states with progressively longer wake-up times
+
+    Setting max_cstate=1 restricts CPUs to only use C0 and C1 states,
+    which can improve performance for latency-sensitive workloads at the
+    cost of higher power consumption.
+*)
+
+exception Invalid_cstate of (int option * int option)
+
+exception Invalid_cstate_string of string
+
+exception Parse_cmd_output_failure of string
+
+exception Command_failure of string
+
+val to_string : int option * int option -> string
+(** [to_string (cstate, sub_cstate)] converts the (cstate, sub_cstate) tuple to a string representation.
+    
+    @param cstate The maximum C-state value, [None] means unlimited
+    @param sub_cstate The maximum C-substate value, [None] means unlimited
+    @return A string representation of the (cstate, sub_cstate) tuple
+    @raise Invalid_cstate if cstate < 0 or sub_cstate < 0 *)
+
+val of_string : string -> int option * int option
+(** [of_string s] parses a string representation of (cstate, sub_cstate) back into a tuple.
+    
+    @param s The string representation of (cstate, sub_cstate), e.g. "1,2" or "None,None"
+    @return The parsed (cstate, sub_cstate) tuple, [None] means unlimited
+    @raise Invalid_cstate_string if the string is not in the correct format *)
+
+val xenpm_set : int option -> int option -> unit
+(** [xenpm_set cstate sub_cstate] sets the maximum C-state and C-substate using the xenpm tool.
+    This affects the runtime power management behavior immediately.
+    
+    @param cstate The maximum C-state value, [None] means unlimited
+    @param sub_cstate The maximum C-substate value, [None] means unlimited
+    @raise Invalid_cstate if cstate < 0 or sub_cstate < 0
+    @raise Command_failure if the xenpm command fails
+    @raise Parse_cmd_output_failure if the output of xenpm cannot be parsed *)
+
+val xen_cmdline_set : int option -> int option -> unit
+(** [xen_cmdline_set cstate sub_cstate] sets the max_cstate parameter in the Xen command line.
+    This setting will take effect on the next reboot.
+    
+    @param cstate The maximum C-state value, [None] means unlimited
+    @param sub_cstate The maximum C-substate value, [None] means unlimited
+    @raise Invalid_cstate if cstate < 0 or sub_cstate < 0
+    @raise Command_failure if the Xen command line cannot be updated *)
+
+val xen_cmdline_get : unit -> int option * int option
+(** [xen_cmdline_get ()] retrieves the current max_cstate setting from the Xen command line.
+    
+    @return The current (max_cstate, max_sub_cstate) in xen cmdline configuration, [None] means unlimited
+    @raise Invalid_cstate if cstate < 0 or sub_cstate < 0
+    @raise Command_failure if the Xen command line cannot be updated
+    @raise Parse_cmd_output_failure if the Xen command line output cannot be parsed *)


### PR DESCRIPTION
C-states are power management states for CPUs where higher numbered states represent deeper sleep modes with lower power consumption but higher wake-up latency. The max_cstate parameter controls the deepest C-state that CPUs are allowed to enter.

Common C-state values:
- C0: CPU is active (not a sleep state)
- C1: CPU is halted but can wake up almost instantly
- C2: CPU caches are flushed, slightly longer wake-up time
- C3+: Deeper sleep states with progressively longer wake-up times

To set max_cstate on dom0 host, two commands are used: `xenpm` to set at runtime and `xen-cmdline` to set it in grub conf file to take effect after reboot.
xenpm examples:
```
   # xenpm set-max-cstate 0 0
   max C-state set to C0
   max C-substate set to 0 succeeded
   # xenpm set-max-cstate 0
   max C-state set to C0
   max C-substate set to unlimited succeeded
   # xenpm set-max-cstate unlimited
   max C-state set to unlimited
   # xenpm set-max-cstate -1
   Missing, excess, or invalid argument(s)
```
xen-command-line examples:
```
/opt/xensource/libexec/xen-cmdline --get-xen max_cstate
     "" -> unlimited
     "max_cstate=N" -> max cstate N
     "max_cstate=N,M" -> max cstate N, max c-sub-state M *)
/opt/xensource/libexec/xen-cmdline --set-xen max_cstate=1
/opt/xensource/libexec/xen-cmdline --set-xen max_cstate=1,0
/opt/xensource/libexec/xen-cmdline --delete-xen max_cstate
```
[xen-command-line.max_cstate](https://xenbits.xen.org/docs/unstable/misc/xen-command-line.html#max_cstate-x86).

This PR adds a new field `host.max_cstate` to manage host's max_cstate. `host.set_max_cstate` use the two commands mentioned above to configure. While dbsync on xapi start, the filed will be synced by `xen-cmdline --get-xen max_cstate`
