### PR TITLE
CA-427275: Fix coordinator fail to start after call emergency-ha-disable

### DIFF
--- a/ocaml/xapi-cli-server/xapi_cli.ml
+++ b/ocaml/xapi-cli-server/xapi_cli.ml
@@ -31,8 +31,12 @@ exception Unknown_command of string
     the HTTP request headers it has already received together with its active file descriptor.
     This way, the cli server can short-circuit API calls without having to go over the network. *)
 let rpc_fun :
-    (Http.Request.t -> Unix.file_descr -> Rpc.call -> Rpc.response) option ref =
+    (Http.Request.t -> Unix.file_descr option -> Rpc.call -> Rpc.response)
+    option
+    ref =
   ref None
+
+let register_rpc_fun rpc = rpc_fun := Some rpc
 
 let get_rpc () =
   match !rpc_fun with None -> failwith "No rpc set!" | Some f -> f
@@ -174,7 +178,7 @@ let do_rpcs req s username password minimal cmd session args =
     @@ fun span ->
     let req = Xmlrpc_client.xmlrpc ~version:"1.1" "/" in
     let req = TraceHelper.inject_span_into_req span req in
-    let rpc = generic_rpc req s in
+    let rpc = generic_rpc req (Some s) in
     if do_forward then
       with_session ~local:false rpc username password session (fun sess ->
           forward args s (Some sess)
@@ -248,7 +252,7 @@ let exec_command req cmd s session args =
     ; (is "pool-sync-updates", [is "token"])
     ]
   in
-  let rpc = get_rpc () req s in
+  let rpc = get_rpc () req (Some s) in
   Cli_frontend.populate_cmdtable rpc Ref.null ;
   (* Log the actual CLI command to help diagnose failures like CA-25516 *)
   let cmd_name = get_cmdname cmd in

--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -12,7 +12,7 @@ module Helper = struct
 end
 
 (* This bit is called directly by the fake_rpc callback *)
