### PR TITLE
CP-54274: Add user-specific error message for vnc connection limits

### DIFF
--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -149,6 +149,10 @@ let response_error_html ?(version = "1.1") s code message hdrs body =
   D.debug "Response %s" (Http.Response.to_string res) ;
   Unixext.really_write_string s (Http.Response.to_wire_string res)
 
+let response_custom_error ?req s error_code reason body =
+  let version = Option.map get_return_version req in
+  response_error_html ?version s error_code reason [] body
+
 let response_unauthorised ?req label s =
   let version = Option.map get_return_version req in
   let body =

--- a/ocaml/libs/http-lib/http_svr.mli
+++ b/ocaml/libs/http-lib/http_svr.mli
@@ -97,6 +97,9 @@ val response_unauthorised :
 
 val response_forbidden : ?req:Http.Request.t -> Unix.file_descr -> unit
 
+val response_custom_error :
+  ?req:Http.Request.t -> Unix.file_descr -> string -> string -> string -> unit
+
 val response_badrequest : ?req:Http.Request.t -> Unix.file_descr -> unit
 
 val response_internal_error :


### PR DESCRIPTION
Add user name and detailed reason in http response when console connection limits are exceeded.