### PR TITLE
Add < 2.0.0 to cmdliner dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -168,7 +168,7 @@
 (package
  (name xapi-storage-cli)
  (depends
-  cmdliner
+  (cmdliner (< "2.0.0"))
   re
   rpclib
   ppx_deriving_rpc
@@ -278,7 +278,7 @@
   angstrom
   astring
   base64
-  cmdliner
+  (cmdliner (< "2.0.0"))
   cohttp
   cstruct
   ctypes
@@ -336,7 +336,7 @@
  (depends
   astring
   base64
-  cmdliner
+  (cmdliner (< "2.0.0"))
   cstruct-unix
   fmt
   logs
@@ -383,7 +383,7 @@
   cdrom
   (clock
    (= :version))
-  cmdliner
+  (cmdliner (< "2.0.0"))
   cohttp
   conf-pam
   (crowbar :with-test)
@@ -498,7 +498,7 @@
   (alcotest-lwt :with-test)
   astring
   bigarray-compat
-  cmdliner
+  (cmdliner (< "2.0.0"))
   cohttp
   cohttp-lwt
   conf-libssl
@@ -582,7 +582,7 @@
   (synopsis "Minimal CLI wrapper for qcow-stream")
   (depends
     qcow-stream
-    cmdliner
+    (cmdliner (< "2.0.0"))
   )
 )
 

--- a/opam/ezxenstore.opam
+++ b/opam/ezxenstore.opam
@@ -11,7 +11,7 @@ build: [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {>= "3.15"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "logs"
   "uuidm"
   "xapi-stdext-unix"

--- a/opam/ezxenstore.opam.template
+++ b/opam/ezxenstore.opam.template
@@ -9,7 +9,7 @@ build: [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {>= "3.15"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "logs"
   "uuidm"
   "xapi-stdext-unix"

--- a/opam/message-switch-cli.opam
+++ b/opam/message-switch-cli.opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml"
   "dune" {>= "3.15"}
   "odoc" {with-doc}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "message-switch-unix"
   "ppx_deriving_rpc"
 ]

--- a/opam/message-switch-cli.opam.template
+++ b/opam/message-switch-cli.opam.template
@@ -14,7 +14,7 @@ depends: [
   "ocaml"
   "dune" {>= "3.15"}
   "odoc" {with-doc}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "message-switch-unix"
   "ppx_deriving_rpc"
 ]

--- a/opam/message-switch.opam
+++ b/opam/message-switch.opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"
   "dune" {>= "3.15"}
   "odoc" {with-doc}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cohttp-lwt-unix"
   "io-page" {>= "2.4.0"}
   "lwt_log"

--- a/opam/message-switch.opam.template
+++ b/opam/message-switch.opam.template
@@ -15,7 +15,7 @@ depends: [
   "ocaml"
   "dune" {>= "3.15"}
   "odoc" {with-doc}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cohttp-lwt-unix"
   "io-page" {>= "2.4.0"}
   "lwt_log"

--- a/opam/qcow-stream-tool.opam
+++ b/opam/qcow-stream-tool.opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/xapi-project/xen-api/issues"
 depends: [
   "dune" {>= "3.15"}
   "qcow-stream"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/opam/varstored-guard.opam
+++ b/opam/varstored-guard.opam
@@ -10,7 +10,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 run-test: [[ "dune" "runtest" "-p" name "-j" jobs ]]
 depends: [
   "dune" {>= "3.15"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "alcotest" {with-test}
   "cohttp-lwt"
   "fmt" {with-test}

--- a/opam/varstored-guard.opam.template
+++ b/opam/varstored-guard.opam.template
@@ -8,7 +8,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 run-test: [[ "dune" "runtest" "-p" name "-j" jobs ]]
 depends: [
   "dune" {>= "3.15"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "alcotest" {with-test}
   "cohttp-lwt"
   "fmt" {with-test}

--- a/opam/vhd-tool.opam
+++ b/opam/vhd-tool.opam
@@ -12,7 +12,7 @@ depends: [
   "alcotest-lwt" {with-test}
   "astring"
   "bigarray-compat"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cohttp"
   "cohttp-lwt"
   "conf-libssl"

--- a/opam/xapi-debug.opam
+++ b/opam/xapi-debug.opam
@@ -14,7 +14,7 @@ depends: [
   "angstrom"
   "astring"
   "base64"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cohttp"
   "cstruct"
   "ctypes"

--- a/opam/xapi-idl.opam
+++ b/opam/xapi-idl.opam
@@ -15,7 +15,7 @@ depends: [
   "alcotest" {with-test}
   "fmt" {with-test}
   "astring"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cohttp"
   "cohttp-posix"
   "fd-send-recv"

--- a/opam/xapi-idl.opam.template
+++ b/opam/xapi-idl.opam.template
@@ -13,7 +13,7 @@ depends: [
   "alcotest" {with-test}
   "fmt" {with-test}
   "astring"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cohttp"
   "cohttp-posix"
   "fd-send-recv"

--- a/opam/xapi-inventory.opam
+++ b/opam/xapi-inventory.opam
@@ -21,7 +21,7 @@ depends: [
   "astring"
   "xapi-stdext-unix"
   "xapi-stdext-threads"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "uuidm"
 ]
 synopsis: "Library for accessing the xapi toolstack inventory file"

--- a/opam/xapi-inventory.opam.template
+++ b/opam/xapi-inventory.opam.template
@@ -19,7 +19,7 @@ depends: [
   "astring"
   "xapi-stdext-unix"
   "xapi-stdext-threads"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "uuidm"
 ]
 synopsis: "Library for accessing the xapi toolstack inventory file"

--- a/opam/xapi-nbd.opam
+++ b/opam/xapi-nbd.opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "3.15"}
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "lwt" {>= "3.0.0" & with-test}
   "lwt_log"
   "mirage-block-unix"

--- a/opam/xapi-nbd.opam.template
+++ b/opam/xapi-nbd.opam.template
@@ -13,7 +13,7 @@ depends: [
   "dune" {>= "3.15"}
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "lwt" {>= "3.0.0" & with-test}
   "lwt_log"
   "mirage-block-unix"

--- a/opam/xapi-storage-cli.opam
+++ b/opam/xapi-storage-cli.opam
@@ -10,7 +10,7 @@ homepage: "https://xapi-project.github.io/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 depends: [
   "dune" {>= "3.15"}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "re"
   "rpclib"
   "ppx_deriving_rpc"

--- a/opam/xapi-storage.opam
+++ b/opam/xapi-storage.opam
@@ -22,7 +22,7 @@ depends: [
   "ppx_deriving_rpc"
   "rpclib"
   "xmlm"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
 ]
 synopsis: "Code and documentation generator for the Xapi storage interface"
 url {

--- a/opam/xapi-storage.opam.template
+++ b/opam/xapi-storage.opam.template
@@ -20,7 +20,7 @@ depends: [
   "ppx_deriving_rpc"
   "rpclib"
   "xmlm"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
 ]
 synopsis: "Code and documentation generator for the Xapi storage interface"
 url {

--- a/opam/xapi-tools.opam
+++ b/opam/xapi-tools.opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "3.15"}
   "astring"
   "base64"
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cstruct-unix"
   "fmt"
   "logs"

--- a/opam/xapi.opam
+++ b/opam/xapi.opam
@@ -19,7 +19,7 @@ depends: [
   "bos" {with-test}
   "cdrom"
   "clock" {= version}
-  "cmdliner"
+  "cmdliner" {< "2.0.0"}
   "cohttp"
   "conf-pam"
   "crowbar" {with-test}


### PR DESCRIPTION
Add version constraint such that we can install cmdliner 2.0.0 in xs-opam and migrate clients one by one.