-let callback1 ?(json_rpc_version = Jsonrpc.V1) is_json req fd call =
+let callback1 ?(json_rpc_version = Jsonrpc.V1) is_json req fd_opt call =
   let@ req = Helper.with_tracing ~name:__FUNCTION__ req in
   (* We now have the body string, the xml and the call name, and can also tell *)
   (* if we're a master or slave and whether the call came in on the unix domain socket or the tcp socket *)
@@ -23,17 +23,10 @@ let callback1 ?(json_rpc_version = Jsonrpc.V1) is_json req fd call =
   let is_slave = not (Pool_role.is_master ()) in
   if !Xapi_globs.slave_emergency_mode && not emergency_call then
     raise !Xapi_globs.emergency_mode_error ;
-  if
-    is_slave
-    && ((Context.is_unix_socket fd && not whitelisted)
-       || (is_himn_req req && not emergency_call)
-       )
-  then
-    forward req call is_json
-  else
+  let dispatch req =
     let response =
       let@ req = Helper.with_tracing ~name:"Server.dispatch_call" req in
-      Server.dispatch_call req (Some fd) call
+      Server.dispatch_call req fd_opt call
     in
     let translated =
       if
@@ -58,6 +51,20 @@ let callback1 ?(json_rpc_version = Jsonrpc.V1) is_json req fd call =
         response
     in
     translated
+  in
+  match fd_opt with
+  | Some fd ->
+      if
+        is_slave
+        && ((Context.is_unix_socket fd && not whitelisted)
+           || (is_himn_req req && not emergency_call)
+           )
+      then
+        forward req call is_json
+      else
+        dispatch req
+  | _ ->
+      dispatch req
 
 (* debug(fmt "response = %s" response); *)
 
@@ -113,7 +120,7 @@ let callback is_json req fd _ =
       in
       Xmlrpc.call_of_string body
     in
-    let response = callback1 is_json req fd rpc in
+    let response = callback1 is_json req (Some fd) rpc in
     let response_str =
       let@ _ =
         Tracing.with_child_trace ~name:"Xmlrpc.string_of_response" span
@@ -163,7 +170,7 @@ let jsoncallback req fd _ =
     let json_rpc_version, id, rpc =
       Jsonrpc.version_id_and_call_of_string body
     in
-    let rpc_response = callback1 ~json_rpc_version true req fd rpc in
+    let rpc_response = callback1 ~json_rpc_version true req (Some fd) rpc in
     let response =
       Jsonrpc.string_of_response ~id ~version:json_rpc_version rpc_response
     in

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -430,7 +430,13 @@ end
 (** Once the server functor has been instantiated, xapi sets this reference to the appropriate
     "fake_rpc" (loopback non-HTTP) rpc function.
     This way, internally the coordinator can short-circuit API calls without having to go over the network. *)
-let rpc_fun : (Http.Request.t -> Rpc.call -> Rpc.response) option ref = ref None
+let rpc_fun :
+    (Http.Request.t -> Unix.file_descr option -> Rpc.call -> Rpc.response)
+    option
+    ref =
+  ref None
+
+let register_rpc_fun rpc = rpc_fun := Some rpc
 
 let choose_rpc () =
   let open Xmlrpc_client in
@@ -452,7 +458,7 @@ let make_rpc' ~subtask_of ?task_id ~__context rpc : Rpc.response =
   let http = TraceHelper.inject_span_into_req tracing http in
   match !rpc_fun with
   | Some rpcfun when Pool_role.is_master () ->
-      rpcfun http rpc
+      rpcfun http None rpc
   | _ ->
       let transport =
         if Pool_role.is_master () then

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -159,20 +159,12 @@ let random_setup () =
   finally (fun () -> really_input chan s 0 n) (fun () -> close_in chan) ;
   Random.full_init (Array.init n (fun i -> Char.code (Bytes.get s i)))
 
-let fake_rpc2 req rpc =
-  let emergency_call =
-    List.mem rpc.Rpc.name Api_server_common.emergency_call_list
-  in
-  if !Xapi_globs.slave_emergency_mode && not emergency_call then
-    raise !Xapi_globs.emergency_mode_error ;
-  Api_server.Server.dispatch_call req None rpc
-
 let register_callback_fns () =
-  let fake_rpc req sock xml : Rpc.response =
-    Api_server.callback1 false req sock xml
+  let fake_rpc req fd_opt call : Rpc.response =
+    Api_server.callback1 false req fd_opt call
   in
-  Xapi_cli.rpc_fun := Some fake_rpc ;
-  Helpers.rpc_fun := Some fake_rpc2 ;
+  Xapi_cli.register_rpc_fun fake_rpc ;
+  Helpers.register_rpc_fun fake_rpc ;
   Message_forwarding.register_callback_fns ()
 
 let noevents = ref false

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -519,6 +519,8 @@ let attempt_host_status_check_with_coordinator ~__context my_ip =
 let start_ha () =
   try Xapi_ha.on_server_restart ()
   with e ->
+    (* Try to clean slave_emergency_mode that on_server_restart may set *)
+    if Pool_role.is_master () then Xapi_globs.slave_emergency_mode := false ;
     (* Critical that we don't continue as a master and use shared resources *)
     debug "Caught exception starting HA system: %s" (ExnHelper.string_of_exn e)
 

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -159,7 +159,13 @@ let random_setup () =
   finally (fun () -> really_input chan s 0 n) (fun () -> close_in chan) ;
   Random.full_init (Array.init n (fun i -> Char.code (Bytes.get s i)))
 
-let fake_rpc2 req rpc = Api_server.Server.dispatch_call req None rpc
+let fake_rpc2 req rpc =
+  let emergency_call =
+    List.mem rpc.Rpc.name Api_server_common.emergency_call_list
+  in
+  if !Xapi_globs.slave_emergency_mode && not emergency_call then
+    raise !Xapi_globs.emergency_mode_error ;
+  Api_server.Server.dispatch_call req None rpc
 
 let register_callback_fns () =
   let fake_rpc req sock xml : Rpc.response =

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -1110,7 +1110,8 @@ let on_server_restart () =
           Helpers.touch_file !Xapi_globs.ready_file ;
           Thread.delay 10.
     done ;
-    if Pool_role.is_master () then
+    if Pool_role.is_master () then (
+      Xapi_globs.slave_emergency_mode := false ;
       if not (local_failover_decisions_are_ok ()) then (
         warn
           "ha.disable_failover_decisions flag set: not proposing myself as \
@@ -1119,7 +1120,8 @@ let on_server_restart () =
       ) else if propose_master () then
         info "ha_propose_master succeeded; continuing"
       else
-        on_master_failure () ;
+        on_master_failure ()
+    ) ;
     (* Start up the redo-log if appropriate. *)
     redo_log_ha_enabled_at_startup () ;
     debug "About to start the monitor" ;


### PR DESCRIPTION
When HA start failed due to like ha_cannot_access_statefile, it will set slave_emergency_mode and retry. User can call `host-emergency-ha-disable` to disable pool ha and go on. But the slave_emergency_mode is not cleaned.

Before commit 8aca0e62, the following XAPI start sequence will fail due to slave_emergency_mode and XAPI crash. System service restart XAPI with slave_emergency_mode unset (default value) and XAPI start successfully.

After 8aca0e62 (PR #6972), the short-circuit internal coordinator rpc by `fake_rpc2` will not check slave_emergency_mode, XAPI start complete but slave_emergency_mode is never cleaned on coordinator. Commands from outside will check slave_emergency_mode and fail with emergency_mode_error, see Api_server `callback1`.

In this PR, two fixes:
- Reuse fake_rpc to replace the new introduced fake_rpc2
- Clean slave_emergency_mode after leave xapi ha start loop