### PR TITLE
xapi_vm_clone: Remove impossible, confusing case when dealing with suspend VDIs

### DIFF
--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -507,9 +507,6 @@ let clone ?snapshot_info_record ?(ignore_vdis = []) disk_op ~__context ~vm
                 let original = Db.VM.get_suspend_VDI ~__context ~self:vm in
                 if original = Ref.null || disk_op = Disk_op_snapshot then
                   Ref.null
-                else if disk_op = Disk_op_checkpoint && power_state = `Runnning
-                then
-                  original
                 else
                   clone_single_vdi rpc session_id disk_op ~__context original
                     driver_params


### PR DESCRIPTION
This case was impossible due to 2 reasons:
1. the polymorphic variant `Runnning used had a typo
2. the reference for the suspend VDI is only present when the VM is suspended, and otherwise is Ref.null. This means that when the VM is running, the code takes the case before this one.

I didn't see any code dealing with shared suspend images, so I'd rather avoid making the clone and deal with the shared situation.