### PR TITLE
CP-310425: Include user names in the http response message

### DIFF
--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -335,7 +335,7 @@ module Server = struct
       x.handlers []
 end
 
-let escape uri =
+let escape str =
   (* from xapi-stdext-std xstringext *)
   let escaped ~rules string =
     let aux h t =
@@ -357,7 +357,7 @@ let escape uri =
       ; ('"', "&quot;")
       ; ('&', "&amp;")
       ]
-    uri
+    str
 
 exception Generic_error of string
 

--- a/ocaml/libs/http-lib/http_svr.mli
+++ b/ocaml/libs/http-lib/http_svr.mli
@@ -50,6 +50,9 @@ end
 
 exception Generic_error of string
 
+val escape : string -> string
+(** [escape str] escapes HTML/XML special characters in [str] for safe inclusion in HTML/XML content. *)
+
 type socket
 
 val bind : ?listen_backlog:int -> Unix.sockaddr -> string -> socket

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1348,6 +1348,8 @@ let ssh_monitor_service = ref "xapi-ssh-monitor"
 
 let ssh_auto_mode_default = ref true
 
+let include_console_username_in_error = ref true
+
 type firewall_backend_type = Firewalld | Iptables
 
 (* Firewall backend to use. iptables in XS 8, firewalld in XS 9. *)
@@ -1454,6 +1456,11 @@ let other_options =
     , (fun () -> string_of_bool !relax_xsm_sr_check)
     , "allow storage migration when SRs have been mirrored out-of-band (and \
        have matching SR uuids)"
+    )
+  ; ( "include-console-username-in-error"
+    , Arg.Set include_console_username_in_error
+    , (fun () -> string_of_bool !include_console_username_in_error)
+    , "Allow displaying user names in XenCenter"
     )
   ; gen_list_option "disable-logging-for"
       "space-separated list of modules to suppress logging from"


### PR DESCRIPTION
    When a VNC console connection is rejected due to the session limit,
    users want to know which user(s) are currently connected. However,
    displaying usernames in HTTP error responses may raise privacy concerns
    in some deployments, so also add a configure to enable/disable the
    display of the usernames.

    The main changes are:
    1. To contain the active users in the response message,
    changed the active_connections to record the existing users
    and use the unique session id to identify them in case
    multiple connections have the same user name.

    2. Added escape_char to escape html special characters

    3. Added `include_console_username_in_error` to enable/disable
       the display of user names


Tested:
1. display-user-name-in-XC = true by default
```
# xe pool-param-set uuid=576102a6-c567-c753-5a0e-9a0614674d09 limit-console-sessions=true
```
Included the currently connected user `root` in the http response message:
```
Nov 25 08:35:32 genuk-21-06d xapi: [debug||1441 HTTPS 10.70.0.166->:::80|Connection to VM console R:c7ad391b568e|console] limit_console_sessions is true. Console connection is rejected for VM OpaqueRef:a071805a-370a-c36b-1608-90e42ec28130, active connections: 1
Nov 25 08:35:32 genuk-21-06d xapi: [debug||1441 HTTPS 10.70.0.166->:::80|Connection to VM console R:c7ad391b568e|console] Sending console limit exceeded response: <html><body><h1>Connection Limit Exceeded</h1><p>User 'root' is currently connected to this console (VM OpaqueRef:a071805a-370a-c36b-1608-90e42ec28130). No more connections are allowed when limit_console_sessions is enabled.</p></body></html>
```
2. Set display-user-name-in-XC = false
No user name in the http response message:
```
Nov 25 08:47:11 genuk-21-06d xapi: [debug||282 HTTPS 10.70.0.167->:::80|Connection to VM console R:2ff9049ff22a|console] limit_console_sessions is true. Console connection is rejected for VM OpaqueRef:a071805a-370a-c36b-1608-90e42ec28130, active connections: 1
Nov 25 08:47:11 genuk-21-06d xapi: [debug||282 HTTPS 10.70.0.167->:::80|Connection to VM console R:2ff9049ff22a|console] Sending console limit exceeded response: <html><body><h1>Connection Limit Exceeded</h1><p>There're users currently connected to this console (VM OpaqueRef:a071805a-370a-c36b-1608-90e42ec28130). No more connections are allowed when limit_console_sessions is enabled.</p></body></html>
```

