### PR TITLE
Supported image formats

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5004,6 +5004,17 @@ module SR = struct
 end
 
 module SM = struct
+  let formats =
+    [
+      ("raw", "Plain disk image")
+    ; ("vhd", "Virtual Hard Disk")
+    ; ("qcow2", "Qemu Copy-On-Write version 2")
+    ]
+
+  let formats_desc = formats |> List.map fst |> String.concat ", "
+
+  let image_format_type = Enum ("image_format_type", formats)
+
   (** XXX: just make this a field and be done with it. Cowardly refusing to change the schema for now. *)
   let get_driver_filename =
     call ~name:"get_driver_filename" ~in_oss_since:None
@@ -5124,6 +5135,10 @@ module SM = struct
             ~ty:(Set String) "required_cluster_stack"
             "The storage plugin requires that one of these cluster stacks is \
              configured and running."
+        ; field ~lifecycle:[] ~qualifier:DynamicRO
+            ~default_value:(Some (VSet [])) ~ty:(Set image_format_type)
+            "supported_image_formats"
+            (Printf.sprintf "Image formats supported by the SR: %s" formats_desc)
         ]
       ()
 end

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5460,7 +5460,11 @@ module VDI = struct
         [
           (Ref _vdi, "vdi", "The VDI to migrate")
         ; (Ref _sr, "sr", "The destination SR")
-        ; (Map (String, String), "options", "Other parameters")
+        ; ( Map (String, String)
+          , "options"
+          , "Extra parameters. Supports: \"dest-img-format\" (raw|vhd|qcow2) \
+             to specify the image format to use on the destination SR."
+          )
         ]
       ~result:(Ref _vdi, "The new reference of the migrated VDI.")
       ~doc:

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 903
+let schema_minor_vsn = 904
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -1715,6 +1715,13 @@ let migrate_send =
         ; param_release= inverness_release
         ; param_default= Some (VMap [])
         }
+      ; {
+          param_type= Map (Ref _vdi, String)
+        ; param_name= "vdi_format_map"
+        ; param_doc= "Map of source VDI to it's expected type on destination"
+        ; param_release= numbered_release "26.14.0-next"
+        ; param_default= Some (VMap [])
+        }
       ]
     ~result:
       (Ref _vm, "The reference of the newly created VM in the destination pool")

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "fe75fa03d7ce97f9e51426bfb9b078fe"
+let last_known_schema_hash = "13dfcc8ba21d122ba59de9c6c03c5236"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/quicktest/qt_filter.ml
+++ b/ocaml/quicktest/qt_filter.ml
@@ -409,3 +409,17 @@ let memtest_iso ?(prefix = "memtest") tcs =
      | (_, iso) :: _ ->
          Printf.eprintf "Choosing ISO %S\n%!" iso.API.vDI_name_label ;
          [(name, speed, test iso)]
+
+(* We only select the first two compatible SRs and generate a single
+   migration path. This test validates that migration works in this
+   environment, but does not attempt to exhaustively test all possible
+   (src, dst) combinations. *)
+let migration_path constraints =
+  for_each (fun (name, speed, test) ->
+      let srs = SR.list_srs constraints in
+      match srs with
+      | src :: dst :: _ ->
+          [(name, speed, test (src, dst))]
+      | _ ->
+          []
+  )

--- a/ocaml/quicktest/qt_filter.mli
+++ b/ocaml/quicktest/qt_filter.mli
@@ -92,3 +92,5 @@ val sr : SR.srs -> (Qt.sr_info -> 'b, 'b) filter
 val vm_template : string -> (API.ref_VM -> 'b, 'b) filter
 
 val memtest_iso : ?prefix:string -> (API.vDI_t -> 'a, 'a) filter
+
+val migration_path : SR.srs -> (Qt.sr_info * Qt.sr_info -> 'b, 'b) filter

--- a/ocaml/quicktest/quicktest.ml
+++ b/ocaml/quicktest/quicktest.ml
@@ -70,6 +70,7 @@ let () =
         ; ("Quicktest_vm_import_export", Quicktest_vm_import_export.tests ())
         ; ("Quicktest_vm_lifecycle", Quicktest_vm_lifecycle.tests ())
         ; ("Quicktest_vm_snapshot", Quicktest_vm_snapshot.tests ())
+        ; ("Quicktest_vm_migration", Quicktest_vm_migration.tests ())
         ; ( "Quicktest_vdi_ops_data_integrity"
           , Quicktest_vdi_ops_data_integrity.tests ()
           )

--- a/ocaml/quicktest/quicktest_vm_migration.ml
+++ b/ocaml/quicktest/quicktest_vm_migration.ml
@@ -1,0 +1,77 @@
+let local_vdi_migration rpc session_id vm_template
+    ((src_sr_info, dst_sr_info) : Qt.sr_info * Qt.sr_info) () =
+  let open Client in
+  Printf.printf "Testing migration from %s to %s\n"
+    (Client.SR.get_name_label ~rpc ~session_id ~self:src_sr_info.sr)
+    (Client.SR.get_name_label ~rpc ~session_id ~self:dst_sr_info.sr) ;
+
+  (* Create a VDI on src *)
+  let vdi =
+    Client.VDI.create ~rpc ~session_id ~name_label:"[QT] testing migration"
+      ~name_description:__FILE__ ~sR:src_sr_info.sr ~virtual_size:2097152L
+      ~_type:`user ~sharable:false ~read_only:false ~other_config:[]
+      ~xenstore_data:[] ~sm_config:[] ~tags:[]
+  in
+
+  (* Track which VDI must be destroyed at cleanup time. After migration, ownership
+     moves from the original VDI to the migrated one. *)
+  let final_vdi = ref vdi in
+
+  Xapi_stdext_pervasives.Pervasiveext.finally
+    (fun () ->
+      (* We can now create the VM and perform the migration *)
+      Qt.VM.with_new rpc session_id ~template:vm_template (fun vm ->
+          (* Attach the VDI *)
+          Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:vdi ~device:""
+            ~userdevice:"0" ~bootable:false ~mode:`RW ~_type:`Disk
+            ~unpluggable:true ~empty:false ~other_config:[]
+            ~qos_algorithm_type:"" ~qos_algorithm_params:[]
+            ~currently_attached:true
+          |> ignore ;
+
+          let migrated_vdi =
+            Client.VDI.pool_migrate ~rpc ~session_id ~vdi ~sr:dst_sr_info.sr
+              ~options:[("dest-img-format", "vhd")]
+          in
+
+          final_vdi := migrated_vdi ;
+
+          let new_sr = Client.VDI.get_SR ~rpc ~session_id ~self:migrated_vdi in
+          let actual = Client.SR.get_uuid ~rpc ~session_id ~self:new_sr in
+          let expected =
+            Client.SR.get_uuid ~rpc ~session_id ~self:dst_sr_info.sr
+          in
+
+          Alcotest.(check string)
+            "VDI migrated to destination SR" expected actual
+      )
+    )
+    (fun () ->
+      try Client.VDI.destroy ~rpc ~session_id ~self:!final_vdi with _ -> ()
+    )
+
+let tests () =
+  let smapiv1_mig =
+    Qt_filter.SR.(
+      all
+      |> not_iso
+      |> smapiv1
+      |> allowed_operations [`vdi_mirror; `vdi_snapshot]
+    )
+  in
+  let smapiv3_mig =
+    Qt_filter.SR.(all |> not_iso |> smapiv3 |> allowed_operations [`vdi_mirror])
+  in
+
+  let open Qt_filter in
+  [
+    [("SMAPIv1 migration test", `Slow, local_vdi_migration)]
+    |> conn
+    |> vm_template Qt.VM.Template.other
+    |> migration_path smapiv1_mig
+  ; [("SMAPIv3 migration test", `Slow, local_vdi_migration)]
+    |> conn
+    |> vm_template Qt.VM.Template.other
+    |> migration_path smapiv3_mig
+  ]
+  |> List.concat

