### PR TITLE
increase max supported NVMe request size

### DIFF
--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -2774,7 +2774,7 @@ module Backend = struct
         ]
 
       (* 4 and 5 are NICs, and we can only have two, 6 is platform *)
-      let extra_args = ["-device"; "nvme,serial=nvme0,id=nvme0,addr=7"]
+      let extra_args = ["-device"; "nvme,serial=nvme0,mdts=9,id=nvme0,addr=7"]
     end
 
     module XenPV = struct let addr ~xs:_ ~domid:_ _ ~nics:_ = 6 end


### PR DESCRIPTION
The current default value for the NVMe MDTS parameter exposed in QEMU emulated NMVe devices is 7 (max 512KiB requests).  However there seems to be an internal Windows Server 2025 issue that possibly triggers when splitting bigger requests into smaller on in the NVMe Windows driver.

Increase the exposed MDTS value on the emulated QEMU NVMe device to 9 (max 2MiB request size), as that seems to drop the reproduction rate of the issue.

Discussion is ongoing with Microsoft to get the issue identified and possibly sorted on their end.  For the time being apply this mitigation in qemu-wrapper as a workaround.