### PR TITLE
CP-54393: VNC console idle timeout

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
@@ -126,7 +126,12 @@ exception Process_still_alive
 
 val kill_and_wait : ?signal:int -> ?timeout:float -> int -> unit
 
-val proxy : Unix.file_descr -> Unix.file_descr -> unit
+val proxy :
+     ?should_close:(bytes * int * int -> bool)
+  -> ?poll_timeout:int
+  -> Unix.file_descr
+  -> Unix.file_descr
+  -> unit
 
 val really_read : Unix.file_descr -> bytes -> int -> int -> unit
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -450,6 +450,11 @@ let xha_timeout = "timeout"
 
 let message_limit = ref 10000
 
+(* The timeout (in seconds) for event polling in the proxy loop.
+   If set to a positive value, the poll will wake up periodically,
+   which is useful for implementing features like idle timeout or periodic inspection of proxy buffers. *)
+let proxy_poll_period_timeout = ref 5.0
+
 let xapi_message_script = ref "mail-alarm"
 
 (* Emit a warning if more than this amount of clock skew detected *)
@@ -1782,6 +1787,14 @@ let other_options =
     , Arg.Set_float vm_sysprep_wait
     , (fun () -> string_of_float !vm_sysprep_wait)
     , "Time in seconds to wait for VM to recognise inserted CD"
+    )
+  ; ( "proxy_poll_period_timeout"
+    , Arg.Set_float proxy_poll_period_timeout
+    , (fun () -> string_of_float !proxy_poll_period_timeout)
+    , "Timeout (in seconds) for event polling in network proxy loops. When \
+       positive, the proxy will wake up periodically to check tasks like vnc \
+       idle timeouts or perform other maintenance tasks. Set to -1 to wait \
+       indefinitely for network events without periodic wake-ups."
     )
   ]
 


### PR DESCRIPTION
This commit adds idle timeout feature for vnc console connections.

Key changes:
- Add idle timeout detection by monitoring RFB keyEvent and pointerEvent.
- Add callback function to `proxy` to parse the RFB messages and determine if the connection is idle or not.