### PR TITLE
dune-project: Drop conf-qemu-img dependency in vhd-tool

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -506,7 +506,6 @@
   cohttp
   cohttp-lwt
   conf-libssl
-  (conf-qemu-img :with-test)
   (cstruct
    (>= "3.0.0"))
   (ezxenstore

--- a/opam/vhd-tool.opam
+++ b/opam/vhd-tool.opam
@@ -16,7 +16,6 @@ depends: [
   "cohttp"
   "cohttp-lwt"
   "conf-libssl"
-  "conf-qemu-img" {with-test}
   "cstruct" {>= "3.0.0"}
   "ezxenstore" {= version}
   "forkexec" {= version}


### PR DESCRIPTION
With #7022 merged, it's no longer needed.