### PR TITLE
CA-425472: Signal correct daemon during log rotation

### DIFF
--- a/ocaml/xcp-rrdd/bin/rrdp-scripts/logrotate-rrdd-plugins
+++ b/ocaml/xcp-rrdd/bin/rrdp-scripts/logrotate-rrdd-plugins
@@ -1,5 +1,5 @@
 /var/log/xcp-rrdd-plugins.log {
     postrotate
-        /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
+        /usr/bin/systemctl kill -s HUP rsyslog.service >/dev/null 2>&1 || true
     endscript
 }

--- a/scripts/audit-logrotate
+++ b/scripts/audit-logrotate
@@ -2,7 +2,6 @@
     missingok
     sharedscripts
     postrotate
-      /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
-      /bin/kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true
+        /usr/bin/systemctl kill -s HUP rsyslog.service >/dev/null 2>&1 || true
     endscript
 }

--- a/scripts/xapi-logrotate.conf
+++ b/scripts/xapi-logrotate.conf
@@ -14,6 +14,6 @@
     rotate 100
 
     postrotate
-               /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
+        /usr/bin/systemctl kill -s HUP rsyslog.service >/dev/null 2>&1 || true
     endscript
 }


### PR DESCRIPTION
/var/run/syslogd.pid file does not exist in XS9.