### PR TITLE
Replaced "e.g." with "for example" in docs and some more user visible messages.

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -877,8 +877,9 @@ module User = struct
             ~lifecycle:
               [(Published, rel_rio, "Unique identifier/object reference")]
         ; field ~qualifier:StaticRO
-            ~lifecycle:[(Published, rel_rio, "short name (e.g. userid)")]
-            "short_name" "short name (e.g. userid)"
+            ~lifecycle:
+              [(Published, rel_rio, "short name (for example, userid)")]
+            "short_name" "short name (for example, userid)"
         ; field
             ~lifecycle:[(Published, rel_rio, "full name")]
             "fullname" "full name"
@@ -2620,10 +2621,11 @@ module PIF = struct
               [
                 ( Published
                 , rel_rio
-                , "machine-readable name of the interface (e.g. eth0)"
+                , "machine-readable name of the interface (for example, eth0)"
                 )
               ]
-            "device" "machine-readable name of the interface (e.g. eth0)"
+            "device"
+            "machine-readable name of the interface (for example, eth0)"
         ; field ~qualifier:StaticRO ~ty:(Ref _network)
             ~lifecycle:
               [
@@ -2793,16 +2795,16 @@ module PIF = struct
                 , rel_orlando
                 , "Prevent this PIF from being unplugged; set this to notify \
                    the management tool-stack that the PIF has a special use \
-                   and should not be unplugged under any circumstances (e.g. \
-                   because you're running storage traffic over it)"
+                   and should not be unplugged under any circumstances (for \
+                   example, because you're running storage traffic over it)"
                 )
               ]
             ~qualifier:DynamicRO ~default_value:(Some (VBool false)) ~ty:Bool
             "disallow_unplug"
             "Prevent this PIF from being unplugged; set this to notify the \
              management tool-stack that the PIF has a special use and should \
-             not be unplugged under any circumstances (e.g. because you're \
-             running storage traffic over it)"
+             not be unplugged under any circumstances (for example, because \
+             you're running storage traffic over it)"
         ; field ~in_oss_since:None ~ty:(Set (Ref _tunnel))
             ~lifecycle:
               [
@@ -4143,7 +4145,9 @@ module Sr_stat = struct
       ( "sr_health"
       , [
           ("healthy", "Storage is fully available")
-        ; ("recovering", "Storage is busy recovering, e.g. rebuilding mirrors.")
+        ; ( "recovering"
+          , "Storage is busy recovering, for example, rebuilding mirrors."
+          )
         ; ( "unreachable"
           , "Storage is unreachable but may be recoverable with admin \
              intervention"
@@ -4229,7 +4233,7 @@ module Probe_result = struct
             ~ty:(Map (String, String))
             "extra_info"
             "Additional plugin-specific information about this configuration, \
-             that might be of use for an API user. This can for example \
+             that might be of use for an API user. This can, for example, \
              include the LUN or the WWPN."
         ]
       ()
@@ -4336,7 +4340,8 @@ module SR = struct
     ; {
         param_type= String
       ; param_name= "content_type"
-      ; param_doc= "The type of the new SRs content, if required (e.g. ISOs)"
+      ; param_doc=
+          "The type of the new SRs content, if required (for example, ISOs)"
       ; param_release= rio_release
       ; param_default= None
       }
@@ -4911,11 +4916,12 @@ module SR = struct
                 [
                   ( Published
                   , rel_rio
-                  , "the type of the SR's content, if required (e.g. ISOs)"
+                  , "the type of the SR's content, if required (for example, \
+                     ISOs)"
                   )
                 ]
               "content_type"
-              "the type of the SR's content, if required (e.g. ISOs)"
+              "the type of the SR's content, if required (for example, ISOs)"
           ; field ~qualifier:DynamicRO "shared" ~ty:Bool
               ~lifecycle:
                 [
@@ -6750,16 +6756,17 @@ module VBD = struct
                      VM"
                   )
                 ]
-              "device" "device seen by the guest e.g. hda1"
+              "device" "device seen by the guest, for example, hda1"
           ; field
               ~lifecycle:
                 [
                   ( Published
                   , rel_rio
-                  , "user-friendly device name e.g. 0,1,2,etc."
+                  , "user-friendly device name, for example, 0, 1, 2, etc."
                   )
                 ]
-              "userdevice" "user-friendly device name e.g. 0,1,2,etc."
+              "userdevice"
+              "user-friendly device name, for example, 0, 1, 2, etc."
           ; field ~ty:Bool
               ~lifecycle:[(Published, rel_rio, "true if this VBD is bootable")]
               "bootable" "true if this VBD is bootable"
@@ -6774,10 +6781,12 @@ module VBD = struct
                 [
                   ( Published
                   , rel_rio
-                  , "how the VBD will appear to the guest (e.g. disk or CD)"
+                  , "how the VBD will appear to the guest (for example, disk \
+                     or CD)"
                   )
                 ]
-              "type" "how the VBD will appear to the guest (e.g. disk or CD)"
+              "type"
+              "how the VBD will appear to the guest (for example, disk or CD)"
           ; field ~in_oss_since:None
               ~lifecycle:
                 [
@@ -6959,8 +6968,8 @@ module Auth = struct
           ( Published
           , rel_george
           , "This call queries the external directory service to obtain the \
-             user information (e.g. username, organization etc) from the \
-             specified subject_identifier"
+             user information (for example, username, organization etc.) from \
+             the specified subject_identifier"
           )
         ]
       ~params:
@@ -6977,8 +6986,8 @@ module Auth = struct
         )
       ~doc:
         "This call queries the external directory service to obtain the user \
-         information (e.g. username, organization etc) from the specified \
-         subject_identifier"
+         information (for example, username, organization etc.) from the \
+         specified subject_identifier"
       ~allowed_roles:_R_READ_ONLY ()
 
   let get_group_membership =
@@ -8651,8 +8660,8 @@ module Event = struct
       ~doc:
         "Blocking call which returns a new token and a (possibly empty) batch \
          of events. The returned token can be used in subsequent calls to this \
-         function. It eliminates redundant events (e.g. same field updated \
-         multiple times)."
+         function. It eliminates redundant events (for example, same field \
+         updated multiple times)."
       ~custom_marshaller:true ~flags:[`Session]
       ~result:
         ( Set (Record _event)

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1508,9 +1508,9 @@ let create_params =
     ; param_name= "pending_guidances_full"
     ; param_doc=
         "The set of pending full guidances after applying updates, which a \
-         user should follow to make some updates, e.g. specific hardware \
-         drivers or CPU features, fully effective, but the 'average user' \
-         doesn't need to"
+         user should follow to make some updates, for example, specific \
+         hardware drivers or CPU features, fully effective, but the 'average \
+         user' doesn't need to"
     ; param_release= numbered_release "26.0.0"
     ; param_default= Some (VSet [])
     }
@@ -2000,7 +2000,7 @@ let enable_external_auth =
       ; (String, "service_name", "The name of the service")
       ; ( String
         , "auth_type"
-        , "The type of authentication (e.g. AD for Active Directory)"
+        , "The type of authentication (for example, AD for Active Directory)"
         )
       ]
     ~doc:"This call enables external authentication on a host"
@@ -2628,9 +2628,9 @@ let set_ssh_auto_mode =
         (Ref _host, "self", "The host")
       ; ( Bool
         , "value"
-        , "The SSH auto mode for the host，when set to true, SSH to normally be \
-           disabled and SSH to be enabled only in case of emergency e.g., xapi \
-           is down"
+        , "The SSH auto mode for the host. When true, the SSH port is closed \
+           by default and it's open only in case the API is unavailable. When \
+           false, the SSH port is always open."
         )
       ]
     ~allowed_roles:_R_POOL_ADMIN ()
@@ -3286,14 +3286,15 @@ let t =
                 ( Published
                 , "1.303.0"
                 , "The set of pending mandatory guidances after applying \
-                   updates, which must be applied, as otherwise there may be \
-                   e.g. VM failures"
+                   updates, which must be applied, otherwise there may be, for \
+                   example, VM failures"
                 )
               ]
             ~ty:(Set update_guidances) "pending_guidances"
             ~default_value:(Some (VSet []))
             "The set of pending mandatory guidances after applying updates, \
-             which must be applied, as otherwise there may be e.g. VM failures"
+             which must be applied, otherwise there may be, for example, VM \
+             failures"
         ; field ~qualifier:DynamicRO
             ~lifecycle:
               [
@@ -3334,9 +3335,9 @@ let t =
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
             "pending_guidances_full" ~default_value:(Some (VSet []))
             "The set of pending full guidances after applying updates, which a \
-             user should follow to make some updates, e.g. specific hardware \
-             drivers or CPU features, fully effective, but the 'average user' \
-             doesn't need to"
+             user should follow to make some updates, for example, specific \
+             hardware drivers or CPU features, fully effective, but the \
+             'average user' doesn't need to"
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:String
             ~default_value:(Some (VString "")) "last_update_hash"
             "The SHA256 checksum of updateinfo of the most recently applied \

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -617,7 +617,7 @@ let enable_external_auth =
       ; (String, "service_name", "The name of the service")
       ; ( String
         , "auth_type"
-        , "The type of authentication (e.g. AD for Active Directory)"
+        , "The type of authentication (for example, AD for Active Directory)"
         )
       ]
     ~doc:
@@ -1613,9 +1613,9 @@ let set_ssh_auto_mode =
         (Ref _pool, "self", "The pool")
       ; ( Bool
         , "value"
-        , "The SSH auto mode for all hosts in the pool，when set to true, SSH \
-           to normally be disabled and SSH to be enabled only in case of \
-           emergency e.g., xapi is down"
+        , "The SSH auto mode for all hosts in the pool. When true, the SSH \
+           port is closed by default and it's open only in case the API is \
+           unavailable. When false, the SSH port is always open."
         )
       ]
     ~allowed_roles:_R_POOL_ADMIN ()
@@ -2237,7 +2237,7 @@ let t =
             ~ty:(Map (String, String))
             ~default_value:(Some (VMap [])) "recommendations"
             "The recommended pool properties for clients to respect for \
-             optimal performance. e.g. max-vm-group=5"
+             optimal performance. For example, max-vm-group=5"
         ; field ~writer_roles:_R_POOL_OP ~qualifier:RW ~lifecycle:[]
             ~ty:(Map (String, String))
             ~default_value:(Some (VMap [])) "license_server"

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -248,8 +248,8 @@ let get_boot_record =
       ]
     ~doc:
       "Returns a record describing the VM's dynamic state, initialised when \
-       the VM boots and updated to reflect runtime configuration changes e.g. \
-       CPU hotplug"
+       the VM boots and updated to reflect runtime configuration changes, for \
+       example CPU hotplug"
     ~result:(Record _vm, "A record describing the VM")
     ~params:[(Ref _vm, "self", "The VM whose boot-time state to return")]
     ~errs:[] ~flags:[`Session] (* no async *)
@@ -347,15 +347,16 @@ let clone =
         , rel_rio
         , "Clones the specified VM, making a new VM. Clone automatically \
            exploits the capabilities of the underlying storage repository in \
-           which the VM's disk images are stored (e.g. Copy on Write).   This \
-           function can only be called when the VM is in the Halted State."
+           which the VM's disk images are stored (for example, Copy on Write). \
+           This function can only be called when the VM is in the Halted \
+           State."
         )
       ]
     ~doc:
       "Clones the specified VM, making a new VM. Clone automatically exploits \
        the capabilities of the underlying storage repository in which the VM's \
-       disk images are stored (e.g. Copy on Write).   This function can only \
-       be called when the VM is in the Halted State."
+       disk images are stored (for example, Copy on Write). This function can \
+       only be called when the VM is in the Halted State."
     ~result:(Ref _vm, "The reference of the newly created VM.")
     ~params:
       [
@@ -418,8 +419,8 @@ let snapshot_with_quiesce =
     ~doc:
       "Snapshots the specified VM with quiesce, making a new VM. Snapshot \
        automatically exploits the capabilities of the underlying storage \
-       repository in which the VM's disk images are stored (e.g. Copy on \
-       Write)."
+       repository in which the VM's disk images are stored (for example, Copy \
+       on Write)."
     ~result:(Ref _vm, "The reference of the newly created VM.")
     ~params:
       [
@@ -464,13 +465,13 @@ let snapshot =
         , rel_orlando
         , "Snapshots the specified VM, making a new VM. Snapshot automatically \
            exploits the capabilities of the underlying storage repository in \
-           which the VM's disk images are stored (e.g. Copy on Write)."
+           which the VM's disk images are stored (for example, Copy on Write)."
         )
       ]
     ~doc:
       "Snapshots the specified VM, making a new VM. Snapshot automatically \
        exploits the capabilities of the underlying storage repository in which \
-       the VM's disk images are stored (e.g. Copy on Write)."
+       the VM's disk images are stored (for example, Copy on Write)."
     ~result:(Ref _vm, "The reference of the newly created VM.")
     ~versioned_params:
       [
@@ -532,15 +533,15 @@ let checkpoint =
         , rel_midnight_ride
         , "Checkpoints the specified VM, making a new VM. Checkpoint \
            automatically exploits the capabilities of the underlying storage \
-           repository in which the VM's disk images are stored (e.g. Copy on \
-           Write) and saves the memory image as well."
+           repository in which the VM's disk images are stored (for example, \
+           Copy on Write) and saves the memory image as well."
         )
       ]
     ~doc:
       "Checkpoints the specified VM, making a new VM. Checkpoint automatically \
        exploits the capabilities of the underlying storage repository in which \
-       the VM's disk images are stored (e.g. Copy on Write) and saves the \
-       memory image as well."
+       the VM's disk images are stored (for example, Copy on Write) and saves \
+       the memory image as well."
     ~result:(Ref _vm, "The reference of the newly created VM.")
     ~params:
       [
@@ -639,8 +640,8 @@ let start =
       ; ( Bool
         , "force"
         , "Attempt to force the VM to start. If this flag is false then the VM \
-           may fail pre-boot safety checks (e.g. if the CPU the VM last booted \
-           on looks substantially different to the current one)"
+           may fail pre-boot safety checks (for example, if the CPU the VM \
+           last booted on looks substantially different to the current one)"
         )
       ]
     ~errs:
