### PR TITLE
CA-426408: Consider chunks in task expiry calculation

### DIFF
--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -309,13 +309,11 @@ let rec atomic_expires_after = function
   | Serial (_, _, ops) ->
       List.map atomic_expires_after ops |> List.fold_left ( +. ) 0.
   | Parallel (_, _, ops) | Nested_parallel (_, _, ops) ->
-      let chunk_count =
-        (List.length ops + max_parallel_atoms - 1) / max_parallel_atoms
-      in
-      let per_chunk =
-        List.map atomic_expires_after ops |> List.fold_left Float.max 0.
-      in
-      per_chunk *. float_of_int chunk_count
+      let expires_of = List.map atomic_expires_after in
+      let max_of = List.fold_left Float.max 0. in
+      Xenops_utils.chunks max_parallel_atoms ops
+      |> List.map (fun ops -> ops |> expires_of |> max_of)
+      |> List.fold_left ( +. ) 0.
   | _ ->
       (* 20 minutes, in seconds *)
       1200.
@@ -2096,6 +2094,7 @@ and queue_atomics_and_wait ~progress_callback dbg id ops redirector =
         (fun (task, op) ->
           let task_id = Xenops_task.id_of_handle task in
           let expiration = atomic_expires_after op in
+          debug "Task %s expires_after=%f" task_id expiration ;
           let completion =
             event_wait updates task ~from ~timeout_start expiration
               (is_task task_id) task_ended

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -303,11 +303,19 @@ let rec name_of_atomic = function
   | Best_effort atomic ->
       Printf.sprintf "Best_effort (%s)" (name_of_atomic atomic)
 
+let max_parallel_atoms = 10
+
 let rec atomic_expires_after = function
   | Serial (_, _, ops) ->
       List.map atomic_expires_after ops |> List.fold_left ( +. ) 0.
   | Parallel (_, _, ops) | Nested_parallel (_, _, ops) ->
-      List.map atomic_expires_after ops |> List.fold_left Float.max 0.
+      let chunk_count =
+        (List.length ops + max_parallel_atoms - 1) / max_parallel_atoms
+      in
+      let per_chunk =
+        List.map atomic_expires_after ops |> List.fold_left Float.max 0.
+      in
+      per_chunk *. float_of_int chunk_count
   | _ ->
       (* 20 minutes, in seconds *)
       1200.
@@ -2010,8 +2018,8 @@ and parallel_atomic ~progress_callback ~description ~nested atoms t =
   let with_tracing = id_with_tracing parallel_id t in
   debug "begin_%s" parallel_id ;
   let task_list =
-    queue_atomics_and_wait ~progress_callback ~max_parallel_atoms:10
-      with_tracing parallel_id atoms redirector
+    queue_atomics_and_wait ~progress_callback with_tracing parallel_id atoms
+      redirector
   in
   debug "end_%s" parallel_id ;
   (* make sure that we destroy all the parallel tasks that finished *)
@@ -2067,8 +2075,7 @@ and queue_atomic_int ~progress_callback dbg id op redirector =
   Redirector.push redirector id item ;
   task
 
-and queue_atomics_and_wait ~progress_callback ~max_parallel_atoms dbg id ops
-    redirector =
+and queue_atomics_and_wait ~progress_callback dbg id ops redirector =
   let from = Updates.last_id dbg updates in
   Xenops_utils.chunks max_parallel_atoms ops
   |> List.mapi (fun chunk_idx ops ->


### PR DESCRIPTION
A test of VM with 239 VBDs (1 system disk + 238 iSCSI VBDs) fails because of `Timed out while waiting on task xxx`. In the fail task:
```
VM.start (task 61)
  → perform_atomics([..., Parallel("Devices.plug"), ...])
    → perform_atomic(Parallel("Devices.plug"))
      ↓
      Parallel:task=61.atoms=2.(Devices.plug (no qemu))
      │
      │ queue_atomics_and_wait(ops=[atom0, atom1])
      │   expiration(atom0) = atomic_expires_after(Nested_parallel(239))
      │                     = Float.max(3600, ...) = 3600s  ← BUG
      │   event_wait(task=79, timeout=3600s)
      │
      ├─ task 79 (worker): Nested_parallel:task=79.atoms=239.(VBDs.activate_epoch_and_plug RW)
      │    │
      │    │ queue_atomics_and_wait(239 ops, chunks of 10)
      │    ├─ chunk 0:  10 × Serial(VBD_set_active, VBD_epoch_begin, VBD_plug)
      │    ├─ chunk 1:  10 × ...
      │    ├─ ...
      │    └─ chunk 23:  9 × ...
      │    └─ total: 82 minutes
      │
      └─ task 80 (worker): Serial(VIF_set_active, VIF_plug)
```
The task expiry calculation for parallel and nested_parallel doesn't consider the multi chunks. Just get the max expiry in the parallel task list. In fact the parallel task split to 24 chunks to run.