--- a/ocaml/sdk-gen/component-test/jsonrpc-client/go/main_test.go
+++ b/ocaml/sdk-gen/component-test/jsonrpc-client/go/main_test.go
@@ -113,6 +113,17 @@ func ConvertMapToVgpuMap(input map[string]interface{}) (map[xenapi.VGPURef]xenap
 	return output, nil
 }
 
+func ConvertMapToVdiFormatMap(input map[string]interface{}) (map[xenapi.VDIRef]string, error) {
+	output := make(map[xenapi.VDIRef]string)
+	for key, value := range input {
+		strValue, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("non-string value found for key %s: %v", key, value)
+		}
+		output[xenapi.VDIRef(key)] = strValue
+	}
+	return output, nil
+}
 func TestMain(m *testing.M) {
 	flag.Parse()
 	exitVal := m.Run()

--- a/ocaml/sdk-gen/component-test/jsonrpc-client/go/vm_test.go
+++ b/ocaml/sdk-gen/component-test/jsonrpc-client/go/vm_test.go
@@ -269,13 +269,14 @@ func TestVMMigrateSend(t *testing.T) {
 
 	inputParams := spec.Key.Params["VM.migrate_send"]
 	const (
-		IndexVMRef   = 1
-		IndexDest    = 2
-		IndexLive    = 3
-		IndexVdiMap  = 4
-		IndexVifMap  = 5
-		IndexOptions = 6
-		IndexVgpuMap = 7
+		IndexVMRef        = 1
+		IndexDest         = 2
+		IndexLive         = 3
+		IndexVdiMap       = 4
+		IndexVifMap       = 5
+		IndexOptions      = 6
+		IndexVgpuMap      = 7
+		IndexVdiFormatMap = 8
 	)
 	vmRef, ok1 := inputParams[IndexVMRef].(string)
 	destOrg, ok2 := inputParams[IndexDest].(map[string]interface{})
@@ -284,7 +285,8 @@ func TestVMMigrateSend(t *testing.T) {
 	vifMapOrg, ok5 := inputParams[IndexVifMap].(map[string]interface{})
 	optionsOrg, ok6 := inputParams[IndexOptions].(map[string]interface{})
 	vgpuMapOrg, ok7 := inputParams[IndexVgpuMap].(map[string]interface{})
-	if !ok1 || !ok2 || !ok3 || !ok4 || !ok5 || !ok6 || !ok7 {
+	vdiFormatMapOrg, ok8 := inputParams[IndexVdiFormatMap].(map[string]interface{})
+	if !ok1 || !ok2 || !ok3 || !ok4 || !ok5 || !ok6 || !ok7 || !ok8 {
 		t.Log("Parameter get error from json file")
 		t.Fail()
 		return
@@ -319,8 +321,13 @@ func TestVMMigrateSend(t *testing.T) {
 		t.Fail()
 		return
 	}
-
-	result, err := xenapi.VM.MigrateSend(session, xenapi.VMRef(vmRef), dest, live, vdiMap, vifMap, options, vgpuMap)
+	vdiFormatMap, err := ConvertMapToVdiFormatMap(vdiFormatMapOrg)
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+		return
+	}
+	result, err := xenapi.VM.MigrateSend(session, xenapi.VMRef(vmRef), dest, live, vdiMap, vifMap, options, vgpuMap, vdiFormatMap)
 	if err != nil {
 		t.Log(err)
 		t.Fail()

--- a/ocaml/sdk-gen/component-test/spec/xapi-24/vm_migrate_send.json
+++ b/ocaml/sdk-gen/component-test/spec/xapi-24/vm_migrate_send.json
@@ -5,14 +5,15 @@
         ],
         "params": {
             "VM.migrate_send": [
-                "", 
-                "OpaqueRef:5vm2d621-7b62-f571-vm00-754341a973e5", 
-                {"name_label": "host1"}, 
-                true, 
-                {"OpaqueRef:5vdid621-7b62-f571-vdi8-754341a973e5": "OpaqueRef:5sr2d621-7b62-f571-s38r-754341a973e5"}, 
-                {"OpaqueRef:9vifb8a9-f6a3-69d2-vifb-7a7b7c81c49e": "OpaqueRef:9network-f6a3-69d2-netw-7a7b7c81c49e"}, 
-                {}, 
-                {"OpaqueRef:9vgpu8a9-f6a3-69d2-vgpu-7a7b7c81c49e": "OpaqueRef:9gpugroup-f6a3-69d2-grou-7a7b7c81c49e"}
+                "",
+                "OpaqueRef:5vm2d621-7b62-f571-vm00-754341a973e5",
+                {"name_label": "host1"},
+                true,
+                {"OpaqueRef:5vdid621-7b62-f571-vdi8-754341a973e5": "OpaqueRef:5sr2d621-7b62-f571-s38r-754341a973e5"},
+                {"OpaqueRef:9vifb8a9-f6a3-69d2-vifb-7a7b7c81c49e": "OpaqueRef:9network-f6a3-69d2-netw-7a7b7c81c49e"},
+                {},
+                {"OpaqueRef:9vgpu8a9-f6a3-69d2-vgpu-7a7b7c81c49e": "OpaqueRef:9gpugroup-f6a3-69d2-grou-7a7b7c81c49e"},
+                {"OpaqueRef:5vdid621-7b62-f571-vdi8-754341a973e5": "vhd"}
             ]
         },
         "expected_result": {

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -362,11 +362,12 @@ let make_sm ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ?(copyright = "") ?(version = "") ?(required_api_version = "")
     ?(capabilities = []) ?(features = default_sm_features)
     ?(host_pending_features = []) ?(configuration = []) ?(other_config = [])
-    ?(driver_filename = "/dev/null") ?(required_cluster_stack = []) () =
+    ?(driver_filename = "/dev/null") ?(required_cluster_stack = [])
+    ?(supported_image_formats = []) () =
   Db.SM.create ~__context ~ref ~uuid ~_type ~name_label ~name_description
     ~vendor ~copyright ~version ~required_api_version ~capabilities ~features
     ~host_pending_features ~configuration ~other_config ~driver_filename
-    ~required_cluster_stack ;
+    ~required_cluster_stack ~supported_image_formats ;
   ref
 
 let make_sr ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())

--- a/ocaml/tests/test_sm_features.ml
+++ b/ocaml/tests/test_sm_features.ml
@@ -249,6 +249,7 @@ module CreateSMObject = Generic.MakeStateful (struct
       ; features
       ; configuration= []
       ; required_cluster_stack= []
+      ; supported_image_formats= []
       ; smapi_version= SMAPIv2
       }
 

--- a/ocaml/tests/test_vdi_cbt.ml
+++ b/ocaml/tests/test_vdi_cbt.ml
@@ -30,6 +30,7 @@ let register_smapiv2_server (module S : Storage_interface.Server_impl) sr_ref =
       ; features= []
       ; configuration= []
       ; required_cluster_stack= []
+      ; supported_image_formats= []
       ; smapi_version= SMAPIv2
       }
   in

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1643,6 +1643,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
           ; "compress"
           ; "vif:"
           ; "vdi:"
+          ; "image-format:"
           ]
       ; help=
           "Migrate the selected VM(s). The parameter '--live' will migrate the \
@@ -1656,7 +1657,9 @@ let rec cmdtable_data : (string * cmd_spec) list =
            'copy=true' will enable the copy mode so that a stopped vm can be \
            copied, instead of migrating, to the destination pool. The vif and \
            vdi mapping parameters take the form 'vif:<source vif uuid>=<dest \
-           network uuid>' and 'vdi:<source vdi uuid>=<dest sr uuid>'. \
+           network uuid>' and 'vdi:<source vdi uuid>=<dest sr uuid>'. You can \
+           also specify the destination image format of the VDI using \
+           'image-format:<source vdi uuid>=<destination image format>'. \
            Unfortunately, destination uuids cannot be tab-completed."
       ; implementation= No_fd Cli_operations.vm_migrate
       ; flags= [Standard; Vm_selectors]
@@ -2499,10 +2502,10 @@ let rec cmdtable_data : (string * cmd_spec) list =
   ; ( "vdi-pool-migrate"
     , {
         reqd= ["uuid"; "sr-uuid"]
-      ; optn= []
+      ; optn= ["dest-img-format"]
       ; help=
-          "Migrate a VDI to a specified SR, while the VDI is attached to a \
-           running guest."
+          "Migrate a VDI to a specified SR, while it is attached to a running \
+           guest. You can specify the image format for the destination."
       ; implementation= No_fd Cli_operations.vdi_pool_migrate
       ; flags= []
       }

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -2161,8 +2161,11 @@ let vdi_pool_migrate printer rpc session_id params =
   and sr =
     Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "sr-uuid" params)
   and options =
-    []
-    (* no options implemented yet *)
+    match List.assoc_opt "dest-img-format" params with
+    | Some v ->
+        [("dest-img-format", v)]
+    | None ->
+        []
   in
   let newvdi = Client.VDI.pool_migrate ~rpc ~session_id ~vdi ~sr ~options in
   let newuuid = Client.VDI.get_uuid ~rpc ~session_id ~self:newvdi in
@@ -4709,6 +4712,7 @@ let vm_migrate_sxm_params =
   ; "remote-network"
   ; "vdi"
   ; "vgpu"
+  ; "image-format"
   ]
 
 let vm_migrate printer rpc session_id params =
@@ -5033,12 +5037,23 @@ let vm_migrate printer rpc session_id params =
         let token =
           remote Client.Host.migrate_receive ~host ~network ~options
         in
+        let vdi_format_map =
+          List.map
+            (fun (vdi_uuid, vdi_fmt) ->
+              let vdi =
+                Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:vdi_uuid
+              in
+              (vdi, vdi_fmt)
+            )
+            (read_map_params "image-format" params)
+        in
         let new_vm =
           do_vm_op ~include_control_vms:false ~include_template_vms:true printer
             rpc session_id
             (fun vm ->
               Client.VM.migrate_send ~rpc ~session_id ~vm:(vm.getref ())
-                ~dest:token ~live:true ~vdi_map ~vif_map ~options ~vgpu_map
+                ~dest:token ~live:true ~vdi_map ~vdi_format_map ~vif_map
+                ~options ~vgpu_map
             )
             params
             (["host"; "host-uuid"; "host-name"; "live"; "force"; "copy"]

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -3963,6 +3963,12 @@ let sm_record rpc session_id sm =
       ; make_field ~name:"required-cluster-stack"
           ~get:(fun () -> concat_with_comma (x ()).API.sM_required_cluster_stack)
           ()
+      ; make_field ~name:"supported-image-formats"
+          ~get:(fun () ->
+            map_and_concat Record_util.image_format_type_to_string
+              (x ()).API.sM_supported_image_formats
+          )
+          ()
       ]
   }
 

