### PR TITLE
xapi/attach_helpers: remove useless check for leaked vbds 

### DIFF
--- a/ocaml/xapi/attach_helpers.ml
+++ b/ocaml/xapi/attach_helpers.ml
@@ -44,52 +44,8 @@ let safe_unplug rpc session_id self =
         raise e
       )
 
-(** For a VBD attached to a control domain, it may correspond to a running task
-    	(if so the task will be linked via an other_config key) or it may be a qemu
-    	frontend (if so it will be linked to another frontend) *)
-let has_vbd_leaked __context vbd =
-  let other_config = Db.VBD.get_other_config ~__context ~self:vbd in
-  let vm = Db.VBD.get_VM ~__context ~self:vbd in
-  let can_leak = Db.VM.get_is_control_domain ~__context ~self:vm in
-  let device = Db.VBD.get_device ~__context ~self:vbd in
-  let has_task = List.mem_assoc Xapi_globs.vbd_task_key other_config in
-  let has_related = List.mem_assoc Xapi_globs.related_to_key other_config in
-  if (not can_leak) || ((not has_task) && not has_related) then (
-    info "Ignoring orphaned disk attached to control domain (device = %s)"
-      device ;
-    false
-  ) else
-    let has_valid_task =
-      has_task
-      &&
-      let task_id =
-        Ref.of_string (List.assoc Xapi_globs.vbd_task_key other_config)
-      in
-      (* check if the task record still exists and is pending *)
-      try
-        let status = Db.Task.get_status ~__context ~self:task_id in
-        List.mem status [`pending; `cancelling]
-        (* pending and cancelling => not leaked *)
-      with _ -> false
-      (* task record gone *)
-    in
-    let has_valid_related =
-      has_related
-      &&
-      let related =
-        Ref.of_string (List.assoc Xapi_globs.related_to_key other_config)
-      in
-      (* check if the VBD still exists and is currently_attached *)
-      try Db.VBD.get_currently_attached ~__context ~self:related
-      with _ -> false
-      (* VBD record gone *)
-    in
-    (* leaked if neither of the two keys are still valid *)
-    (not has_valid_task) && not has_valid_related
-
 (** Execute a function with a list of VBDs after attaching a bunch of VDIs to an vm *)
 let with_vbds rpc session_id __context vm vdis mode f =
-  let task_id = Context.get_task_id __context in
   let vbds = ref [] in
   finally
     (fun () ->
@@ -99,13 +55,8 @@ let with_vbds rpc session_id __context vm vdis mode f =
             Client.VBD.create ~rpc ~session_id ~vM:vm ~empty:false ~vDI:vdi
               ~userdevice:"autodetect" ~bootable:false ~mode ~_type:`Disk
               ~unpluggable:true ~qos_algorithm_type:"" ~qos_algorithm_params:[]
-              ~other_config:[(Xapi_globs.vbd_task_key, Ref.string_of task_id)]
-              ~device:"" ~currently_attached:false
+              ~other_config:[] ~device:"" ~currently_attached:false
           in
-          (* sanity-check *)
-          if has_vbd_leaked __context vbd then
-            error "Attach_helpers.with_vbds new VBD has leaked: %s"
-              (Ref.string_of vbd) ;
           let vbd_uuid = Client.VBD.get_uuid ~rpc ~session_id ~self:vbd in
           let uuid = Client.VM.get_uuid ~rpc ~session_id ~self:vm in
           debug "created VBD (uuid %s); attempting to hotplug to VM (uuid: %s)"

--- a/ocaml/xapi/attach_helpers.ml
+++ b/ocaml/xapi/attach_helpers.ml
@@ -49,10 +49,12 @@ let safe_unplug rpc session_id self =
     	frontend (if so it will be linked to another frontend) *)
 let has_vbd_leaked __context vbd =
   let other_config = Db.VBD.get_other_config ~__context ~self:vbd in
+  let vm = Db.VBD.get_VM ~__context ~self:vbd in
+  let can_leak = Db.VM.get_is_control_domain ~__context ~self:vm in
   let device = Db.VBD.get_device ~__context ~self:vbd in
   let has_task = List.mem_assoc Xapi_globs.vbd_task_key other_config in
   let has_related = List.mem_assoc Xapi_globs.related_to_key other_config in
-  if (not has_task) && not has_related then (
+  if (not can_leak) || ((not has_task) && not has_related) then (
     info "Ignoring orphaned disk attached to control domain (device = %s)"
       device ;
     false

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -274,11 +274,6 @@ let default_template_key = "default_template"
 
 let base_template_name_key = "base_template_name"
 
-(* Keys to explain the presence of dom0 block-attached VBDs: *)
-let vbd_task_key = "task_id"
-
-let related_to_key = "related_to"
-
 let get_nbd_extents = "/opt/xensource/libexec/get_nbd_extents.py"
 
 (* other-config keys to sync over when mirroring/remapping/importing a VDI *)


### PR DESCRIPTION
Looks like this mechanism was used in the past, and only one vestigial
check on VBD creation was used.

It does not make sense to create a VBD associated with a task and
immediately check whether it has leaked.