### PR TITLE
system_status: enhance useability of the API call

### DIFF
--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -233,7 +233,7 @@ let response_redirect ?req s dest =
   in
   Unixext.really_write_string s (Http.Response.to_wire_string res)
 
-let response_file ?mime_content_type ~hsts_time s file =
+let response_file ?mime_content_type ?download_name ~hsts_time s file =
   let size = (Unix.LargeFile.stat file).Unix.LargeFile.st_size in
   let keep_alive = [(Http.Hdr.connection, "keep-alive")] in
   let hsts_header =
@@ -248,9 +248,17 @@ let response_file ?mime_content_type ~hsts_time s file =
       ~some:(fun ty -> [(Hdr.content_type, ty)])
       mime_content_type
   in
+  let content_disposition =
+    let hdr = Hdr.content_disposition in
+    let typ = "attachment" in
+    Option.fold ~none:[]
+      ~some:(fun name -> [(hdr, Printf.sprintf {|%s; filename="%s"|} typ name)])
+      download_name
+  in
   let res =
     Http.Response.make ~version:"1.1"
-      ~headers:(List.concat [keep_alive; hsts_header; mime_header])
+      ~headers:
+        (List.concat [keep_alive; hsts_header; mime_header; content_disposition])
       ~length:size "200" "OK"
   in
   Unixext.with_file file [Unix.O_RDONLY] 0 (fun f ->

--- a/ocaml/libs/http-lib/http_svr.mli
+++ b/ocaml/libs/http-lib/http_svr.mli
@@ -109,6 +109,7 @@ val response_redirect : ?req:Http.Request.t -> Unix.file_descr -> string -> unit
 
 val response_file :
      ?mime_content_type:string
+  -> ?download_name:string
   -> hsts_time:int
   -> Unix.file_descr
   -> string

--- a/ocaml/xapi/system_status.ml
+++ b/ocaml/xapi/system_status.ml
@@ -91,17 +91,18 @@ let send_via_cp __context s entries output =
   in
   let () = debug "running %s" cmd in
   try
-    let filename = String.rtrim (Helpers.get_process_output cmd) in
+    let filepath = String.rtrim (Helpers.get_process_output cmd) in
+    let filename = Filename.basename filepath in
     let hsts_time = !Xapi_globs.hsts_max_age in
     finally
       (fun () ->
-        debug "bugball path: %s" filename ;
-        Http_svr.response_file ~mime_content_type:content_type ~hsts_time s
-          filename
+        debug "bugball path: %s" filepath ;
+        Http_svr.response_file ~mime_content_type:content_type ~hsts_time
+          ~download_name:filename s filepath
       )
       (fun () ->
         Helpers.log_exn_continue "deleting xen-bugtool output" Unix.unlink
-          filename
+          filepath
       )
   with e ->
     let msg = "xen-bugtool failed: " ^ ExnHelper.string_of_exn e in

--- a/ocaml/xapi/system_status.mli
+++ b/ocaml/xapi/system_status.mli
@@ -1,0 +1,3 @@
+val get_capabilities : unit -> string
+
+val handler : Http.Request.t -> Unix.file_descr -> 'a -> unit

--- a/ocaml/xapi/xapi_vncsnapshot.ml
+++ b/ocaml/xapi/xapi_vncsnapshot.ml
@@ -30,6 +30,7 @@ let vncsnapshot_handler (req : Request.t) s _ =
           Rbac_static.permission_http_get_vncsnapshot_host_console
             .Db_actions.role_name_label ;
         let tmp = Filename.temp_file "snapshot" "jpg" in
+        let filename = Filename.basename tmp in
         Xapi_stdext_pervasives.Pervasiveext.finally
           (fun () ->
             let vnc_port =
@@ -48,7 +49,7 @@ let vncsnapshot_handler (req : Request.t) s _ =
             in
             let hsts_time = !Xapi_globs.hsts_max_age in
             waitpid_fail_if_bad_exit pid ;
-            Http_svr.response_file ~hsts_time s tmp
+            Http_svr.response_file ~hsts_time s tmp ~download_name:filename
           )
           (fun () -> try Unix.unlink tmp with _ -> ())
       with e ->

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -25,7 +25,7 @@ verify-cert () {
 }
 
 mli-files () {
-  N=463
+  N=462
   X="ocaml/tests"
   X+="|ocaml/quicktest"
   X+="|ocaml/message-switch/core_test"


### PR DESCRIPTION
Now there's no failure when called without parameters, suggests a nice filename with the correct extension, advertises the content-type of the file served, and adds an option to list all the allowed entries supported by xen-bugtool in an xml format.