--- a/ocaml/xapi-idl/storage/storage_interface.ml
+++ b/ocaml/xapi-idl/storage/storage_interface.ml
@@ -476,6 +476,7 @@ type query_result = {
   ; features: string list
   ; configuration: (string * string) list
   ; required_cluster_stack: string list
+  ; supported_image_formats: string list
   ; smapi_version: smapi_version
 }
 [@@deriving rpcty]

--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
+++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
@@ -183,7 +183,7 @@ module DATA = struct
   let copy ctx ~dbg ~sr ~vdi ~vm ~url ~dest =
     Storage_interface.unimplemented __FUNCTION__
 
-  let mirror ctx ~dbg ~sr ~vdi ~vm ~dest =
+  let mirror ctx ~dbg ~sr ~vdi ~image_format ~vm ~dest =
     Storage_interface.unimplemented __FUNCTION__
 
   let stat ctx ~dbg ~sr ~vdi ~vm ~key =
@@ -198,18 +198,19 @@ module DATA = struct
   module MIRROR = struct
     type context = unit
 
-    let send_start ctx ~dbg ~task_id ~dp ~sr ~vdi ~mirror_vm ~mirror_id
-        ~local_vdi ~copy_vm ~live_vm ~url ~remote_mirror ~dest_sr ~verify_dest =
-      Storage_interface.unimplemented __FUNCTION__
-
-    let receive_start ctx ~dbg ~sr ~vdi_info ~id ~similar =
-      Storage_interface.unimplemented __FUNCTION__
-
-    let receive_start2 ctx ~dbg ~sr ~vdi_info ~id ~similar ~vm =
-      Storage_interface.unimplemented __FUNCTION__
-
-    let receive_start3 ctx ~dbg ~sr ~vdi_info ~mirror_id ~similar ~vm ~url
+    let send_start ctx ~dbg ~task_id ~dp ~sr ~vdi ~image_format ~mirror_vm
+        ~mirror_id ~local_vdi ~copy_vm ~live_vm ~url ~remote_mirror ~dest_sr
         ~verify_dest =
