### PR TITLE
CP-312077: Set winbind_keep_configuration to true by default

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1065,7 +1065,7 @@ let winbind_set_machine_account_kerberos_encryption_type = ref false
 
 let winbind_scan_trusted_domains = ref false
 
-let winbind_keep_configuration = ref false
+let winbind_keep_configuration = ref true
 
 let serialize_auth_service = ref true
 


### PR DESCRIPTION
Keep winbind configuration on failure by default is good for debug
- Get configuration details that cause the fail
- Can perform a manual retry