@@ -665,7 +666,7 @@ let assert_can_boot_here =
       ; ( Changed
         , rel_quebec
         , "Does additional compatibility checks when VM powerstate is not \
-           halted (e.g. CPUID). Use this before calling VM.resume or \
+           halted (for example, CPUID). Use this before calling VM.resume or \
            VM.pool_migrate."
         )
       ]
@@ -703,13 +704,13 @@ let assert_agile =
       [
         ( Published
         , rel_orlando
-        , "Returns an error if the VM is not considered agile e.g. because it \
-           is tied to a resource local to a host"
+        , "Returns an error if the VM is not considered agile, for example, \
+           because it is tied to a resource local to a host"
         )
       ]
     ~doc:
-      "Returns an error if the VM is not considered agile e.g. because it is \
-       tied to a resource local to a host"
+      "Returns an error if the VM is not considered agile, for example, \
+       because it is tied to a resource local to a host"
     ~params:[(Ref _vm, "self", "The VM")]
     ~allowed_roles:_R_READ_ONLY ()
 
@@ -1088,8 +1089,8 @@ let start_on =
       ; ( Bool
         , "force"
         , "Attempt to force the VM to start. If this flag is false then the VM \
-           may fail pre-boot safety checks (e.g. if the CPU the VM last booted \
-           on looks substantially different to the current one)"
+           may fail pre-boot safety checks (for example, if the CPU the VM \
+           last booted on looks substantially different to the current one)"
         )
       ]
     ~errs:
