### PR TITLE
CA-423816 avoid double counting VM overhead memory

### DIFF
--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -1838,11 +1838,13 @@ module VM = struct
                         "VM = %s; using memory_dynamic_min = %Ld and \
                          memory_dynamic_max = %Ld"
                         vm.Vm.id vm.memory_dynamic_min vm.memory_dynamic_max ;
-                      (vm.memory_dynamic_min, vm.memory_dynamic_max)
+                      ( vm.memory_dynamic_min +++ overhead_bytes
+                      , vm.memory_dynamic_max +++ overhead_bytes
+                      )
                     )
               in
-              let min_kib = kib_of_bytes_used (min_bytes +++ overhead_bytes)
-              and max_kib = kib_of_bytes_used (max_bytes +++ overhead_bytes) in
+              let min_kib = kib_of_bytes_used min_bytes
+              and max_kib = kib_of_bytes_used max_bytes in
               (* XXX: we would like to be able to cancel an in-progress
                  with_reservation *)
               let dbg = Xenops_task.get_dbg task in


### PR DESCRIPTION
Backport of aef2acf51801310c819d12b368e29fe16d58e316

In the original code we 3-tuples where we here have 2-tuples; so the original patch does not apply.

When we are using a known memory configuration it includes the overhead. So we only have to add it when we create a new configuration.

Localhost migration in a loop before and after the patch, memory reported by list_domains -memory -bytes:

  Before:

  id |         uuid |  state |  tot bytes |  max bytes | shadow bytes
  17 | 8fc1ada1-... |    B H | 4296003584 | 4336898048 |     36700160
  18 | 8fc1ada1-... |    B H | 4296003584 | 4376743936 |     36700160
  19 | 8fc1ada1-... |    B H | 4296003584 | 4416589824 |     36700160
  20 | 8fc1ada1-... |    B H | 4296003584 | 4456435712 |     36700160
  21 | 8fc1ada1-... |    B H | 4296003584 | 4496281600 |     36700160
  22 | 8fc1ada1-... |    B H | 4296003584 | 4536127488 |     36700160
  23 | 8fc1ada1-... |    B H | 4296003584 | 4575973376 |     36700160
  24 | 8fc1ada1-... |    B H | 4296003584 | 4615819264 |     36700160
  25 | 8fc1ada1-... |    B H | 4296003584 | 4655665152 |     36700160
  26 | 8fc1ada1-... |    B H | 4296003584 | 4695511040 |     36700160

  After:

  id |         uuid |  state |  tot bytes |  max bytes | shadow bytes
  27 | 8fc1ada1-... |    B H | 4256157696 | 4297052160 |     36700160
  28 | 8fc1ada1-... |    B H | 4256157696 | 4297052160 |     36700160
  29 | 8fc1ada1-... |    B H | 4256157696 | 4297052160 |     36700160
  30 | 8fc1ada1-... |    B H | 4256157696 | 4297052160 |     36700160
  31 | 8fc1ada1-... |    B H | 4256157696 | 4297052160 |     36700160
  32 | 8fc1ada1-... |    B H | 4256157696 | 4297052160 |     36700160
  33 | 8fc1ada1-... |    B H | 4256157696 | 4297052160 |     36700160
  34 | 8fc1ada1-... |    B H | 4256157696 | 4297052160 |     36700160
  35 | 8fc1ada1-... |    B H | 4256157696 | 4297052160 |     36700160
  36 | 8fc1ada1-... |    B H | 4256157696 | 4297052160 |     36700160

Based on work by Edwin Torok.