+      Storage_interface.unimplemented __FUNCTION__
+
+    let receive_start ctx ~dbg ~sr ~vdi_info ~id ~image_format ~similar =
+      Storage_interface.unimplemented __FUNCTION__
+
+    let receive_start2 ctx ~dbg ~sr ~vdi_info ~id ~image_format ~similar ~vm =
+      Storage_interface.unimplemented __FUNCTION__
+
+    let receive_start3 ctx ~dbg ~sr ~vdi_info ~mirror_id ~image_format ~similar
+        ~vm ~url ~verify_dest =
       Storage_interface.unimplemented __FUNCTION__
 
     let receive_finalize ctx ~dbg ~id =

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -934,6 +934,9 @@ module QueryImpl (M : META) = struct
         ; configuration= response.Xapi_storage.Plugin.configuration
         ; required_cluster_stack=
             response.Xapi_storage.Plugin.required_cluster_stack
+        ; supported_image_formats=
+            []
+            (* currently unused because no SMAPIv3 drivers support SXM migration *)
         ; smapi_version= SMAPIv3
         }
     in

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1811,7 +1811,10 @@ module DATAImpl (M : META) = struct
 
   let stat_impl dbg sr vdi vm key = wrap @@ stat dbg sr vdi vm key
 
-  let mirror dbg sr vdi' vm' remote =
+  let mirror dbg sr vdi' image_format vm' remote =
+    let* () =
+      info (fun m -> m "image_format (%s) is not currently used" image_format)
+    in
     let vdi = Storage_interface.Vdi.string_of vdi' in
     let domain = Storage_interface.Vm.string_of vm' in
     Attached_SRs.find sr >>>= fun sr ->
@@ -1835,7 +1838,8 @@ module DATAImpl (M : META) = struct
     | MirrorV1 v ->
         return (Storage_interface.Mirror.MirrorV1 v)
 
-  let mirror_impl dbg sr vdi vm remote = wrap @@ mirror dbg sr vdi vm remote
+  let mirror_impl dbg sr vdi image_format vm remote =
+    wrap @@ mirror dbg sr vdi image_format vm remote
 
   let data_import_activate_impl dbg _dp sr vdi' vm' =
     wrap

--- a/ocaml/xapi-storage-script/python-self-test.t
+++ b/ocaml/xapi-storage-script/python-self-test.t
@@ -6,7 +6,7 @@ pids and uuids
 
   $ export PYTHONPATH=../xapi-storage/python/; ./main.exe --root=$PWD/test --self-test-only=true 2>&1 >/dev/null | sed -E 's/\[[0-9]+\]/[PID]/g' | sed -E 's/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/UUID/g'
   [INFO] {"method":"Plugin.query","params":[{"dbg":"debug"}],"id":2}
-  [INFO] $TESTCASE_ROOT/test/volume/org.xen.xapi.storage.dummyv5/Plugin.Query[PID] succeeded: {"plugin": "dummy", "name": "dummy SR plugin", "description": "Dummy v5 SR for unit tests.", "vendor": "Citrix Systems Inc", "copyright": "(C) 2018 Citrix Inc", "version": "1.0", "required_api_version": "5.0", "features": ["SR_ATTACH", "SR_DETACH", "SR_CREATE", "SR_PROBE", "VDI_CREATE", "VDI_DESTROY"], "configuration": {}, "required_cluster_stack": []}
+  [INFO] $TESTCASE_ROOT/test/volume/org.xen.xapi.storage.dummyv5/Plugin.Query[PID] succeeded: {"plugin": "dummy", "name": "dummy SR plugin", "description": "Dummy v5 SR for unit tests.", "vendor": "Citrix Systems Inc", "copyright": "(C) 2018 Citrix Inc", "version": "1.0", "required_api_version": "5.0", "features": ["SR_ATTACH", "SR_DETACH", "SR_CREATE", "SR_PROBE", "VDI_CREATE", "VDI_DESTROY"], "configuration": {}, "required_cluster_stack": [], "supported_image_formats": []}
   
   [INFO] {"method":"Plugin.diagnostics","params":[{"dbg":"debug"}],"id":4}
   [INFO] $TESTCASE_ROOT/test/volume/org.xen.xapi.storage.dummyv5/Plugin.diagnostics[PID] succeeded: "Dummy diagnostics"

--- a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/plugin.py
+++ b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/plugin.py
@@ -31,7 +31,8 @@ class Implementation(xapi.storage.api.v5.plugin.Plugin_skeleton):
                     "VDI_CREATE",
                     "VDI_DESTROY"],
                 "configuration": {},
-                "required_cluster_stack": []}
+                "required_cluster_stack": [],
+                "supported_image_formats": []}
 
 
 if __name__ == "__main__":

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2661,16 +2661,16 @@ functor
           ~vgpu_map ~options
 
       let migrate_send ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options
-          ~vgpu_map =
+          ~vgpu_map ~vdi_format_map =
         info "VM.migrate_send: VM = '%s'" (vm_uuid ~__context vm) ;
         let source_host = Db.VM.get_resident_on ~__context ~self:vm in
         let local_fn =
-          Local.VM.migrate_send ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map
-            ~options
+          Local.VM.migrate_send ~vm ~dest ~live ~vdi_map ~vdi_format_map
+            ~vif_map ~vgpu_map ~options
         in
         let remote_fn =
-          Client.VM.migrate_send ~vm ~dest ~live ~vdi_map ~vif_map ~options
-            ~vgpu_map
+          Client.VM.migrate_send ~vm ~dest ~live ~vdi_map ~vdi_format_map
+            ~vif_map ~options ~vgpu_map
         in
         let host = List.assoc Xapi_vm_migrate._host dest |> Ref.of_string in
         let cross_pool = not (Db.is_valid_ref __context host) in
@@ -2692,7 +2692,8 @@ functor
                 Helpers.try_internal_async ~__context API.ref_VM_of_rpc
                   (fun () ->
                     Client.InternalAsync.VM.migrate_send ~rpc ~session_id ~vm
-                      ~dest ~live ~vdi_map ~vif_map ~options ~vgpu_map
+                      ~dest ~live ~vdi_map ~vdi_format_map ~vif_map ~options
+                      ~vgpu_map
                   )
                   (fun () -> remote_fn ~session_id ~rpc)
             )

--- a/ocaml/xapi/sm_exec.ml
+++ b/ocaml/xapi/sm_exec.ml
@@ -556,6 +556,7 @@ let parse_sr_get_driver_info driver (xml : Xml.xml) =
   ; sr_driver_configuration= configuration
   ; sr_driver_text_features= text_features
   ; sr_driver_required_cluster_stack= []
