### PR TITLE
`xenopsd/bootloader`: No need to create `/var/run/xend/boot` anymore

### DIFF
--- a/ocaml/xenopsd/lib/bootloader.ml
+++ b/ocaml/xenopsd/lib/bootloader.ml
@@ -223,8 +223,6 @@ let sanity_check_path p =
 let extract (task : Xenops_task.task_handle) ~bootloader ~disk
     ?(legacy_args = "") ?(extra_args = "") ?(pv_bootloader_args = "")
     ~vm:vm_uuid ~domid () =
-  (* Without this path, pygrub will fail: *)
-  Unixext.mkdir_rec "/var/run/xend/boot" 0o0755 ;
   let bootloader_path, cmdline =
     command bootloader true pv_bootloader_args disk vm_uuid domid
   in


### PR DESCRIPTION
Since c00965172 `("pygrub: make sure /var/run/xend/boot exists before calling pygrub")` added this safety measure, pygrub moved to using `/var/run/xen/boot` (see [63dcc68151](https://xenbits.xen.org/gitweb/?p=xen.git;a=commit;h=63dcc681511356d42645ef2c78955864e3b3e6b9) `("tools/pygrub: store kernels in /var/run/xen/pygrub")` in upstream xen ) and started creating the directory itself (if it doesn't already exist).

It's time to drop this unnecessary workaround.