@@ -1164,15 +1165,15 @@ let cleanShutdown =
         ( Published
         , rel_rio
         , "Attempt to cleanly shutdown the specified VM. (Note: this may not \
-           be supported---e.g. if a guest agent is not installed). This can \
-           only be called when the specified VM is in the Running state."
+           be supported, for example, if a guest agent is not installed). This \
+           can only be called when the specified VM is in the Running state."
         )
       ]
     ~name:"clean_shutdown"
     ~doc:
       "Attempt to cleanly shutdown the specified VM. (Note: this may not be \
-       supported---e.g. if a guest agent is not installed). This can only be \
-       called when the specified VM is in the Running state."
+       supported, for example, if a guest agent is not installed). This can \
+       only be called when the specified VM is in the Running state."
     ~params:[(Ref _vm, "vm", "The VM to shutdown")]
     ~errs:
       [
@@ -1192,15 +1193,15 @@ let cleanReboot =
         ( Published
         , rel_rio
         , "Attempt to cleanly shutdown the specified VM (Note: this may not be \
-           supported---e.g. if a guest agent is not installed). This can only \
-           be called when the specified VM is in the Running state."
+           supported, for example, if a guest agent is not installed). This \
+           can only be called when the specified VM is in the Running state."
         )
       ]
     ~name:"clean_reboot"
     ~doc:
       "Attempt to cleanly shutdown the specified VM (Note: this may not be \
-       supported---e.g. if a guest agent is not installed). This can only be \
-       called when the specified VM is in the Running state."
+       supported, for example, if a guest agent is not installed). This can \
+       only be called when the specified VM is in the Running state."
     ~params:[(Ref _vm, "vm", "The VM to shutdown")]
     ~errs:
       [
@@ -1392,8 +1393,8 @@ let resume =
       ; ( Bool
         , "force"
         , "Attempt to force the VM to resume. If this flag is false then the \
-           VM may fail pre-resume safety checks (e.g. if the CPU the VM was \
-           running on looks substantially different to the current one)"
+           VM may fail pre-resume safety checks (for example, if the CPU the \
+           VM was running on looks substantially different to the current one)"
         )
       ]
     ~errs:
@@ -1426,8 +1427,8 @@ let resume_on =
       ; ( Bool
         , "force"
         , "Attempt to force the VM to resume. If this flag is false then the \
-           VM may fail pre-resume safety checks (e.g. if the CPU the VM was \
-           running on looks substantially different to the current one)"
+           VM may fail pre-resume safety checks (for example, if the CPU the \
+           VM was running on looks substantially different to the current one)"
         )
       ]
     ~errs:
@@ -3116,7 +3117,7 @@ let t =
             ~lifecycle:[(Published, rel_ely, "")]
             ~default_value:(Some (VBool false)) "requires_reboot"
             "Indicates whether a VM requires a reboot in order to update its \
-             configuration, e.g. its memory allocation."
+             configuration, for example, its memory allocation."
         ; field ~qualifier:StaticRO ~ty:String
             ~lifecycle:
               [
@@ -3158,14 +3159,15 @@ let t =
                 ( Published
                 , "1.303.0"
                 , "The set of pending mandatory guidances after applying \
-                   updates, which must be applied, as otherwise there may be \
-                   e.g. VM failures"
+                   updates, which must be applied, otherwise there may be, for \
+                   example, VM failures"
                 )
               ]
             ~ty:(Set update_guidances) "pending_guidances"
             ~default_value:(Some (VSet []))
             "The set of pending mandatory guidances after applying updates, \
-             which must be applied, as otherwise there may be e.g. VM failures"
+             which must be applied, otherwise there may be, for example, VM \
+             failures"
         ; field ~qualifier:DynamicRO ~internal_only:true
             ~lifecycle:[(Prototyped, "23.18.0", ""); (Removed, "23.24.0", "")]
             ~ty:(Set update_guidances) "recommended_guidances"