+  ; sr_driver_supported_image_formats= []
   ; sr_smapi_version= SMAPIv1
   }
 

--- a/ocaml/xapi/sm_exec.ml
+++ b/ocaml/xapi/sm_exec.ml
@@ -544,6 +544,13 @@ let parse_sr_get_driver_info driver (xml : Xml.xml) =
       )
       (XMLRPC.From.array XMLRPC.From.structure (safe_assoc "configuration" info))
   in
+  let image_formats =
+    match List.assoc_opt "supported_image_formats" info with
+    | None ->
+        []
+    | Some lst ->
+        XMLRPC.From.array XMLRPC.From.string lst
+  in
   {
     sr_driver_filename= driver
   ; sr_driver_name= name
@@ -556,7 +563,7 @@ let parse_sr_get_driver_info driver (xml : Xml.xml) =
   ; sr_driver_configuration= configuration
   ; sr_driver_text_features= text_features
   ; sr_driver_required_cluster_stack= []
-  ; sr_driver_supported_image_formats= []
+  ; sr_driver_supported_image_formats= image_formats
   ; sr_smapi_version= SMAPIv1
   }
 

--- a/ocaml/xapi/smint.ml
+++ b/ocaml/xapi/smint.ml
@@ -192,6 +192,7 @@ type sr_driver_info = {
   ; sr_driver_text_features: string list
   ; sr_driver_configuration: (string * string) list
   ; sr_driver_required_cluster_stack: string list
+  ; sr_driver_supported_image_formats: string list
   ; sr_smapi_version: Storage_interface.smapi_version
 }
 
@@ -207,6 +208,7 @@ let query_result_of_sr_driver_info x =
   ; features= x.sr_driver_text_features
   ; configuration= x.sr_driver_configuration
   ; required_cluster_stack= x.sr_driver_required_cluster_stack
+  ; supported_image_formats= x.sr_driver_supported_image_formats
   ; smapi_version= x.sr_smapi_version
   }
 

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -82,6 +82,7 @@ module Mux = struct
       ; features= []
       ; configuration= []
       ; required_cluster_stack= []
+      ; supported_image_formats= []
       ; smapi_version= SMAPIv2
       }
 

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -820,14 +820,15 @@ module Mux = struct
     let copy () ~dbg =
       with_dbg ~name:"DATA.copy" ~dbg @@ fun dbg -> Storage_migrate.copy ~dbg
 
-    let mirror () ~dbg ~sr ~vdi ~vm ~dest =
+    let mirror () ~dbg ~sr ~vdi ~image_format ~vm ~dest =
       with_dbg ~name:"DATA.mirror" ~dbg @@ fun di ->
-      info "%s dbg:%s sr: %s vdi: %s vm:%s  remote:%s" __FUNCTION__ dbg
-        (s_of_sr sr) (s_of_vdi vdi) (s_of_vm vm) dest ;
+      info "%s dbg:%s sr: %s vdi: %s image_format: %s vm:%s  remote:%s"
+        __FUNCTION__ dbg (s_of_sr sr) (s_of_vdi vdi) image_format (s_of_vm vm)
+        dest ;
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
-      C.DATA.mirror (Debug_info.to_string di) sr vdi vm dest
+      C.DATA.mirror (Debug_info.to_string di) sr vdi image_format vm dest
 
     let stat () ~dbg ~sr ~vdi ~vm ~key =
       with_dbg ~name:"DATA.stat" ~dbg @@ fun di ->
@@ -859,41 +860,45 @@ module Mux = struct
     module MIRROR = struct
       type context = unit
 
-      let send_start _ctx ~dbg:_ ~task_id:_ ~dp:_ ~sr:_ ~vdi:_ ~mirror_vm:_
-          ~mirror_id:_ ~local_vdi:_ ~copy_vm:_ ~live_vm:_ ~url:_
+      let send_start _ctx ~dbg:_ ~task_id:_ ~dp:_ ~sr:_ ~vdi:_ ~image_format:_
+          ~mirror_vm:_ ~mirror_id:_ ~local_vdi:_ ~copy_vm:_ ~live_vm:_ ~url:_
           ~remote_mirror:_ ~dest_sr:_ ~verify_dest:_ =
         Storage_interface.unimplemented
           __FUNCTION__ (* see storage_smapi{v1,v3}_migrate.ml *)
 
-      let receive_start () ~dbg ~sr ~vdi_info ~id ~similar =
+      let receive_start () ~dbg ~sr ~vdi_info ~id ~image_format ~similar =
         with_dbg ~name:"DATA.MIRROR.receive_start" ~dbg @@ fun _di ->
-        info "%s dbg: %s sr: %s vdi_info: %s mirror_id: %s similar: %s"
+        info
+          "%s dbg: %s sr: %s vdi_info: %s mirror_id: %s image_format: %s \
+           similar: %s"
           __FUNCTION__ dbg (s_of_sr sr)
           (string_of_vdi_info vdi_info)
-          id
+          id image_format
           (String.concat ";" similar) ;
         (* This goes straight to storage_smapiv1_migrate for backwards compatability
            reasons, new code should not call receive_start any more *)
         Storage_smapiv1_migrate.MIRROR.receive_start () ~dbg ~sr ~vdi_info ~id
-          ~similar
+          ~image_format ~similar
 
-      let receive_start2 () ~dbg ~sr ~vdi_info ~id ~similar ~vm =
+      let receive_start2 () ~dbg ~sr ~vdi_info ~id ~image_format ~similar ~vm =
         with_dbg ~name:"DATA.MIRROR.receive_start2" ~dbg @@ fun _di ->
-        info "%s dbg: %s sr: %s vdi_info: %s mirror_id: %s similar: %s vm: %s"
+        info
+          "%s dbg: %s sr: %s vdi_info: %s mirror_id: %s image_format: %s \
+           similar: %s vm: %s"
           __FUNCTION__ dbg (s_of_sr sr)
           (string_of_vdi_info vdi_info)
-          id
+          id image_format
           (String.concat ";" similar)
           (s_of_vm vm) ;
         info "%s dbg:%s" __FUNCTION__ dbg ;
         (* This goes straight to storage_smapiv1_migrate for backwards compatability
            reasons, new code should not call receive_start any more *)
         Storage_smapiv1_migrate.MIRROR.receive_start2 () ~dbg ~sr ~vdi_info ~id
-          ~similar ~vm
+          ~image_format ~similar ~vm
 
       (** see storage_smapiv{1,3}_migrate.receive_start3 *)
-      let receive_start3 () ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_ ~similar:_
-          ~vm:_ =
+      let receive_start3 () ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_
+          ~image_format:_ ~similar:_ ~vm:_ =
         Storage_interface.unimplemented __FUNCTION__
 
       let receive_finalize () ~dbg ~id =

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -125,6 +125,7 @@ module SMAPIv1 : Server_impl = struct
       ; features= []
       ; configuration= []
       ; required_cluster_stack= []
