### PR TITLE
XSI-2025: Only abort HA host reenable for unpluggable PIFs

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -109,17 +109,17 @@ let assert_safe_to_reenable ~__context ~self ~user_request =
       )
       unplugged_pbds ;
     let pifs = Db.Host.get_PIFs ~__context ~self in
-    let unplugged_pifs =
+    let non_pluggable_pifs =
       List.filter
-        (fun pif -> not (Db.PIF.get_currently_attached ~__context ~self:pif))
+        (fun pif -> not (Xapi_pif_helpers.is_pluggable ~__context pif))
         pifs
     in
-    (* Make sure it is 'ok' to have these PIFs remain unplugged *)
+    (* Make sure it is 'ok' that these PIFs cannot be plugged *)
     List.iter
       (fun self ->
         Xapi_pif.abort_if_network_attached_to_protected_vms ~__context ~self
       )
-      unplugged_pifs
+      non_pluggable_pifs
   )
 
 (* The maximum pool size allowed must be restricted to 3 hosts for the pool which does not have Pool_size feature *)

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -1044,9 +1044,6 @@ let rec unplug ~__context ~self =
   assert_no_protection_enabled ~__context ~self ;
   assert_not_management_pif ~__context ~self ;
   let pif_rec = Db.PIF.get_record ~__context ~self in
-  let host = pif_rec.API.pIF_host in
-  if Db.Host.get_enabled ~__context ~self:host then
-    abort_if_network_attached_to_protected_vms ~__context ~self ;
   let network = Db.PIF.get_network ~__context ~self in
   Xapi_network_attach_helpers.assert_network_has_no_vifs_in_use_on_me ~__context
     ~host:(Helpers.get_localhost ~__context)

--- a/ocaml/xapi/xapi_pif_helpers.ml
+++ b/ocaml/xapi/xapi_pif_helpers.ml
@@ -246,6 +246,15 @@ let is_device_underneath_same_type ~__context pif1 pif2 =
   in
   get_device_info pif1 = get_device_info pif2
 
+let is_pluggable ~__context pif_ref =
+  let pif_rec = Db.PIF.get_record ~__context ~self:pif_ref in
+  (* If the root pif is a bond slave, it is not pluggable *)
+  match List.rev (get_pif_topo ~__context ~pif_rec) with
+  | Physical pif_rec :: _ ->
+      not (Db.is_valid_ref __context pif_rec.API.pIF_bond_slave_of)
+  | _ ->
+      true
+
 let get_non_link_ipv6 ~__context ~pif =
   let valid_nonlink ipv6 =
     let open Ipaddr.V6 in


### PR DESCRIPTION
Currently, abort_if_network_attached_to_protected_vms is used to abort unplugs and host reenables under HA when there are any unplugged PIFs. This isn't necessary for pluggable PIFs as it is a quick local operation to do so. The only time we should abort is for bond slave PIFs as these are not pluggable and should be blocked for VM agility.