@@ -3179,9 +3181,9 @@ let t =
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
             "pending_guidances_full" ~default_value:(Some (VSet []))
             "The set of pending full guidances after applying updates, which a \
-             user should follow to make some updates, e.g. specific hardware \
-             drivers or CPU features, fully effective, but the 'average user' \
-             doesn't need to"
+             user should follow to make some updates, for example, specific \
+             hardware drivers or CPU features, fully effective, but the \
+             'average user' doesn't need to"
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set (Ref _vm_group))
             "groups" "VM groups associated with the VM"
         ]

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "32bbba07579ca8844fa6162164530268"
+let last_known_schema_hash = "87b39cf2131c990f186bb6baa6e5ece8"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1861,7 +1861,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; help=
           "Calls the function within the plugin on the given vm with optional \
            arguments (args:key=value). To pass a \"value\" string with special \
-           characters in it (e.g. new line), an alternative syntax \
+           characters in it (for example, new line), an alternative syntax \
            args:key:file=local_file can be used in place, where the content of \
            local_file will be retrieved and assigned to \"key\" as a whole."
       ; implementation= With_fd Cli_operations.vm_call_plugin
@@ -1875,10 +1875,10 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; help=
           "Calls function fn within the plugin on the host where the VM is \
            running with arguments (args:key=value). To pass a \"value\" string \
-           with special characters in it (e.g. new line), an alternative \
-           syntax args:key:file=local_file can be used in place, where the \
-           content of local_file will be retrieved and assigned to \"key\" as \
-           a whole."
+           with special characters in it (for example, new line), an \
+           alternative syntax args:key:file=local_file can be used in place, \
+           where the content of local_file will be retrieved and assigned to \
+           \"key\" as a whole."
       ; implementation= With_fd Cli_operations.vm_call_host_plugin
       ; flags= []
       }