+      ; supported_image_formats= []
       ; smapi_version= SMAPIv1
       }
 

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -1133,7 +1133,8 @@ module SMAPIv1 : Server_impl = struct
     let copy _context ~dbg:_ ~sr:_ ~vdi:_ ~vm:_ ~url:_ ~dest:_ ~verify_dest:_ =
       assert false
 
-    let mirror _context ~dbg:_ ~sr:_ ~vdi:_ ~vm:_ ~dest:_ = assert false
+    let mirror _context ~dbg:_ ~sr:_ ~vdi:_ ~image_format:_ ~vm:_ ~dest:_ =
+      assert false
 
     let stat _context ~dbg:_ ~sr:_ ~vdi:_ ~vm:_ ~key:_ = assert false
 
@@ -1144,20 +1145,21 @@ module SMAPIv1 : Server_impl = struct
     module MIRROR = struct
       type context = unit
 
-      let send_start _ctx ~dbg:_ ~task_id:_ ~dp:_ ~sr:_ ~vdi:_ ~mirror_vm:_
-          ~mirror_id:_ ~local_vdi:_ ~copy_vm:_ ~live_vm:_ ~url:_
+      let send_start _ctx ~dbg:_ ~task_id:_ ~dp:_ ~sr:_ ~vdi:_ ~image_format:_
+          ~mirror_vm:_ ~mirror_id:_ ~local_vdi:_ ~copy_vm:_ ~live_vm:_ ~url:_
           ~remote_mirror:_ ~dest_sr:_ ~verify_dest:_ =
         assert false
 
-      let receive_start _context ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~similar:_ =
+      let receive_start _context ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~image_format:_
+          ~similar:_ =
         assert false
 
-      let receive_start2 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~similar:_
-          ~vm:_ =
+      let receive_start2 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~image_format:_
+          ~similar:_ ~vm:_ =
         assert false
 
       let receive_start3 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_
-          ~similar:_ ~vm:_ ~url:_ ~verify_dest:_ =
+          ~image_format:_ ~similar:_ ~vm:_ ~url:_ ~verify_dest:_ =
         assert false
 
       let receive_finalize _context ~dbg:_ ~id:_ = assert false

--- a/ocaml/xapi/storage_smapiv1_migrate.mli
+++ b/ocaml/xapi/storage_smapiv1_migrate.mli
@@ -70,6 +70,7 @@ val mirror_snapshot :
   -> dp:string
   -> mirror_id:string
   -> local_vdi:Storage_interface.vdi_info
+  -> image_format:string
   -> Storage_interface.vdi_info
 
 val mirror_checker : string -> Tapctl.tapdev -> unit

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -1156,7 +1156,7 @@ functor
           (s_of_vdi vdi) url (s_of_sr dest) ;
         Impl.DATA.copy context ~dbg ~sr ~vdi ~vm ~url ~dest
 
-      let mirror _context ~dbg:_ ~sr:_ ~vdi:_ ~vm:_ ~dest:_ =
+      let mirror _context ~dbg:_ ~sr:_ ~vdi:_ ~image_format:_ ~vm:_ ~dest:_ =
         Storage_interface.unimplemented __FUNCTION__
 
       let stat _context ~dbg:_ ~sr:_ ~vdi:_ ~vm:_ ~key:_ =
@@ -1206,28 +1206,34 @@ functor
       module MIRROR = struct
         type context = unit
 
-        let send_start _ctx ~dbg:_ ~task_id:_ ~dp:_ ~sr:_ ~vdi:_ ~mirror_vm:_
-            ~mirror_id:_ ~local_vdi:_ ~copy_vm:_ ~live_vm:_ ~url:_
+        let send_start _ctx ~dbg:_ ~task_id:_ ~dp:_ ~sr:_ ~vdi:_ ~image_format:_
+            ~mirror_vm:_ ~mirror_id:_ ~local_vdi:_ ~copy_vm:_ ~live_vm:_ ~url:_
             ~remote_mirror:_ ~dest_sr:_ ~verify_dest:_ =
           Storage_interface.unimplemented __FUNCTION__
 
-        let receive_start context ~dbg ~sr ~vdi_info ~id ~similar =
-          info "DATA.MIRROR.receive_start dbg:%s sr:%s id:%s similar:[%s]" dbg
-            (s_of_sr sr) id
-            (String.concat "," similar) ;
-          Impl.DATA.MIRROR.receive_start context ~dbg ~sr ~vdi_info ~id ~similar
-
-        let receive_start2 context ~dbg ~sr ~vdi_info ~id ~similar ~vm =
+        let receive_start context ~dbg ~sr ~vdi_info ~id ~image_format ~similar
+            =
           info
-            "DATA.MIRROR.receive_start2 dbg:%s sr:%s id:%s similar:[%s] vm:%s"
-            dbg (s_of_sr sr) id
+            "DATA.MIRROR.receive_start dbg:%s sr:%s id:%s image_format:%s \
+             similar:[%s]"
+            dbg (s_of_sr sr) id image_format
+            (String.concat "," similar) ;
+          Impl.DATA.MIRROR.receive_start context ~dbg ~sr ~vdi_info ~id
+            ~image_format ~similar
+
+        let receive_start2 context ~dbg ~sr ~vdi_info ~id ~image_format ~similar
+            ~vm =
+          info
+            "DATA.MIRROR.receive_start2 dbg:%s sr:%s id:%s image_format:%s \
+             similar:[%s] vm:%s"
+            dbg (s_of_sr sr) id image_format
             (String.concat "," similar)
             (s_of_vm vm) ;
           Impl.DATA.MIRROR.receive_start2 context ~dbg ~sr ~vdi_info ~id
-            ~similar ~vm
+            ~image_format ~similar ~vm
 
         let receive_start3 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_
-            ~similar:_ ~vm:_ =
+            ~image_format:_ ~similar:_ ~vm:_ =
           (* See Storage_smapiv1_migrate.receive_start3 *)
           Storage_interface.unimplemented __FUNCTION__
 

--- a/ocaml/xapi/xapi_services.ml
+++ b/ocaml/xapi/xapi_services.ml
@@ -255,6 +255,7 @@ let get_handler (req : Http.Request.t) s _ =
             ; features= List.map (fun x -> path [_services; x]) [_SM]
             ; configuration= []
             ; required_cluster_stack= []
+            ; supported_image_formats= []
             ; smapi_version= SMAPIv2
             }
           in

--- a/ocaml/xapi/xapi_sm.ml
+++ b/ocaml/xapi/xapi_sm.ml
@@ -45,6 +45,10 @@ let create_from_query_result ~__context q =
       ~host_pending_features:[] ~configuration:q.configuration ~other_config:[]
       ~driver_filename:(Sm_exec.cmd_name q.driver)
       ~required_cluster_stack:q.required_cluster_stack
+      ~supported_image_formats:
+        (List.map Record_util.image_format_type_of_string
+           q.supported_image_formats
+        )
   )
 
 let find_pending_features existing_features features =
