### PR TITLE
xapi: Add secure boot field to host datamodel

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 790
+let schema_minor_vsn = 791
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1367,6 +1367,13 @@ let create_params =
     ; param_release= numbered_release "25.27.0"
     ; param_default= Some (VBool Constants.default_ssh_auto_mode)
     }
+  ; {
+      param_type= Bool
+    ; param_name= "secure_boot"
+    ; param_doc= "True if the host is in secure boot mode"
+    ; param_release= numbered_release "25.32.0"
+    ; param_default= Some (VBool false)
+    }
   ]
 
 let create =
@@ -3108,6 +3115,9 @@ let t =
             ~default_value:(Some (VBool Constants.default_ssh_auto_mode))
             "ssh_auto_mode"
             "Reflects whether SSH auto mode is enabled for the host"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Bool
+            ~default_value:(Some (VBool false)) "secure_boot"
+            "Whether the host has booted in secure boot mode"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -97,6 +97,8 @@ let prototyped_of_field = function
       Some "22.26.0"
   | "SM", "host_pending_features" ->
       Some "24.37.0"
+  | "host", "secure_boot" ->
+      Some "25.31.0"
   | "host", "ssh_auto_mode" ->
       Some "25.27.0"
   | "host", "console_idle_timeout" ->

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "7586cb039918e573594fc358e90b0f04"
+let last_known_schema_hash = "3b20f4304cfaaa7b6213af91ae632e64"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -172,14 +172,15 @@ let make_host ~__context ?(uuid = make_uuid ()) ?(name_label = "host")
     ?(local_cache_sr = Ref.null) ?(chipset_info = []) ?(ssl_legacy = false)
     ?(last_software_update = Date.epoch) ?(last_update_hash = "")
     ?(ssh_enabled = true) ?(ssh_enabled_timeout = 0L) ?(ssh_expiry = Date.epoch)
-    ?(console_idle_timeout = 0L) ?(ssh_auto_mode = false) () =
+    ?(console_idle_timeout = 0L) ?(ssh_auto_mode = false) ?(secure_boot = false)
+    () =
   let host =
     Xapi_host.create ~__context ~uuid ~name_label ~name_description ~hostname
       ~address ~external_auth_type ~external_auth_service_name
       ~external_auth_configuration ~license_params ~edition ~license_server
       ~local_cache_sr ~chipset_info ~ssl_legacy ~last_software_update
       ~last_update_hash ~ssh_enabled ~ssh_enabled_timeout ~ssh_expiry
-      ~console_idle_timeout ~ssh_auto_mode
+      ~console_idle_timeout ~ssh_auto_mode ~secure_boot
   in
   Db.Host.set_cpu_info ~__context ~self:host ~value:default_cpu_info ;
   host
@@ -219,7 +220,8 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown
     ~pending_guidances_recommended:[] ~pending_guidances_full:[]
     ~last_update_hash:"" ~ssh_enabled:true ~ssh_enabled_timeout:0L
-    ~ssh_expiry:Date.epoch ~console_idle_timeout:0L ~ssh_auto_mode:false ;
+    ~ssh_expiry:Date.epoch ~console_idle_timeout:0L ~ssh_auto_mode:false
+    ~secure_boot:false ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/tests/test_host.ml
+++ b/ocaml/tests/test_host.ml
@@ -25,7 +25,7 @@ let add_host __context name =
        ~local_cache_sr:Ref.null ~chipset_info:[] ~ssl_legacy:false
        ~last_software_update:Clock.Date.epoch ~last_update_hash:""
        ~ssh_enabled:true ~ssh_enabled_timeout:0L ~ssh_expiry:Clock.Date.epoch
-       ~console_idle_timeout:0L ~ssh_auto_mode:false
+       ~console_idle_timeout:0L ~ssh_auto_mode:false ~secure_boot:false
     )
 
 (* Creates an unlicensed pool with the maximum number of hosts *)

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -3393,6 +3393,9 @@ let host_record rpc session_id host =
               ~value:(safe_bool_of_string "ssh-auto-mode" value)
           )
           ()
+      ; make_field ~name:"secure-boot"
+          ~get:(fun () -> string_of_bool (x ()).API.host_secure_boot)
+          ()
       ]
   }
 

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -65,6 +65,7 @@ let create_localhost ~__context info =
         ~ssh_expiry:Date.epoch
         ~console_idle_timeout:Constants.default_console_idle_timeout
         ~ssh_auto_mode:!Xapi_globs.ssh_auto_mode_default
+        ~secure_boot:false
     in
     ()
 
