### PR TITLE
CP-47867: Add observer uuid to span attributes

### DIFF
--- a/ocaml/tests/test_observer.ml
+++ b/ocaml/tests/test_observer.ml
@@ -98,6 +98,7 @@ module TracerProvider = struct
       ; "xs.host.name"
       ; "xs.host.uuid"
       ; "xs.observer.name"
+      ; "xs.observer.uuid"
       ; "service.name"
       ]
 
@@ -301,6 +302,7 @@ let verify_json_fields_and_values ~json =
         , `Assoc
             [
               ("xs.pool.uuid", `String _)
+            ; ("xs.observer.uuid", `String _)
             ; ("xs.observer.name", `String "test-observer")
             ; ("xs.host.uuid", `String _)
             ; ("xs.host.name", `String _)


### PR DESCRIPTION
Currently, if two observers have the same name (eg. job 3931663), then it is difficult to distinguish which generated a span. This commit adds the observer uuid to the default span attributes, and updates tests accordingly.