### PR TITLE
CA-426857: Should not apply live patches when RebootHost is mandatory

### DIFF
--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -841,6 +841,12 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
     =
   (* This function runs on coordinator host *)
   let open Guidance in
+  let livepatches =
+    if can_avoid_live_patching ~updates_info ~updates:acc_rpm_updates then
+      []
+    else
+      livepatches
+  in
   let guidance' =
     reduce_guidance ~updates_info ~updates:acc_rpm_updates ~livepatches
   in
@@ -862,7 +868,6 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
   Helpers.call_api_functions ~__context (fun rpc session_id ->
       Client.Client.Repository.apply ~rpc ~session_id ~host
   ) ;
-  (* Always apply livepatches even if host will reboot *)
   let applied_livepatches, failed_livepatches =
     apply_livepatches' ~__context ~host ~livepatches
   in

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -1303,6 +1303,11 @@ let reduce_guidance ~updates_info ~updates ~livepatches =
   |> GuidanceSet.reduce_cascaded_list
   |> List.map (fun (kind, s) -> (kind, GuidanceSet.elements s))
 
+(* Do not apply any live patches when RebootHost is in mandatory guidance. *)
+let can_avoid_live_patching ~updates_info ~updates =
+  eval_guidances ~updates_info ~updates ~kind:Mandatory ~livepatches:[]
+  |> GuidanceSet.mem RebootHost
+
 let consolidate_updates_of_host ~repository_name ~updates_info host
     updates_of_host =
   let latest_updates =
@@ -1334,7 +1339,11 @@ let consolidate_updates_of_host ~repository_name ~updates_info host
    * They are only to be returned in the update list.
    *)
   let livepatches =
-    retrieve_livepatches_from_updateinfo ~updates_info ~updates:updates_of_host
+    if can_avoid_live_patching ~updates_info ~updates then
+      []
+    else
+      retrieve_livepatches_from_updateinfo ~updates_info
+        ~updates:updates_of_host
   in
   let guidance = reduce_guidance ~updates_info ~updates ~livepatches in
   let upd_ids_of_livepatches, lps = merge_livepatches ~livepatches in


### PR DESCRIPTION
When RebootHost is in mandatory guidance, it's pointless to apply live patches as the host will be rebooted up soon. The guidance of live patches have no impact on the mandatory guidance due to the nature of live patches.