### PR TITLE
Remove handling of VBD.other_config:backend-local

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -240,8 +240,6 @@ let vbd_polling_idle_threshold_key = "polling-idle-threshold"
 
 (* set in VBD other-config *)
 
-let vbd_backend_local_key = "backend-local" (* set in VBD other-config *)
-
 let mac_seed = "mac_seed" (* set in a VM to generate MACs by hash chaining *)
 
 let ( ** ) = Int64.mul

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -678,16 +678,7 @@ module MD = struct
              )
         )
     in
-    let backend_of_vbd vbd =
-      let vbd_oc = vbd.API.vBD_other_config in
-      if List.mem_assoc Xapi_globs.vbd_backend_local_key vbd_oc then (
-        let path = List.assoc Xapi_globs.vbd_backend_local_key vbd_oc in
-        warn "Using local override for VBD backend: %s -> %s" vbd.API.vBD_uuid
-          path ;
-        Some (Local path)
-      ) else
-        disk_of_vdi ~__context ~self:vbd.API.vBD_VDI
-    in
+    let backend_of_vbd vbd = disk_of_vdi ~__context ~self:vbd.API.vBD_VDI in
     let can_attach_early =
       let sr_opt =
         try Some (Db.VDI.get_SR ~__context ~self:vbd.API.vBD_VDI)


### PR DESCRIPTION
There is no use case for it anymore.

This is part of XSA-489 / CVE-2026-23559.