### PR TITLE
Revert CA-423816 - memory double counting

### DIFF
--- a/ocaml/quicktest/quicktest_vm_memory.ml
+++ b/ocaml/quicktest/quicktest_vm_memory.ml
@@ -12,7 +12,7 @@ let check_tasks tasks =
 let one t ~host ~vm ~workload_vm n =
   Trace.with_ __FUNCTION__ @@ fun scope ->
   workload t ~host ~workload_vm ;
-  let vms = fill_mem_n t ~workaround_migration:false ~host ~vm ~n in
+  let vms = fill_mem_n t ~workaround_migration:true ~host ~vm ~n in
 
   let migration_host, migration_vm = List.nth vms 0 in
 

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -1852,16 +1852,13 @@ module VM = struct
                         "VM = %s; using memory_dynamic_min = %Ld and \
                          memory_dynamic_max = %Ld"
                         vm.Vm.id vm.memory_dynamic_min vm.memory_dynamic_max ;
-                      ( vm.memory_dynamic_min +++ overhead_bytes
-                      , vm.memory_dynamic_max +++ overhead_bytes
-                      , None
-                      )
+                      (vm.memory_dynamic_min, vm.memory_dynamic_max, None)
                     )
               in
-              let min_kib = kib_of_bytes_used min_bytes
+              let min_kib = kib_of_bytes_used (min_bytes +++ overhead_bytes)
               and memory_total_source_kib =
                 Option.map kib_of_bytes_used memory_total_source_bytes
-              and max_kib = kib_of_bytes_used max_bytes in
+              and max_kib = kib_of_bytes_used (max_bytes +++ overhead_bytes) in
               (* XXX: we would like to be able to cancel an in-progress
                  with_reservation *)
               let dbg = Xenops_task.get_dbg task in


### PR DESCRIPTION
Revert this for now because it triggers a bug at lower levels: CA-426859