### PR TITLE
CA-427271: update non secureboot vm certificate state

### DIFF
--- a/ocaml/tests/test_xapi_db_upgrade.ml
+++ b/ocaml/tests/test_xapi_db_upgrade.ml
@@ -88,9 +88,35 @@ let remove_restricted_pbd_keys () =
     )
     other_keys
 
+let upgrade_secureboot_certificates_state_for_uefi_vm_without_secureboot () =
+  let __context = T.make_test_database () in
+  let vm =
+    T.make_vm ~__context ~name_label:"uefi-no-secureboot"
+      ~hVM_boot_params:[("firmware", "uefi")]
+      ~platform:[("secureboot", "false")]
+      ()
+  in
+  Db.VM.set_secureboot_certificates_state ~__context ~self:vm
+    ~value:`update_available ;
+  Alcotest.(check string)
+    "precondition: state starts as update_available" "update_available"
+    (Record_util.vm_secureboot_certificates_state_to_string
+       (Db.VM.get_secureboot_certificates_state ~__context ~self:vm)
+    ) ;
+  X.upgrade_secureboot_certificates_state.fn ~__context ;
+  Alcotest.(check string)
+    "UEFI VM without secureboot still gets checked" "ok"
+    (Record_util.vm_secureboot_certificates_state_to_string
+       (Db.VM.get_secureboot_certificates_state ~__context ~self:vm)
+    )
+
 let test =
   [
     ("upgrade_bios", `Quick, upgrade_bios)
   ; ("update_snapshots", `Quick, update_snapshots)
   ; ("remove_restricted_pbd_keys", `Quick, remove_restricted_pbd_keys)
+  ; ( "upgrade_secureboot_certificates_state_for_uefi_vm_without_secureboot"
+    , `Quick
+    , upgrade_secureboot_certificates_state_for_uefi_vm_without_secureboot
+    )
   ]

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -983,12 +983,7 @@ let upgrade_secureboot_certificates_state =
               let is_uefi =
                 List.assoc_opt "firmware" boot_params = Some "uefi"
               in
-              let platformdata = Db.VM.get_platform ~__context ~self in
-              let is_secureboot =
-                Vm_platform.is_true ~key:"secureboot" ~platformdata
-                  ~default:false
-              in
-              if is_uefi && is_secureboot then
+              if is_uefi then
                 let state =
                   ( Xapi_vm_helpers.check_secureboot_certificates_state
                       ~__context ~self


### PR DESCRIPTION
According to design doc, we treat non-secure-boot VM same as secure-boot VM, that is to say, the certificate and certificate state should be updated for non-secure-boot VM.