### PR TITLE
Revert "CA-423816 avoid double counting VM overhead memory"

### DIFF
--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -1852,16 +1852,13 @@ module VM = struct
                         "VM = %s; using memory_dynamic_min = %Ld and \
                          memory_dynamic_max = %Ld"
                         vm.Vm.id vm.memory_dynamic_min vm.memory_dynamic_max ;
-                      ( vm.memory_dynamic_min +++ overhead_bytes
-                      , vm.memory_dynamic_max +++ overhead_bytes
-                      , None
-                      )
+                      (vm.memory_dynamic_min, vm.memory_dynamic_max, None)
                     )
               in
-              let min_kib = kib_of_bytes_used min_bytes
+              let min_kib = kib_of_bytes_used (min_bytes +++ overhead_bytes)
               and memory_total_source_kib =
                 Option.map kib_of_bytes_used memory_total_source_bytes
-              and max_kib = kib_of_bytes_used max_bytes in
+              and max_kib = kib_of_bytes_used (max_bytes +++ overhead_bytes) in
               (* XXX: we would like to be able to cancel an in-progress
                  with_reservation *)
               let dbg = Xenops_task.get_dbg task in


### PR DESCRIPTION
This reverts commit aef2acf51801310c819d12b368e29fe16d58e316.

We see sporadic test failures; revert this for now.