### PR TITLE
stunnel: assign the tests to the package

### DIFF
--- a/ocaml/libs/stunnel/test/dune
+++ b/ocaml/libs/stunnel/test/dune
@@ -1,5 +1,6 @@
 (test
  (name test_stunnel_log_scanner)
+ (package stunnel)
  (libraries
   alcotest
   astring


### PR DESCRIPTION
Otherwise the tests are run as part of all the packages in the repository

This fixes the failures in xs-opam's CI