### PR TITLE
unixpwd: fix reentrance of unixpwd_setpwd() and unixpwd_setspw()

### DIFF
--- a/unixpwd/c/unixpwd.c
+++ b/unixpwd/c/unixpwd.c
@@ -189,7 +189,8 @@ unixpwd_setspw(const char *user, char *password)
         fclose(spasswd_file);
         if (tmp_file)
             fclose(tmp_file);
-        close(tmp);
+        else
+            close(tmp);
         unlink(tmp_name);
         return ENOLCK;
     }


### PR DESCRIPTION
- prefer `fgetpwent_r()` over `getpwent_r()` to avoid ETC_PASSWD FILE to be shared against threads
- prefer `fgetspent_r()` over `getspent_r()` to avoid ETC_SPASSWD FILE to be shared against threads
- while here, `unlink(2)` tmp_name on error in unixpwd_setpwd() to avoid leaving temporary file on error