### PR TITLE
CA-419238: Remove /etc/dnf/repos.override.d/99-config_manager.repo after using

### DIFF
--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -293,7 +293,11 @@ let sync ~__context ~self ~token ~token_id ~username ~password =
          * will always write_initial_yum_config every time before syncing repo,
          * this should be ok.
          *)
-        write_initial_yum_config ~binary_url
+        match Pkgs.manager with
+        | Yum ->
+            write_initial_yum_config ~binary_url
+        | Dnf ->
+            Unixext.unlink_safe !Xapi_globs.dnf_repo_config_file
       ) ;
     (* The custom yum-utils will fully download repository metadata including
      * the repo gpg signature.

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -972,6 +972,9 @@ let pvsproxy_close_cache_vdi = ref "/opt/citrix/pvsproxy/close-cache-vdi.sh"
 
 let yum_repos_config_dir = ref "/etc/yum.repos.d"
 
+let dnf_repo_config_file =
+  ref "/etc/dnf/repos.override.d/99-config_manager.repo"
+
 let remote_repository_prefix = ref "remote"
 
 let bundle_repository_prefix = ref "bundle"


### PR DESCRIPTION

This file is generated by dnf config manager and contains proxy password, needs to be removed after using.