@@ -2242,8 +2242,8 @@ let rec cmdtable_data : (string * cmd_spec) list =
           ; "sm-config:"
           ]
       ; help=
-          "Create an SR, also a PBD. the device-config parameters can be \
-           specified by e.g. device-config:foo=baa."
+          "Create an SR, also a PBD. The device-config parameters can be \
+           specified by device-config:foo=baa, for example."
       ; implementation= With_fd Cli_operations.sr_create
       ; flags= []
       }
@@ -2254,7 +2254,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; optn= ["host-uuid"; "device-config:"; "sm-config:"]
       ; help=
           "Perform a storage probe.  The device-config parameters can be \
-           specified by e.g. device-config:devs=/dev/sdb1."
+           specified by device-config:devs=/dev/sdb1, for example."
       ; implementation= No_fd Cli_operations.sr_probe
       ; flags= []
       }
@@ -2265,9 +2265,9 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; optn= ["host-uuid"; "device-config:"; "sm-config:"]
       ; help=
           "Perform a storage probe. The device-config parameters can be \
-           specified by e.g. device-config:devs=/dev/sdb1. Unlike sr-probe, \
-           this command returns results in the same human-readable format for \
-           every SR type."
+           specified by device-config:devs=/dev/sdb1, for example. Unlike \
+           sr-probe, this command returns results in the same human-readable \
+           format for every SR type."
       ; implementation= No_fd Cli_operations.sr_probe_ext
       ; flags= []
       }

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1466,14 +1466,14 @@ let message_destroy_all (_ : printer) rpc session_id params =
     try Option.map Date.of_iso8601 before_str
     with _ ->
       fail
-        "invalid timestamp format for 'before' (expected RFC3339, e.g. \
+        "invalid timestamp format for 'before' (expected RFC3339, for example, \
          2025-01-01T00:00:00Z)"
   in
   let after =
     try Option.map Date.of_iso8601 after_str
     with _ ->
       fail
-        "Invalid timestamp format for 'after' (expected RFC3339, e.g. \
+        "Invalid timestamp format for 'after' (expected RFC3339, for example, \
          2025-01-01T00:00:00Z)"
   in
   let priority =

--- a/ocaml/xapi-guard/src/main.ml
+++ b/ocaml/xapi-guard/src/main.ml
@@ -333,7 +333,7 @@ open! Cmdliner
 let cmd =
   let info = Cmd.info daemon_name in
   let log_level =
-    let doc = "Syslog level. E.g. debug, info etc." in
+    let doc = "Syslog level. For example, debug, info etc." in
     let level_conv =
       let parse s =
         try `Ok (Syslog.level_of_string s)

--- a/ocaml/xapi-storage-cli/main.ml
+++ b/ocaml/xapi-storage-cli/main.ml
@@ -578,8 +578,8 @@ let sr_attach_cmd =
     ; `P "Simple parameters may be written directly on the commandline as:"
     ; `P "key=value"
     ; `P
