### PR TITLE
quicktest: Add delta tests for VHD/QCOW data integrity suite

### DIFF
--- a/ocaml/quicktest/quicktest_vdi_ops_data_integrity.ml
+++ b/ocaml/quicktest/quicktest_vdi_ops_data_integrity.ml
@@ -171,7 +171,11 @@ let export_import_vhd = export_import_vdi ~exportformat:"vhd"
 
 let export_import_tar = export_import_vdi ~exportformat:"tar"
 
+let export_import_qcow = export_import_vdi ~exportformat:"qcow2"
+
 let delta_export_import_vhd = export_delta_import_vdi ~exportformat:"vhd"
+
+let delta_export_import_qcow = export_delta_import_vdi ~exportformat:"qcow2"
 
 let data_integrity_tests vdi_op op_name =
   [
@@ -275,6 +279,14 @@ let tests () =
     |> supported_srs
     )
   @ (data_integrity_tests export_import_tar "VDI export/import to/from TAR file"
+    |> supported_srs
+    )
+  @ (data_integrity_tests export_import_qcow
+       "VDI export/import to/from QCOW file"
+    |> supported_srs
+    )
+  @ (delta_data_integrity_tests delta_export_import_qcow
+       "VDI delta export/import to/from QCOW file"
     |> supported_srs
     )
   @ (large_data_integrity_tests export_import_tar


### PR DESCRIPTION
These generate two different VDIs (base and leaf), export the difference, import the diff file into the base VDI and check if it's the same as the leaf.

Refactored the code somewhat to use the same helpers in different places.

Tested by running the quicktest suite on a host.