### PR TITLE
CA-418960: VM with vTPM Delete doesn't remove the snapshot

### DIFF
--- a/ocaml/xapi/xapi_vtpm.ml
+++ b/ocaml/xapi/xapi_vtpm.ml
@@ -85,8 +85,8 @@ let copy ~__context ~vM ref =
 
 let destroy ~__context ~self =
   let vm = Db.VTPM.get_VM ~__context ~self in
-  Xapi_vm_lifecycle.assert_initial_power_state_is ~__context ~self:vm
-    ~expected:`Halted ;
+  Xapi_vm_lifecycle.assert_initial_power_state_in ~__context ~self:vm
+    ~allowed:[`Halted; `Suspended] ;
   let secret = Db.VTPM.get_contents ~__context ~self in
   Db.Secret.destroy ~__context ~self:secret ;
   Db.VTPM.destroy ~__context ~self


### PR DESCRIPTION
The snapshot of VM with vTPM are VM object in `Suspended state, During destory of the VM object, it would expect the VM in state of `Halted, thus, cuase the snapshot can not be destoryed.

Instead of expect the VM in `Halted state, the VM is espected in not alive state, e.g: `Suspended or `Halted