### PR TITLE
CP-311896: ldaps feature sync with trusted certs

### DIFF
--- a/ocaml/idl/datamodel_certificate.ml
+++ b/ocaml/idl/datamodel_certificate.ml
@@ -37,7 +37,13 @@ let certificate_type =
 let certificate_purpose =
   Enum
     ( "certificate_purpose"
-    , [("licensing", "Trusted certificates that are for licensing purpose.")]
+    , [
+        ("licensing", "Trusted certificates that are for licensing purpose.")
+      ; ( "ldaps"
+        , "Trusted certificates that are for LDAPS connections to external \
+           authentication services."
+        )
+      ]
     )
 
 let t =

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 902
+let schema_minor_vsn = 903
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -2049,7 +2049,7 @@ let external_auth_set_ldaps =
     ~lifecycle:
       [
         ( Published
-        , "26.6.0-next"
+        , "26.12.0-next"
         , "This call enables or disables LDAPS for external authentication on \
            the host"
         )
@@ -2060,21 +2060,21 @@ let external_auth_set_ldaps =
           param_type= Ref _host
         ; param_name= "host"
         ; param_doc= "The host whose LDAPS configuration should be set"
-        ; param_release= numbered_release "26.6.0-next"
+        ; param_release= numbered_release "26.12.0-next"
         ; param_default= None
         }
       ; {
           param_type= Bool
         ; param_name= "ldaps"
         ; param_doc= "Whether to enable or disable LDAPS"
-        ; param_release= numbered_release "26.6.0-next"
+        ; param_release= numbered_release "26.12.0-next"
         ; param_default= None
         }
       ; {
           param_type= Bool
         ; param_name= "force"
         ; param_doc= "Force the operation even if already in the desired state"
-        ; param_release= numbered_release "26.6.0-next"
+        ; param_release= numbered_release "26.12.0-next"
         ; param_default= Some (VBool false)
         }
       ]

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -665,7 +665,7 @@ let external_auth_set_ldaps =
     ~lifecycle:
       [
         ( Published
-        , "26.6.0-next"
+        , "26.12.0-next"
         , "This call enables or disables LDAPS for external authentication on \
            all hosts in the pool"
         )
@@ -676,21 +676,21 @@ let external_auth_set_ldaps =
           param_type= Ref _pool
         ; param_name= "pool"
         ; param_doc= "The pool whose LDAPS configuration should be set"
-        ; param_release= numbered_release "26.6.0-next"
+        ; param_release= numbered_release "26.12.0-next"
         ; param_default= None
         }
       ; {
           param_type= Bool
         ; param_name= "ldaps"
         ; param_doc= "Whether to enable or disable LDAPS"
-        ; param_release= numbered_release "26.6.0-next"
+        ; param_release= numbered_release "26.12.0-next"
         ; param_default= None
         }
       ; {
           param_type= Bool
         ; param_name= "force"
         ; param_doc= "Force the operation even if already in the desired state"
-        ; param_release= numbered_release "26.6.0-next"
+        ; param_release= numbered_release "26.12.0-next"
         ; param_default= Some (VBool false)
         }
       ]

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "2d8501063ef6b243facc24a3dbdc2a5d"
+let last_known_schema_hash = "46452a1b64f1a0af668f37c3b89e702a"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi/extauth_plugin_ADwinbind.ml
+++ b/ocaml/xapi/extauth_plugin_ADwinbind.ml
@@ -89,26 +89,29 @@ let tdb_tool = !Xapi_globs.tdb_tool
 
 let domain_krb5_dir = Filename.concat Xapi_globs.samba_dir "lock/smb_krb5"
 
-(* Legacy certificates folder *)
-let certs_dir = "/etc/stunnel/certs"
+let ca_bundle_for_purpose purpose =
+  Printf.sprintf "%s/%s-%s.pem" Constants.trusted_certs_by_purpose_dir
+    Constants.trusted_certs_root_prefix purpose
 
-let ldaps_ca_bundle = "/etc/trusted-certs/ca-bundle-ldaps.pem"
+let ldaps_ca_bundle = ca_bundle_for_purpose "ldaps"
 
-let general_ca_bundle = "/etc/trusted-certs/ca-bundle-general.pem"
+let general_ca_bundle = ca_bundle_for_purpose "general"
 
-(** Return the best available CA bundle/cert path, in priority order:
-    ldaps-specific bundle > general bundle > legacy certs dir.
+(** Return the best available CA bundle path, in priority order:
+    ldaps-specific bundle > general bundle.
     Returns [None] if none exist. *)
-
 let ca_bundle_path () =
-  [ldaps_ca_bundle; general_ca_bundle; certs_dir]
-  |> List.find_opt Sys.file_exists
+  [ldaps_ca_bundle; general_ca_bundle] |> List.find_opt Sys.file_exists
 
 let assert_ca_exists = function
   | true ->
       ca_bundle_path ()
       |> Option.to_result
-           ~none:(gen_ex E_NO_CERTS "No certs to setup TLS connection to DC")
+           ~none:
+             (gen_ex E_NO_CERTS
+                "No certs to setup TLS connection to DC. Note: ldaps does not \
+                 support non-CA certs"
+             )
       |> maybe_raise
       |> ignore
   | false ->


### PR DESCRIPTION
- Add `ldaps` as one of the trusted certs purpose
- Bump up `external_auth_set_ldaps` API version according to master
- Get trusted certs dir by consts instead of hardcode