### PR TITLE
numa_placement: use Seq instead of List

### DIFF
--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -942,20 +942,19 @@ let numa_placement domid ~vcpus ~memory affinity =
       let ( let* ) = Option.bind in
       let xcext = get_handle () in
       let* host = Lazy.force numa_hierarchy in
-      let numa_meminfo = (numainfo xcext).memory |> Array.to_list in
+      let numa_meminfo = (numainfo xcext).memory |> Array.to_seq in
       let nodes =
-        ListLabels.map2
-          (NUMA.nodes host |> List.of_seq)
-          numa_meminfo
-          ~f:(fun node m -> NUMA.resource host node ~memory:m.memfree)
+        Seq.map2
+          (fun node m -> NUMA.resource host node ~memory:m.memfree)
+          (NUMA.nodes host) numa_meminfo
       in
       let vm = NUMARequest.make ~memory ~vcpus in
       let nodea =
         match !numa_resources with
         | None ->
-            Array.of_list nodes
+            Array.of_seq nodes
         | Some a ->
-            Array.map2 NUMAResource.min_memory (Array.of_list nodes) a
+            Array.map2 NUMAResource.min_memory (Array.of_seq nodes) a
       in
       numa_resources := Some nodea ;
       let memory_plan =


### PR DESCRIPTION
This partially applies the following commit to reduce the complexity of a Xen-4.20 patch:

> xenopsd-xc: do not try keep track of free memory when planning NUMA nodes (CA-411684)
>
> Free memory is now properly accounted for because the memory pages are claimed
> within the NUMA mutex, so there's no need to have double tracking.
>
> On top of that, this code never increased the free memory, which means that it
> always reached a point where it was impossible to allocate a domain into a
> single numa node.
> Signed-off-by: Pau Ruiz Safont <pau.ruizsafont@cloud.com>

However it doesn't actually drop the free memory accounting code, so: No functional change