@@ -125,6 +129,10 @@ let update_from_query_result ~__context (self, r) q_result =
       |> addto_pending_hosts_features ~__context self
       |> valid_hosts_pending_features ~__context
     in
+    let supported_image_formats =
+      List.map Record_util.image_format_type_of_string
+        q_result.supported_image_formats
+    in
     remove_valid_features_from_pending ~__context ~self new_features ;
     let features = retained_features @ new_features in
     List.iter
@@ -155,7 +163,10 @@ let update_from_query_result ~__context (self, r) q_result =
     if r.API.sM_configuration <> q_result.configuration then
       Db.SM.set_configuration ~__context ~self ~value:q_result.configuration ;
     if r.API.sM_driver_filename <> driver_filename then
-      Db.SM.set_driver_filename ~__context ~self ~value:driver_filename
+      Db.SM.set_driver_filename ~__context ~self ~value:driver_filename ;
+    if r.API.sM_supported_image_formats <> supported_image_formats then
+      Db.SM.set_supported_image_formats ~__context ~self
+        ~value:supported_image_formats
   )
 
 let is_v1 x = version_of_string x < [2; 0]

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -218,6 +218,93 @@ let assert_sr_support_operations ~__context ~vdi_map ~remote ~local_ops
       op_supported_on_dest_sr sr remote_ops sm_record remote
   )
 
+(** [check_supported_image_format] checks that the [image_format] string
+    corresponds to valid image format type listed in [sm_formats].
+    If [sm_formats] is an empty list or [image_format] is an empty string
+    there function does nothing. Otherwise, if [image_format] is not found
+    in [sm_formats], an exception is raised. *)
+let check_supported_image_format ~image_format ~sm_formats ~sr_uuid =
+  if image_format = "" || sm_formats = [] then
+    ()
+  else
+    let ty = Record_util.image_format_type_of_string image_format in
+    if not (List.mem ty sm_formats) then
+      let msg =
+        Printf.sprintf "Image format %s is not supported by %s" image_format
+          sr_uuid
+      in
+      raise Api_errors.(Server_error (vdi_incompatible_type, [msg]))
+
+(** [assert_vdi_format_is_supported] checks that all VDIs in [vdi_map] are included in the list of
+    supported image format of their corresponding SM. The type of the VDI is found in [vdi_format_map].
+    - If no VDI type is specified we just returned so no error is raised.
+    - If an SM reports an empty list of supported formats, we cannot verify compatibility and no error
+      is raised. So if the format is not actually supported, the failure will be detected later when
+      attempting to create the VDI using that image format. *)
+let assert_vdi_format_is_supported ~__context ~remote_opt ~vdi_map
+    ~vdi_format_map =
+  let get_uuid_sr sr_ref =
+    match remote_opt with
+    | None ->
+        Db.SR.get_uuid ~__context ~self:sr_ref
+    | Some r ->
+        XenAPI.SR.get_uuid ~rpc:r.rpc ~session_id:r.session ~self:sr_ref
+  in
+  let get_sr_type sr_ref =
+    match remote_opt with
+    | None ->
+        Db.SR.get_type ~__context ~self:sr_ref
+    | Some r ->
+        XenAPI.SR.get_type ~rpc:r.rpc ~session_id:r.session ~self:sr_ref
+  in
+  let get_sm_refs sr_type =
+    match remote_opt with
+    | None ->
+        Db.SM.get_refs_where ~__context
+          ~expr:(Eq (Field "type", Literal sr_type))
+    | Some r ->
+        XenAPI.SM.get_all_where ~rpc:r.rpc ~session_id:r.session
+          ~expr:(Printf.sprintf {|(field "type"="%s")|} sr_type)
+  in
+  let get_sm_formats sm_ref =
+    match remote_opt with
+    | None ->
+        Db.SM.get_supported_image_formats ~__context ~self:sm_ref
+    | Some r ->
+        XenAPI.SM.get_supported_image_formats ~rpc:r.rpc ~session_id:r.session
+          ~self:sm_ref
+  in
+  List.iter
+    (fun (vdi_ref, sr_ref) ->
+      let vdi_uuid = Db.VDI.get_uuid ~__context ~self:vdi_ref in
+      let sr_uuid = get_uuid_sr sr_ref in
+      match List.assoc_opt vdi_ref vdi_format_map with
+      | None ->
+          debug "read vdi %s, sr %s. No type specified." vdi_uuid sr_uuid
+      | Some image_format -> (
+          (* To get the supported image format from SM we need the SR type because both have
+             the same type. *)
+          let sr_type = get_sr_type sr_ref in
+          let sm_refs = get_sm_refs sr_type in
+          (* We expect that one sr_type matches one sm_ref *)
+          match sm_refs with
+          | [sm_ref] ->
+              debug "read vdi %s, sr %s. Type is %s" vdi_uuid sr_uuid
+                image_format ;
+              let sm_formats = get_sm_formats sm_ref in
+              check_supported_image_format ~image_format ~sm_formats ~sr_uuid
+          | _ ->
+              let msg =
+                Printf.sprintf
+                  "Found more than one SM ref (%d) when checking type (%s) of \
+                   VDI."
+                  (List.length sm_refs) image_format
+              in
+              raise Api_errors.(Server_error (vdi_incompatible_type, [msg]))
+        )
+    )
+    vdi_map
+
 (** Check that none of the VDIs that are mapped to a different SR have CBT
     or encryption enabled. This function must be called with the complete
     [vdi_map], which contains all the VDIs of the VM.
@@ -240,6 +327,12 @@ let assert_can_migrate_vdis ~__context ~vdi_map =
       )
     )
     vdi_map
+
+(** [get_vdi_type vdi_ref vdi_format_map] returns the vdi type found in the
+    [vdi_format_map] mapping for a given [vdi_ref]. If no type is found None
+    is returned. *)
+let get_vdi_type ~vdi_ref ~vdi_format_map =
+  List.assoc_opt vdi_ref vdi_format_map
 
 let assert_licensed_storage_motion ~__context =
   Pool_features.assert_enabled ~__context ~f:Features.Storage_motion
