### PR TITLE
CA-427441: Avoid using proxy for local repositories

### DIFF
--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -446,8 +446,8 @@ let with_local_repositories ~__context f =
                   s
             in
             remove_repo_conf_file repo_name ;
-            write_yum_config ~proxy_config:[] ~source_url:None ~binary_url
-              ~repo_gpgcheck:false ~gpgkey_path ~repo_name ;
+            write_yum_config ~proxy_config:["proxy="] ~source_url:None
+              ~binary_url ~repo_gpgcheck:false ~gpgkey_path ~repo_name ;
             clean_yum_cache repo_name ;
             let Pkg_mgr.{cmd; params} =
               [


### PR DESCRIPTION
If you have a global proxy set in `/etc/dnf/dnf.conf` local repositories (pointing to `http://127.0.0.1 ...`) are not working.
A proxy should not be used for such repositories.