### PR TITLE
CA-418759: Failed to start attach-static-vdis

### DIFF
--- a/ocaml/xapi/static_vdis.ml
+++ b/ocaml/xapi/static_vdis.ml
@@ -114,12 +114,14 @@ let gc () =
         (list ())
   )
 
-(** If we just rebooted and failed to attach our static VDIs then this can be called to reattempt the attach:
-    	this is necessary for HA to start. *)
+(** If we just rebooted and failed to attach our static VDIs then this can be
+    called to reattempt the attach: this is necessary for HA to start. *)
 let reattempt_on_boot_attach () =
-  debug "%s" __FUNCTION__ ;
-  let script = "attach-static-vdis" in
-  try ignore (Helpers.call_script "/sbin/service" [script; "start"])
+  debug "%s: Attempt to reattach static VDIs" __FUNCTION__ ;
+  let service = "attach-static-vdis.service" in
+  try Xapi_systemctl.start ~wait_until_success:false service
   with e ->
-    warn "Attempt to reattach static VDIs via '%s start' failed: %s" script
+    warn
+      "%s: Attempt to reattach static VDIs via 'systemctl start %s' failed: %s"
+      __FUNCTION__ service
       (ExnHelper.string_of_exn e)


### PR DESCRIPTION
Xapi still uses `/sbin/service` to start `attach-static-vdis` when boots up for HA. It will fail in XS 9 as `/sbin/service` has been removed in XS 9.

Replace it with `systemctl`.