### PR TITLE
CA-426596: Supports SM feature removing

### DIFF
--- a/ocaml/xapi/xapi_sm.ml
+++ b/ocaml/xapi/xapi_sm.ml
@@ -109,14 +109,18 @@ let update_from_query_result ~__context (self, r) q_result =
   if _type <> "storage_access" then (
     let driver_filename = Sm_exec.cmd_name q_result.driver in
     let existing_features = Db.SM.get_features ~__context ~self in
+    let query_features = Smint.Feature.parse_string_int64 q_result.features in
+    let retained_features =
+      List.filter (fun x -> List.mem x query_features) existing_features
+    in
     let new_features =
-      Smint.Feature.parse_string_int64 q_result.features
+      query_features
       |> find_pending_features existing_features
       |> addto_pending_hosts_features ~__context self
       |> valid_hosts_pending_features ~__context
     in
     remove_valid_features_from_pending ~__context ~self new_features ;
-    let features = existing_features @ new_features in
+    let features = retained_features @ new_features in
     List.iter
       (fun (f, v) -> debug "%s: declaring new features %s:%Ld" __FUNCTION__ f v)
       new_features ;

--- a/ocaml/xapi/xapi_sm.ml
+++ b/ocaml/xapi/xapi_sm.ml
@@ -110,8 +110,14 @@ let update_from_query_result ~__context (self, r) q_result =
     let driver_filename = Sm_exec.cmd_name q_result.driver in
     let existing_features = Db.SM.get_features ~__context ~self in
     let query_features = Smint.Feature.parse_string_int64 q_result.features in
+    let removed_features =
+      Listext.List.set_difference existing_features query_features
+    in
+    List.iter
+      (fun (f, v) -> debug "%s: removing features %s:%Ld" __FUNCTION__ f v)
+      removed_features ;
     let retained_features =
-      List.filter (fun x -> List.mem x query_features) existing_features
+      Listext.List.set_difference existing_features removed_features
     in
     let new_features =
       query_features


### PR DESCRIPTION
In current xapi_sm.ml, the quired new sm features at XAPI start goes to pending_features. After all hosts reporting the new sm features, they are set in xapi-db.
However, when the sm feature is removed, the item still exists. For example, xapi-storage-plugins-xfs remove SR_PROB as it is not implemented, but XAPI doesn't detect it. It leads to fresh-installed host (withour xfs SR_PROB) can't join the pool (with xfs SR_PROB) due to POOL_JOINING_SM_FEATURES_INCOMPATIBLE.
Considering the pending_features, it wants to keep the minimal common features all over the hosts. As the same principle, the removed feature shall be removed immediately in the pool-level sm table. If one host reports the feature is removed, it should be removed from pool-level db.