### PR TITLE
qemu-wrapper: increase max supported NVMe request size

### DIFF
--- a/ocaml/xenopsd/scripts/qemu-wrapper
+++ b/ocaml/xenopsd/scripts/qemu-wrapper
@@ -258,6 +258,12 @@ def main(argv):
             n += 1
             continue
 
+        if p == "-device":
+            if qemu_args[n + 1].startswith('nvme,'):
+                qemu_args[n + 1] += ',mdts=9'
+            n += 1
+            continue
+
         if p == "-loadvm":
             loadvm_path = qemu_args[n+1]
             incoming_fd = os.open(loadvm_path, os.O_RDONLY)


### PR DESCRIPTION
The current default value for the NVMe MDTS parameter exposed in QEMU emulated NMVe devices is 7 (max 512KiB requests).  However there seems to be an internal Windows Server 2025 issue that possibly triggers when splitting bigger requests into smaller on in the NVMe Windows driver.

Increase the exposed MDTS value on the emulated QEMU NVMe device to 9 (max 2MiB request size), as that seems to drop the reproduction rate of the issue.

Discussion is ongoing with Microsoft to get the issue identified and possibly sorted on their end.  For the time being apply this mitigation in qemu-wrapper as a workaround.