### PR TITLE
Fix quicktest error

### DIFF
--- a/ocaml/quicktest/quicktest_http.ml
+++ b/ocaml/quicktest/quicktest_http.ml
@@ -102,7 +102,7 @@ module Cookies = struct
       match body with
       | first_line :: _ ->
           D.warn "expected = [%s]; received = [%s]" expected first_line ;
-          Astring.String.is_infix ~affix:first_line expected
+          Astring.String.is_infix ~affix:expected first_line
       | _ ->
           false
     in


### PR DESCRIPTION
A mistake in https://github.com/xapi-project/xen-api/pull/6795 that breaks quicktest.