@@ -408,5 +409,17 @@ let update_env __context sync_keys =
         Xapi_host.set_console_idle_timeout ~__context ~self:localhost
           ~value:console_timeout
   ) ;
-
+  switched_sync Xapi_globs.sync_secure_boot (fun () ->
+      let result =
+        try
+          let contents = Unixext.string_of_file !Xapi_globs.secure_boot_path in
+          contents.[4] <> '\x00'
+        with e ->
+          warn "%s error while reading %S: %s" __FUNCTION__
+            !Xapi_globs.secure_boot_path
+            (Printexc.to_string e) ;
+          false
+      in
+      Db.Host.set_secure_boot ~__context ~self:localhost ~value:result
+  ) ;
   remove_pending_guidances ~__context

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -374,6 +374,8 @@ let sync_chipset_info = "sync_chipset_info"
 
 let sync_ssh_status = "sync_ssh_status"
 
+let sync_secure_boot = "sync_secure_boot"
+
 let sync_pci_devices = "sync_pci_devices"
 
 let sync_gpus = "sync_gpus"
@@ -1330,6 +1332,10 @@ let ssh_monitor_service = ref "xapi-ssh-monitor"
 
 let ssh_auto_mode_default = ref true
 
+let secure_boot_path =
+  ref
+    "/sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"
+
 (* Fingerprint of default patch key *)
 let citrix_patch_key =
   "NERDNTUzMDMwRUMwNDFFNDI4N0M4OEVCRUFEMzlGOTJEOEE5REUyNg=="
@@ -1785,6 +1791,11 @@ let other_options =
     , (fun () -> string_of_bool !ssh_auto_mode_default)
     , "Defaults to true; overridden to false via \
        /etc/xapi.conf.d/ssh-auto-mode.conf(e.g., in XenServer 8)"
+    )
+  ; ( "secure-boot-efi-path"
+    , Arg.Set_string secure_boot_path
+    , (fun () -> !secure_boot_path)
+    , "Path to secure boot status file"
     )
   ; ( "vm-sysprep-enabled"
     , Arg.Set vm_sysprep_enabled

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1027,7 +1027,8 @@ let create ~__context ~uuid ~name_label ~name_description:_ ~hostname ~address
     ~external_auth_type ~external_auth_service_name ~external_auth_configuration
     ~license_params ~edition ~license_server ~local_cache_sr ~chipset_info
     ~ssl_legacy:_ ~last_software_update ~last_update_hash ~ssh_enabled
-    ~ssh_enabled_timeout ~ssh_expiry ~console_idle_timeout ~ssh_auto_mode =
+    ~ssh_enabled_timeout ~ssh_expiry ~console_idle_timeout ~ssh_auto_mode
+    ~secure_boot =
   (* fail-safe. We already test this on the joining host, but it's racy, so multiple concurrent
      pool-join might succeed. Note: we do it in this order to avoid a problem checking restrictions during
      the initial setup of the database *)
@@ -1092,7 +1093,8 @@ let create ~__context ~uuid ~name_label ~name_description:_ ~hostname ~address
     ~tls_verification_enabled ~last_software_update ~last_update_hash
     ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown
     ~pending_guidances_recommended:[] ~pending_guidances_full:[] ~ssh_enabled
-    ~ssh_enabled_timeout ~ssh_expiry ~console_idle_timeout ~ssh_auto_mode ;
+    ~ssh_enabled_timeout ~ssh_expiry ~console_idle_timeout ~ssh_auto_mode
+    ~secure_boot ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics ~value:(Date.now ()) ;
   Db.Host_metrics.set_live ~__context ~self:metrics ~value:host_is_us ;

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -136,6 +136,7 @@ val create :
   -> ssh_expiry:API.datetime
   -> console_idle_timeout:int64
   -> ssh_auto_mode:bool
+  -> secure_boot:bool
   -> [`host] Ref.t
 
 val destroy : __context:Context.t -> self:API.ref_host -> unit

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1058,6 +1058,7 @@ let rec create_or_get_host_on_master __context rpc session_id (host_ref, host) :
           ~ssh_expiry:host.API.host_ssh_expiry
           ~console_idle_timeout:host.API.host_console_idle_timeout
           ~ssh_auto_mode:host.API.host_ssh_auto_mode
+          ~secure_boot:host.API.host_secure_boot
       in
       (* Copy other-config into newly created host record: *)
       no_exn


### PR DESCRIPTION
The secure boot status can be read from the fifth byte of file /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c

This adds a secure_boot field to the host datamodel, which is set during dbsync to the value held in the above file.