### PR TITLE
idl: Rename pool_allowed_operations to pool_operations

### DIFF
--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -5,8 +5,7 @@ open Datamodel_types
 let operations =
   Enum
     ( "pool_allowed_operations"
-    , (* FIXME: This should really be called `pool_operations`, to avoid confusion with the Pool.allowed_operations field *)
-      [
+    , [
         ("ha_enable", "Indicates this pool is in the process of enabling HA")
       ; ("ha_disable", "Indicates this pool is in the process of disabling HA")
       ; ( "cluster_create"


### PR DESCRIPTION
This commit addresses a fixme in idl/datamodel_pool.ml. The name pool_allowed_operations conflicts with field Pool.allowed_operations, so renaming for clarity.

As far as I can tell, this change does not impact functionality in any way.