-        "If a particular value is stored in a file (e.g. as XML) then you may \
-         write:"
+        "If a particular value is stored in a file (for example, as XML) then \
+         you may write:"
     ; `P " key-filename=<filename containing the value>."
     ]
     @ help
@@ -595,8 +595,8 @@ let sr_detach_cmd =
       `S "DESCRIPTION"
     ; `P
         "Disconnects from a connected storage repository, and frees any \
-         associated resources (e.g. iSCSI sessions, other control connections \
-         etc)."
+         associated resources (for example, iSCSI sessions, other control \
+         connections etc)."
     ]
     @ help
   in
@@ -651,7 +651,7 @@ let vdi_create_cmd =
   let format_arg =
     let doc =
       "Request a specific format for the disk on the backend storage \
-       substrate, e.g. 'vhd' or 'raw'. Note that not all storage \
+       substrate, for example, 'vhd' or 'raw'. Note that not all storage \
        implementations support all formats. Every storage implementation will \
        use its preferred format if no override is supplied."
     in

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -2214,7 +2214,8 @@ let description =
     [
       "Allow xapi storage adapters to be written as individual scripts."
     ; "To add a storage adapter, create a sub-directory in the --root directory"
-    ; "with the name of the adapter (e.g. org.xen.xcp.storage.mylvm) and place"
+    ; "with the name of the adapter (for example, org.xen.xcp.storage.mylvm) \
+       and place"
     ; "the scripts inside."
     ]
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1853,7 +1853,7 @@ let other_options =
     , Arg.Bool (fun b -> ssh_auto_mode_default := b)
     , (fun () -> string_of_bool !ssh_auto_mode_default)
     , "Defaults to true; overridden to false via \
-       /etc/xapi.conf.d/ssh-auto-mode.conf(e.g., in XenServer 8)"
+       /etc/xapi.conf.d/ssh-auto-mode.conf (for example, in XenServer 8)"
     )
   ; ( "secure-boot-efi-path"
     , Arg.Set_string secure_boot_path

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1274,7 +1274,7 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
          ( Api_errors.operation_not_allowed
          , [
              "Copy mode is disallowed on intra pool storage migration, try \
-              efficient alternatives e.g. VM.copy/clone."
+              efficient alternatives, for example, VM.copy/clone."
            ]
          )
       ) ;

--- a/ocaml/xenopsd/pvs/pvs_proxy_setup.ml
+++ b/ocaml/xenopsd/pvs/pvs_proxy_setup.ml
@@ -563,7 +563,7 @@ module CLI = struct
     C.Arg.(
       required
       & pos 1 (some string) None
-      & info [] ~docv:"vif4.0" ~doc:"Device name, e.g. vif4.0"
+      & info [] ~docv:"vif4.0" ~doc:"Device name, for example, vif4.0"
     )
 
   (** xenstore path *)

--- a/ocaml/xs-trace/xs_trace.ml
+++ b/ocaml/xs-trace/xs_trace.ml
@@ -70,12 +70,13 @@ module Cli = struct
   open Cmdliner
 
   let src =
-    let doc = "The trace file, e.g. /path/to/trace.ndjson" in
+    let doc = "The trace file, for example, /path/to/trace.ndjson" in
     Arg.(required & pos 0 (some string) None (info [] ~docv:"SRC" ~doc))
 
   let dst =
     let doc =
-      "The destination endpoint URL, e.g. http://localhost:9411/api/v2/spans"
+      "The destination endpoint URL, for example, \
+       http://localhost:9411/api/v2/spans"
     in
     Arg.(required & pos 1 (some string) None (info [] ~docv:"DST" ~doc))
 


### PR DESCRIPTION
The corporate docs don't like "e.g." and it's a pain to have to undo it every time we copy in the autogenerated API reference. Alongside the API strings, I changed some more that appear in other user visible messages.