### PR TITLE
CA-420533: Only clear RestartVM guidance on up-to-date hosts

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -909,6 +909,9 @@ let force_state_reset_keep_current_operations ~__context ~self ~value:state =
     (* Blank the requires_reboot flag *)
     Db.VM.set_requires_reboot ~__context ~self ~value:false ;
     remove_pending_guidance ~__context ~self ~value:`restart_device_model ;
+    (* Always remove RestartVM guidance when VM becomes Halted: VM.start_on checks
+       host version via assert_host_has_highest_version_in_pool, preventing the VM
+       from starting on an outdated host, so it will necessarily start on an up-to-date host *)
     remove_pending_guidance ~__context ~self ~value:`restart_vm
   ) ;
   (* Do not clear resident_on for VM and VGPU in a checkpoint operation *)

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2350,8 +2350,13 @@ let update_vm_internal ~__context ~id ~self ~previous ~info ~localhost =
           then (
             Xapi_vm_lifecycle.remove_pending_guidance ~__context ~self
               ~value:`restart_device_model ;
-            Xapi_vm_lifecycle.remove_pending_guidance ~__context ~self
-              ~value:`restart_vm
+            (* Only remove RestartVM guidance if host is up-to-date with coordinator *)
+            if
+              Helpers.Checks.RPU.are_host_versions_same_on_master ~__context
+                ~host:localhost
+            then
+              Xapi_vm_lifecycle.remove_pending_guidance ~__context ~self
+                ~value:`restart_vm
           )
         ) ;
         create_guest_metrics_if_needed () ;


### PR DESCRIPTION
During rolling pool upgrade (RPU), RestartVM guidance should only be cleared when a VM restarts on a host that has been updated to match the coordinator's software version. Previously, the guidance was cleared whenever a VM restarted, regardless of the host's update status.

This commit ensures that RestartVM guidance persists until the VM restarts on an up-to-date host, this provides accurate feedback to administrators about which VMs still need restarting after RPU.

Also adds unit tests covering 6 scenarios:
* VM restart on updated vs old host (via xenopsd)
* VM halt on updated vs old host (via force_state_reset)
* Suspended VM resume on updated vs old host