### PR TITLE
26.1-lcm: Revert "log/debug: use Ptime's rfc3339 formatting when logging to stdout 

### DIFF
--- a/ocaml/idl/ocaml_backend/dune
+++ b/ocaml/idl/ocaml_backend/dune
@@ -4,8 +4,6 @@
   (libraries
     astring
     cmdliner
-    fmt
-    ptime.clock
     uuidm
     xapi-consts
     xapi-datamodel

--- a/ocaml/idl/ocaml_backend/gen_rbac.ml
+++ b/ocaml/idl/ocaml_backend/gen_rbac.ml
@@ -34,13 +34,10 @@ let internal_role_local_root = "_local_root_"
 
 (* the output of this function is used as input by the automatic tests *)
 let writer_csv static_permissions_roles =
-  let now =
-    let now = Ptime_clock.now () in
-    let str = Fmt.str "%a" Ptime.(pp_rfc3339 ~frac_s:3 ~tz_offset_s:0 ()) now in
-    (* remove separators between Year, Month, and Day; to keep old logging format *)
-    Astring.String.filter (function '-' -> false | _ -> true) str
-  in
-  Printf.sprintf "%s,PERMISSION/ROLE,%s\n" now
+  Printf.sprintf "%s,PERMISSION/ROLE,%s\n"
+    (let t = Debug.gettimestring () in
+     String.sub t 0 (String.length t - 1)
+    )
     (* role titles are ordered by roles in roles_all *)
     (List.fold_left (fun rr r -> rr ^ r ^ ",") "" Datamodel_roles.roles_all)
   ^ List.fold_left

--- a/ocaml/libs/log/debug.ml
+++ b/ocaml/libs/log/debug.ml
@@ -74,8 +74,13 @@ let tasks : task ThreadLocalTable.t = ThreadLocalTable.make ()
 let names : string ThreadLocalTable.t = ThreadLocalTable.make ()
 
 let gettimestring () =
-  let now = Ptime_clock.now () in
-  Fmt.str "%a|" Ptime.(pp_rfc3339 ~frac_s:3 ~tz_offset_s:0 ()) now
+  let time = Unix.gettimeofday () in
+  let tm = Unix.gmtime time in
+  let msec = time -. floor time in
+  Printf.sprintf "%d%.2d%.2dT%.2d:%.2d:%.2d.%.3dZ|" (1900 + tm.Unix.tm_year)
+    (tm.Unix.tm_mon + 1) tm.Unix.tm_mday tm.Unix.tm_hour tm.Unix.tm_min
+    tm.Unix.tm_sec
+    (int_of_float (1000.0 *. msec))
 
 (** [escape str] efficiently escapes non-printable characters and in addition
     the backslash character. The function is efficient in the sense that it will

--- a/ocaml/libs/log/debug.mli
+++ b/ocaml/libs/log/debug.mli
@@ -31,6 +31,9 @@ val with_thread_named : string -> ('a -> 'b) -> 'a -> 'b
 
 module type BRAND = sig val name : string end
 
+val gettimestring : unit -> string
+(** The current time of day in a format suitable for logging *)
+
 val set_facility : Syslog.facility -> unit
 (** Set the syslog facility that will be used by this program. *)
 

--- a/ocaml/libs/log/dune
+++ b/ocaml/libs/log/dune
@@ -9,8 +9,6 @@
    fmt
    mtime
    logs
-   ptime
-   ptime.clock
    threads.posix
    xapi-backtrace
    unix


### PR DESCRIPTION
It changes behaviour of the audit_log endpoint