### PR TITLE
CA-417520: Fix firewalld issues for HA

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -3404,7 +3404,11 @@ let update_firewalld_service_status ~__context =
               )
               (Db.Tunnel.get_all ~__context)
         | Xenha ->
+            (* Only xha needs to enable firewalld service. Other HA cluster
+               stacks don't need. *)
             bool_of_string (Localdb.get Constants.ha_armed)
+            && Localdb.get Constants.ha_cluster_stack
+               = !Xapi_globs.cluster_stack_default
       in
       List.iter
         (fun s -> if is_enabled s then enable_firewalld_service s)


### PR DESCRIPTION
1. Modify startup order in `server_init`. Checking HA configuration depends on the firewalld service, so move the updating firewalld service before checking HA configuration.
2. HA supports 2 cluster stacks: xha and corosync. Only xha needs to control firewalld service dynamically. For corosync HA, the firewalld service dlm has been already controlled by the xapi-clusterd, so it doesn't need to control dynamically.
3. Slave's HA is shutdown in `ha_wait_for_shutdown_via_statefile`. Add disabling firewalld service here.