### PR TITLE
CP-308544 Promote legacy default ntp servers

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1420,6 +1420,8 @@ let failed_login_alert_freq = ref 3600
 
 let default_ntp_servers = ref []
 
+let legacy_default_ntp_servers = ref []
+
 let other_options =
   [
     gen_list_option "sm-plugins"
@@ -1902,6 +1904,11 @@ let other_options =
     , (fun () -> !ntp_client_path)
     , "Path to the ntp client binary"
     )
+  ; gen_list_option "legacy-default-ntp-servers"
+      "space-separated list of legacy default NTP servers"
+      (fun s -> s)
+      (fun s -> s)
+      legacy_default_ntp_servers
   ; gen_list_option "default-ntp-servers"
       "space-separated list of default NTP servers"
       (fun s -> s)

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -3530,6 +3530,7 @@ let disable_ntp ~__context ~self =
   Db.Host.set_ntp_enabled ~__context ~self ~value:false
 
 let sync_ntp_config ~__context ~host =
+  Xapi_host_ntp.promote_legacy_default_servers () ;
   let servers = Xapi_host_ntp.get_servers_from_conf () in
   let is_ntp_dhcp_enabled = Xapi_host_ntp.is_ntp_dhcp_enabled () in
   let ntp_mode =

--- a/ocaml/xapi/xapi_host_ntp.mli
+++ b/ocaml/xapi/xapi_host_ntp.mli
@@ -20,6 +20,8 @@ val set_servers_in_conf : string list -> unit
 
 val clear_servers_in_conf : unit -> unit
 
+val promote_legacy_default_servers : unit -> unit
+
 val restart_ntp_service : unit -> unit
 
 val enable_ntp_service : unit -> unit


### PR DESCRIPTION
For example, the legacy default ntp servers are `[0-3].centos.pool.ntp.org`, and current default ntp servers are `[0-3].xenserver.pool.ntp.org`. After update or upgrade, the legacy default ntp servers are recognized and changed to current default ntp servers. The mode is `ntp_mode_default` as well.
Add a new config option named legacy-default-ntp-servers. It will be defined in xapi.conf.d/xenserver.conf (the same with default-ntp-servers)