@@ -727,25 +820,22 @@ let update_snapshot_info ~__context ~dbg ~url ~vdi_map ~snapshots_map
     debug "Remote SMAPI doesn't implement update_snapshot_info_src - ignoring"
 
 type vdi_mirror = {
-    vdi: [`VDI] API.Ref.t
-  ; (* The API reference of the local VDI *)
-    dp: string
-  ; (* The datapath the VDI will be using if the VM is running *)
-    location: Storage_interface.Vdi.t
-  ; (* The location of the VDI in the current SR *)
-    sr: Storage_interface.Sr.t
-  ; (* The VDI's current SR uuid *)
-    xenops_locator: string
-  ; (* The 'locator' xenops uses to refer to the VDI on the current host *)
-    size: Int64.t
-  ; (* Size of the VDI *)
-    snapshot_of: [`VDI] API.Ref.t
-  ; (* API's snapshot_of reference *)
-    do_mirror: bool (* Whether we should mirror or just copy the VDI *)
+    vdi: [`VDI] API.Ref.t  (** The API reference of the local VDI *)
+  ; format: string
+        (** The image format of the VDI that must be used during its creation *)
+  ; dp: string  (** The datapath the VDI will be using if the VM is running *)
+  ; location: Storage_interface.Vdi.t
+        (** The location of the VDI in the current SR *)
+  ; sr: Storage_interface.Sr.t  (** The VDI's current SR uuid *)
+  ; xenops_locator: string
+        (** The 'locator' xenops uses to refer to the VDI on the current host *)
+  ; size: Int64.t  (** Size of the VDI *)
+  ; snapshot_of: [`VDI] API.Ref.t  (** API's snapshot_of reference *)
+  ; do_mirror: bool  (** Whether we should mirror or just copy the VDI *)
   ; mirror_vm: Vm.t
-        (* The domain slice to which SMAPI calls should be made when mirroring this vdi *)
+        (** The domain slice to which SMAPI calls should be made when mirroring this vdi *)
   ; copy_vm: Vm.t
-        (* The domain slice to which SMAPI calls should be made when copying this vdi *)
+        (** The domain slice to which SMAPI calls should be made when copying this vdi *)
 }
 
 (* For VMs (not snapshots) xenopsd does not allow remapping, so we
@@ -825,8 +915,11 @@ let get_vdi_mirror __context vm vdi do_mirror =
     |> ( ^ ) "MIR"
     |> Storage_interface.Vm.of_string
   in
+  (* format of VDI will be updated in migrate_send *)
+  let format = "" in
   {
     vdi
+  ; format
   ; dp
   ; location
   ; sr
@@ -1055,8 +1148,9 @@ let vdi_copy_fun __context dbg vdi_map remote is_intra_pool remote_vdis so_far
         (* Layering violation!! *)
         ignore (Storage_access.register_mirror __context id) ;
         Storage_migrate.start ~dbg ~sr:vconf.sr ~vdi:vconf.location ~dp:new_dp
-          ~mirror_vm:vconf.mirror_vm ~copy_vm:vconf.copy_vm ~live_vm
-          ~url:remote.sm_url ~dest:dest_sr ~verify_dest:is_intra_pool
+          ~image_format:vconf.format ~mirror_vm:vconf.mirror_vm
+          ~copy_vm:vconf.copy_vm ~live_vm ~url:remote.sm_url ~dest:dest_sr
+          ~verify_dest:is_intra_pool
     in
     let mapfn x =
       let total = Int64.to_float total_size in
@@ -1224,8 +1318,8 @@ let check_vdi_map ~__context vms_vdis vdi_map =
       vms_vdis
   )
 
-let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
-    ~options =
+let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vdi_format_map ~vif_map
+    ~vgpu_map ~options =
   SMPERF.debug "vm.migrate_send called vm:%s"
     (Db.VM.get_uuid ~__context ~self:vm) ;
   let open Xapi_xenops in
@@ -1406,10 +1500,28 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
       extra_vdis
   in
   let vdi_map = vdi_map @ extra_vdi_map in
-  let all_vdis = vms_vdis @ extra_vdis in
+  let all_vdis =
+    List.map
+      (fun vm ->
+        match get_vdi_type ~vdi_ref:vm.vdi ~vdi_format_map with
+        | None ->
+            vm
+        | Some vdi_ty ->
+            {vm with format= vdi_ty}
+      )
+      vms_vdis
+    @ extra_vdis
+  in
   (* This is a good time to check our VDIs, because the vdi_map should be
      complete at this point; it should include all the VDIs in the all_vdis list. *)
   assert_can_migrate_vdis ~__context ~vdi_map ;
+  let remote_opt =
+    if is_same_host then
+      None
+    else
+      Some remote
+  in
+  assert_vdi_format_is_supported ~__context ~remote_opt ~vdi_map ~vdi_format_map ;
   let dbg = Context.string_of_task_and_tracing __context in
   let open Xapi_xenops_queue in
   let queue_name = queue_of_vm ~__context ~self:vm in
@@ -2005,13 +2117,16 @@ let assert_can_migrate_sender ~__context ~vm ~dest ~live:_ ~vdi_map:_ ~vif_map:_
       ~vm ~vgpu_map ~host:remote.dest_host ?remote:remote_for_migration_type ()
 
 let migrate_send ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options ~vgpu_map
-    =
+    ~vdi_format_map =
   with_migrate (fun () ->
-      migrate_send' ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map
-        ~options
+      migrate_send' ~__context ~vm ~dest ~live ~vdi_map ~vdi_format_map ~vif_map
+        ~vgpu_map ~options
   )
 
 let vdi_pool_migrate ~__context ~vdi ~sr ~options =
+  let dest_img_format =
+    List.assoc_opt "dest-img-format" options |> Option.value ~default:""
+  in
   if Db.VDI.get_type ~__context ~self:vdi = `cbt_metadata then (
     error "VDI.pool_migrate: the specified VDI has type cbt_metadata (at %s)"
       __LOC__ ;
@@ -2102,8 +2217,9 @@ let vdi_pool_migrate ~__context ~vdi ~sr ~options =
       assert_can_migrate_sender ~__context ~vm ~dest ~live:true ~vdi_map
         ~vif_map:[] ~vgpu_map:[] ~options:[] ;
       ignore
-        (migrate_send ~__context ~vm ~dest ~live:true ~vdi_map ~vif_map:[]
-           ~vgpu_map:[] ~options:[]
+        (migrate_send ~__context ~vm ~dest ~live:true ~vdi_map
+           ~vdi_format_map:[(vdi, dest_img_format)]
+           ~vif_map:[] ~vgpu_map:[] ~options:[]
         )
   ) ;
   Db.VBD.get_VDI ~__context ~self:vbd


### PR DESCRIPTION
This PR implements the supported image format mechanism proposed in this design document: https://xapi-project.github.io/new-docs/design/sm-supported-image-formats/index.html

- It adds supported image formats to the SM object if the SM plugin specifies it in its `DRIVER_INFO`.
- When the information is available, you can select which image format to use as the destination during a VM or VDI migration.

This feature is particularly useful because XCP-ng is adding support for the Qcow2 format in SMAPI to allow _VDIs_ larger than 2TB. So in the near future (we're currently releasing the beta version), some _SRs_ will support multiple formats such as VHD, RAW, and Qcow2. 

With this patch, it becomes possible to migrate a VM with VHD disks on one SR to another SR with Qcow2 disks.  If an SM plugin does not provide information about the supported image formats, the behavior remains unchanged.

For more details see the [specification](https://xapi-project.github.io/new-docs/design/sm-supported-image-formats/index.html).