### PR TITLE
CP-312095: xenopsd/QEMU cross-version compatibility

### DIFF
--- a/ocaml/xenopsd/scripts/qemu-wrapper
+++ b/ocaml/xenopsd/scripts/qemu-wrapper
@@ -23,6 +23,7 @@ import subprocess
 import ctypes
 import ctypes.util
 import os
+import re
 from resource import getrlimit, RLIMIT_CORE, RLIMIT_FSIZE, setrlimit
 
 import xen.lowlevel.xs as xs
@@ -53,6 +54,9 @@ CLONE_NEWNS = 0x00020000 # mount namespace
 CLONE_NEWNET = 0x40000000 # network namespace
 CLONE_NEWIPC = 0x08000000 # IPC namespace
 
+QEMU_VERSION_REGEX = "QEMU emulator version (\d+)\.\d+\.\d+"
+QEMU_UPGRADED_MAJOR_VERSION = 10
+
 def unshare(flags):
     libc = ctypes.CDLL(ctypes.util.find_library('c'), use_errno=True)
     unshare_prototype = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_int, use_errno=True)
@@ -77,6 +81,21 @@ def xenstore_ls(path):
 def close_fds():
     for i in open_fds:
         os.close(i)
+
+def get_qemu_major_version(qemu_dm):
+    process = subprocess.run([qemu_dm, "-version"], capture_output=True, text=True)
+    process.check_returncode()
+
+    qemu_version_line = process.stdout.splitlines()[0]
+    match = re.match(QEMU_VERSION_REGEX, qemu_version_line)
+    if not match:
+        print("Checking major version of qemu_dm=%s" % qemu_dm)
+        print("$ %s -version" % qemu_dm)
+        print(process.stdout)
+        print(process.stderr)
+        raise Exception("Could not identify QEMU major version")
+
+    return int(match.group(1))
 
 def prepare_exec():
     """Set up the execution environment for QEMU."""
@@ -129,6 +148,7 @@ def main(argv):
             break
 
     qemu_dm = '/usr/lib64/xen/bin/qemu-system-i386'
+    qemu_version = get_qemu_major_version(qemu_dm)
     qemu_args = ['qemu-dm-%d' % domid]
 
     mmio_start = HVM_BELOW_4G_MMIO_START
@@ -283,11 +303,16 @@ def main(argv):
                 raise
 
         qemu_args += ["-xen-domid-restrict"]
-        qemu_args += ["-chroot", root_dir]
 
         uid = pwd.getpwnam('qemu_base').pw_uid + domid
         gid = grp.getgrnam('qemu_base').gr_gid + domid
-        qemu_args += ["-runas", "%d:%d" % (uid, gid)]
+
+        if qemu_version >= QEMU_UPGRADED_MAJOR_VERSION:
+            qemu_args += ["-run-with", "chroot=%s" % root_dir]
+            qemu_args += ["-run-with", "user=%d:%d" % (uid, gid)]
+        else:
+            qemu_args += ["-chroot", root_dir]
+            qemu_args += ["-runas", "%d:%d" % (uid, gid)]
 
     xenstore_write("/libxl/%d/dm-version" % domid, "qemu_xen")
 

--- a/ocaml/xenopsd/scripts/qemu-wrapper
+++ b/ocaml/xenopsd/scripts/qemu-wrapper
@@ -174,7 +174,7 @@ def main(argv):
                       '%s,accel=xen,max-ram-below-4g=%lu,'
                       'suppress-vmdesc=on,'
                       'allow-unassigned=true,trad_compat=%s%s'
-                      % (machine, mmio_start, trad_compat, igdpt)])
+                      % (machine, mmio_start, trad_compat and "on" or "off", igdpt)])
 
     qemu_args.extend(argv[2:])
 

--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -2788,7 +2788,7 @@ module Backend = struct
         ; ["-global"; "PIIX4_PM.revision_id=0x1"]
         ; ["-global"; "ide-hd.ver=0.10.2"]
         ; mult
-            ["piix3-ide-xen"; "piix3-usb-uhci"; nic_type]
+            ["piix3-ide"; "piix3-ide-xen"; "piix3-usb-uhci"; nic_type]
             ["subvendor_id=0x5853"; "subsystem_id=0x0001"]
           |> List.concat_map (fun x -> ["-global"; x])
         ]


### PR DESCRIPTION
Newer versions of QEMU accept slightly difference arguments than older versions.


- chroot and runas were replaced with run-with
- 'on'/'off' boolean values are accepted in most versions
- global variables are machine/device dependent

Adding global variables for both piix3-ide and piix3-ide-xen ensures the variables are present the relevant device, variables which do not apply to any devices in use will log a warning (in daemon.log) but are otherwise ignored.

Example of the warning(s) produced:
```
<time> <host> qemu-dm-<domid>[<pid>]: qemu-dm-<domid>: warning: global piix3-ide-xen.subvendor_id has invalid class name
<time> <host> qemu-dm-<domid>[<pid>]: qemu-dm-<domid>: warning: global piix3-ide-xen.subsystem_id has invalid class name
```

These changes were tested alongside QEMU version 4.2.1 and QEMU version 10.1.0, in both cases guests booted as expected and the respective warning appeared in the daemon log.