### PR TITLE
CA-406020: parse dnf5 output in pool_update plugins

### DIFF
--- a/python3/extensions/pool_update.apply
+++ b/python3/extensions/pool_update.apply
@@ -4,7 +4,6 @@
 import errno
 import logging
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -14,17 +13,6 @@ import fasteners
 import xcp.logger
 import XenAPI
 
-TMP_DIR = "/tmp/"
-UPDATE_ALREADY_APPLIED = "UPDATE_ALREADY_APPLIED"
-UPDATE_APPLY_FAILED = "UPDATE_APPLY_FAILED"
-OTHER_OPERATION_IN_PROGRESS = "OTHER_OPERATION_IN_PROGRESS"
-UPDATE_PRECHECK_FAILED_UNKNOWN_ERROR = "UPDATE_PRECHECK_FAILED_UNKNOWN_ERROR"
-CANNOT_FIND_UPDATE = "CANNOT_FIND_UPDATE"
-INVALID_UPDATE = "INVALID_UPDATE"
-ERROR_MESSAGE_DOWNLOAD_PACKAGE = "Error downloading packages:\n"
-ERROR_MESSAGE_START = "Error: "
-ERROR_MESSAGE_END = "You could try "
-
 TMP_DIR = '/tmp/'
 UPDATE_ALREADY_APPLIED = 'UPDATE_ALREADY_APPLIED'
 UPDATE_APPLY_FAILED = 'UPDATE_APPLY_FAILED'
@@ -32,12 +20,9 @@ OTHER_OPERATION_IN_PROGRESS = 'OTHER_OPERATION_IN_PROGRESS'
 UPDATE_PRECHECK_FAILED_UNKNOWN_ERROR = 'UPDATE_PRECHECK_FAILED_UNKNOWN_ERROR'
 CANNOT_FIND_UPDATE = 'CANNOT_FIND_UPDATE'
 INVALID_UPDATE = 'INVALID_UPDATE'
-ERROR_MESSAGE_DOWNLOAD_PACKAGE = 'Error downloading packages:\n'
-ERROR_MESSAGE_START = 'Error: '
-ERROR_MESSAGE_END = 'You could try '
-YUM_CMD = '/usr/bin/yum'
+ERROR_MESSAGE_DOWNLOAD_PACKAGE = 'Failed to download packages'
 DNF_CMD = '/usr/bin/dnf'
-PKG_MGR = DNF_CMD if os.path.exists(DNF_CMD) else YUM_CMD
+PKG_MGR = DNF_CMD
 
 class EnvironmentFailure(Exception):
     """Failure due to running environment"""
@@ -81,10 +66,8 @@ def execute_apply(update_package, yum_conf_file):
     if p.returncode != 0:
         raise EnvironmentFailure("Error cleaning yum cache")
 
-    # dnf reject to upgrade group if it is not installed,
-    # `dnf install` upgrade the group if it is already installed
-    sub_cmd = 'upgrade' if PKG_MGR == YUM_CMD else 'install'
-    cmd = [PKG_MGR, sub_cmd, '-y', '--noplugins', '-c', yum_conf_file, update_package]
+    # `dnf install` upgrades the group if it is already installed.
+    cmd = [PKG_MGR, 'install', '-y', '--noplugins', '-c', yum_conf_file, update_package]
     p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                          close_fds=True, env=yum_env, universal_newlines=True)
     output, _ = p.communicate()
@@ -94,12 +77,6 @@ def execute_apply(update_package, yum_conf_file):
     if p.returncode != 0:
         if ERROR_MESSAGE_DOWNLOAD_PACKAGE in output:
             raise InvalidUpdate("Missing package(s) in the update.")
-
-        m = re.search("(?<=" + ERROR_MESSAGE_START + ").+$", output, flags=re.DOTALL)
-        if m:
-            errmsg = m.group()
-            errmsg = re.sub(ERROR_MESSAGE_END + ".+", "", errmsg, flags=re.DOTALL)
-            raise ApplyFailure(errmsg)
         raise ApplyFailure(output)
 
 

--- a/python3/extensions/pool_update.precheck
+++ b/python3/extensions/pool_update.precheck
@@ -134,6 +134,70 @@ def parse_precheck_failure(xmldoc):
         raise PrecheckError(code, *params)
     raise PrecheckFailure(xmldoc.toxml())
 
+
+def classify_dnf_failure(output):
+    """Classify a failed `dnf install` output into a precheck exception.
+
+    Always raises; the caller is responsible for the fallback when none
+    of the known patterns match (in which case this function simply
+    returns and the caller raises PrecheckFailure(output)).
+    """
+    if ERROR_MESSAGE_DOWNLOAD_PACKAGE in output:
+        raise InvalidUpdate('Missing package(s) in the update')
+
+    # GPG patterns must only be matched when dnf5 never reached the solver.
+    # Librepo prints transient messages like
+    #   ">>> Librepo error: repomd.xml GPG signature verification error: ..."
+    # before auto-importing keys; those appear even on successful runs and
+    # also precede genuine resolution failures. If a "Failed to resolve"
+    # block is present, the real error is there, not in the GPG noise.
+    if (ERROR_MESSAGE_FAILED_TO_RESOLVE not in output
+            and any(pat in output
+                    for pat in ERROR_MESSAGE_GPGKEY_NOT_IMPORTED_PATTERNS)):
+        raise GpgkeyNotImported()
+
+    if PATCH_PRECHECK_FAILED_ISO_MOUNTED in output:
+        raise IsoMounted
+
+    if PATCH_PRECHECK_FAILED_VM_RUNNING in output:
+        raise VmRunning
+
+    m = re.search(ERROR_MESSAGE_FAILED_TO_RESOLVE + '(.+)$',
+                  output, flags=re.DOTALL)
+    if m:
+        errmsg = m.group(1)
+        errmsg = re.sub(ERROR_MESSAGE_END + '.+', '', errmsg, flags=re.DOTALL)
+        if ERROR_MESSAGE_CONFLICTS_WITH in errmsg:
+            conflicts = re.findall(
+                ERROR_MESSAGE_CONFLICTS_WITH + r'(\S+)', errmsg)
+            if conflicts:
+                raise ConflictPresent(' '.join(conflicts))
+            raise PrecheckFailure(errmsg)
+        wrong_version = re.search(
+            ERROR_MESSAGE_NOTHING_PROVIDES
+            + r'(\S+\s*[<>=]+\s*\S+) needed by (\S+)', errmsg)
+        if wrong_version:
+            required = wrong_version.group(1).strip()
+            installed = wrong_version.group(2).strip()
+            raise WrongServerVersion(required, installed)
+        prerequisites = re.findall(
+            ERROR_MESSAGE_NOTHING_PROVIDES + r'(.+?)(?: needed by | from |\n)',
+            errmsg)
+        prerequisites += re.findall(
+            ERROR_MESSAGE_REQUIRES + r'(.+?), but none of', errmsg)
+        if prerequisites:
+            raise PrerequisiteMissing(' '.join(prerequisites))
+        raise PrecheckFailure(errmsg)
+
+    regex = ERROR_XML_START + '.+' + ERROR_XML_END
+    m = re.search(regex, output, flags=re.DOTALL)
+    if m:
+        try:
+            xmldoc = xml.dom.minidom.parseString(m.group(0))
+        except Exception as e:
+            raise PrecheckFailure(output) from e
+        parse_precheck_failure(xmldoc)
+
 def execute_precheck(control_package, yum_conf_file, update_precheck_file):
     #pylint: disable=too-many-locals
     #pylint: disable=too-many-branches
@@ -164,61 +228,9 @@ def execute_precheck(control_package, yum_conf_file, update_precheck_file):
     for line in output.split('\n'):
         xcp.logger.info(line)
     if p.returncode != 0:
-        if ERROR_MESSAGE_DOWNLOAD_PACKAGE in output:
-            raise InvalidUpdate('Missing package(s) in the update')
-
-        # GPG patterns must only be matched when dnf5 never reached the solver.
-        # Librepo prints transient messages like
-        #   ">>> Librepo error: repomd.xml GPG signature verification error: ..."
-        # before auto-importing keys; those appear even on successful runs and
-        # also precede genuine resolution failures. If a "Failed to resolve"
-        # block is present, the real error is there, not in the GPG noise.
-        if (ERROR_MESSAGE_FAILED_TO_RESOLVE not in output
-                and any(pat in output
-                        for pat in ERROR_MESSAGE_GPGKEY_NOT_IMPORTED_PATTERNS)):
-            raise GpgkeyNotImported()
-
-        if PATCH_PRECHECK_FAILED_ISO_MOUNTED in output:
-            raise IsoMounted
-
-        if PATCH_PRECHECK_FAILED_VM_RUNNING in output:
-            raise VmRunning
-
-        m = re.search(ERROR_MESSAGE_FAILED_TO_RESOLVE + '(.+)$',
-                      output, flags=re.DOTALL)
-        if m:
-            errmsg = m.group(1)
-            errmsg = re.sub(ERROR_MESSAGE_END + '.+', '', errmsg, flags=re.DOTALL)
-            if ERROR_MESSAGE_CONFLICTS_WITH in errmsg:
-                conflicts = re.findall(
-                    ERROR_MESSAGE_CONFLICTS_WITH + r'(\S+)', errmsg)
-                if conflicts:
-                    raise ConflictPresent(' '.join(conflicts))
-                raise PrecheckFailure(errmsg)
-            wrong_version = re.search(
-                ERROR_MESSAGE_NOTHING_PROVIDES
-                + r'(\S+\s*[<>=]+\s*\S+) needed by (\S+)', errmsg)
-            if wrong_version:
-                required = wrong_version.group(1).strip()
-                installed = wrong_version.group(2).strip()
-                raise WrongServerVersion(required, installed)
-            prerequisites = re.findall(
-                ERROR_MESSAGE_NOTHING_PROVIDES + r'(.+?)(?: needed by | from |\n)',
-                errmsg)
-            prerequisites += re.findall(
-                ERROR_MESSAGE_REQUIRES + r'(.+?), but none of', errmsg)
-            if prerequisites:
-                raise PrerequisiteMissing(' '.join(prerequisites))
-            raise PrecheckFailure(errmsg)
-
-        regex = ERROR_XML_START + '.+' + ERROR_XML_END
-        m = re.search(regex, output, flags=re.DOTALL)
-        if m:
-            try:
-                xmldoc = xml.dom.minidom.parseString(m.group(0))
-            except Exception as e:
-                raise PrecheckFailure(output) from e
-            parse_precheck_failure(xmldoc)
+        classify_dnf_failure(output)
+        # classify_dnf_failure raises in every case it understands; if we get
+        # here it didn't match any pattern, so surface the raw dnf output.
         raise PrecheckFailure(output)
 
     if os.path.isfile(update_precheck_file):

--- a/python3/extensions/pool_update.precheck
+++ b/python3/extensions/pool_update.precheck
@@ -31,17 +31,19 @@ PATCH_PRECHECK_FAILED_ISO_MOUNTED = 'PATCH_PRECHECK_FAILED_ISO_MOUNTED'
 PATCH_PRECHECK_FAILED_VM_RUNNING = 'PATCH_PRECHECK_FAILED_VM_RUNNING'
 INVALID_UPDATE = 'INVALID_UPDATE'
 CANNOT_FIND_UPDATE = 'CANNOT_FIND_UPDATE'
-ERROR_MESSAGE_START = 'Error: '
-ERROR_MESSAGE_END = 'You could try '
+ERROR_MESSAGE_FAILED_TO_RESOLVE = 'Failed to resolve the transaction:\n'
+ERROR_MESSAGE_END = 'You can try to add to command line:'
 ERROR_MESSAGE_CONFLICTS_WITH = ' conflicts with '
-ERROR_MESSAGE_CONFLICTS = 'conflicts '
-ERROR_MESSAGE_PROCESSING_CONFLICT = '--> Processing Conflict:'
-ERROR_MESSAGE_PREREQUISITE = 'Requires: '
-ERROR_MESSAGE_VERSION_REQUIRED = 'Requires: '
-ERROR_MESSAGE_VERSION_INSTALLED = 'Installed: '
-ERROR_MESSAGE_VERSION_UPDATED_BY = 'Updated By: '
-ERROR_MESSAGE_DOWNLOAD_PACKAGE = 'Error downloading packages:\n'
-ERROR_MESSAGE_GPGKEY_NOT_IMPORTED = 'Gpg Keys not imported'
+ERROR_MESSAGE_NOTHING_PROVIDES = 'nothing provides '
+ERROR_MESSAGE_REQUIRES = ' requires '
+ERROR_MESSAGE_DOWNLOAD_PACKAGE = 'Failed to download packages'
+ERROR_MESSAGE_GPGKEY_NOT_IMPORTED_PATTERNS = (
+    'Signature verification failed.',
+    'Public key is not installed.',
+    'Public key import failed.',
+    'The package is not signed.',
+    'GPG signature verification error',
+)
 ERROR_XML_START = '<error errorcode='
 ERROR_XML_END = '</error>'
 ERRORCODE = 'errorcode'
@@ -165,7 +167,15 @@ def execute_precheck(control_package, yum_conf_file, update_precheck_file):
         if ERROR_MESSAGE_DOWNLOAD_PACKAGE in output:
             raise InvalidUpdate('Missing package(s) in the update')
 
-        if ERROR_MESSAGE_GPGKEY_NOT_IMPORTED in output:
+        # GPG patterns must only be matched when dnf5 never reached the solver.
+        # Librepo prints transient messages like
+        #   ">>> Librepo error: repomd.xml GPG signature verification error: ..."
+        # before auto-importing keys; those appear even on successful runs and
+        # also precede genuine resolution failures. If a "Failed to resolve"
+        # block is present, the real error is there, not in the GPG noise.
+        if (ERROR_MESSAGE_FAILED_TO_RESOLVE not in output
+                and any(pat in output
+                        for pat in ERROR_MESSAGE_GPGKEY_NOT_IMPORTED_PATTERNS)):
             raise GpgkeyNotImported()
 
         if PATCH_PRECHECK_FAILED_ISO_MOUNTED in output:
@@ -174,34 +184,31 @@ def execute_precheck(control_package, yum_conf_file, update_precheck_file):
         if PATCH_PRECHECK_FAILED_VM_RUNNING in output:
             raise VmRunning
 
-        m = re.search('(?<=' + ERROR_MESSAGE_START + ').+$', output, flags=re.DOTALL)
+        m = re.search(ERROR_MESSAGE_FAILED_TO_RESOLVE + '(.+)$',
+                      output, flags=re.DOTALL)
         if m:
-            errmsg = m.group()
+            errmsg = m.group(1)
             errmsg = re.sub(ERROR_MESSAGE_END + '.+', '', errmsg, flags=re.DOTALL)
-            if (ERROR_MESSAGE_CONFLICTS_WITH in errmsg and
-                ERROR_MESSAGE_PROCESSING_CONFLICT in output):
-                regex = (ERROR_MESSAGE_PROCESSING_CONFLICT + '(.*)'
-                         + ERROR_MESSAGE_CONFLICTS + '(.+?)\n')
-                conflict_tuples = re.findall(regex, output)
-                if conflict_tuples:
-                    raise ConflictPresent(' '.join([tup[1] for tup in conflict_tuples]))
+            if ERROR_MESSAGE_CONFLICTS_WITH in errmsg:
+                conflicts = re.findall(
+                    ERROR_MESSAGE_CONFLICTS_WITH + r'(\S+)', errmsg)
+                if conflicts:
+                    raise ConflictPresent(' '.join(conflicts))
                 raise PrecheckFailure(errmsg)
-            if (ERROR_MESSAGE_VERSION_REQUIRED in errmsg and
-                (ERROR_MESSAGE_VERSION_INSTALLED in errmsg
-                 or ERROR_MESSAGE_VERSION_UPDATED_BY in errmsg)):
-                regex = ERROR_MESSAGE_VERSION_REQUIRED + '(.+?)\n.+ {2,2}(.+)$'
-                match = re.search(regex, errmsg, flags=re.DOTALL)
-                if match:
-                    required_version = match.group(1).rstrip()
-                    installed_version = match.group(2).rstrip()
-                    raise WrongServerVersion(required_version, installed_version)
-                raise PrecheckFailure(errmsg)
-            if ERROR_MESSAGE_PREREQUISITE in errmsg:
-                regex = ERROR_MESSAGE_PREREQUISITE + '(.+?)\n'
-                prerequisite_list = re.findall(regex, errmsg)
-                if prerequisite_list:
-                    raise PrerequisiteMissing(' '.join(prerequisite_list))
-                raise PrecheckFailure(errmsg)
+            wrong_version = re.search(
+                ERROR_MESSAGE_NOTHING_PROVIDES
+                + r'(\S+\s*[<>=]+\s*\S+) needed by (\S+)', errmsg)
+            if wrong_version:
+                required = wrong_version.group(1).strip()
+                installed = wrong_version.group(2).strip()
+                raise WrongServerVersion(required, installed)
+            prerequisites = re.findall(
+                ERROR_MESSAGE_NOTHING_PROVIDES + r'(.+?)(?: needed by | from |\n)',
+                errmsg)
+            prerequisites += re.findall(
+                ERROR_MESSAGE_REQUIRES + r'(.+?), but none of', errmsg)
+            if prerequisites:
+                raise PrerequisiteMissing(' '.join(prerequisites))
             raise PrecheckFailure(errmsg)
 
         regex = ERROR_XML_START + '.+' + ERROR_XML_END

--- a/python3/tests/test_pool_update_precheck.py
+++ b/python3/tests/test_pool_update_precheck.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the dnf5 output parser in pool_update.precheck.
+"""
+
+import unittest
+
+from python3.tests.import_helper import import_file_as_module, mocked_modules
+
+with mocked_modules("XenAPI", "xcp", "xcp.logger"):
+    precheck = import_file_as_module("python3/extensions/pool_update.precheck")
+
+
+# ---------------------------------------------------------------------------
+# Captured dnf5 outputs (real, not synthesised)
+# ---------------------------------------------------------------------------
+
+CONFLICT = """\
+Updating and loading repositories:
+Repositories loaded.
+Failed to resolve the transaction:
+Problem: installed package xs-host-1.0-1.noarch conflicts with xs-host provided by xs-conflict-1.0-1.noarch from testrepo
+  - problem with installed package
+  - conflicting requests
+  - nothing provides xs-platform >= 2.0 needed by xs-host-2.0-1.noarch from testrepo
+You can try to add to command line:
+  --skip-broken to skip uninstallable packages
+"""
+
+WRONG_VERSION = """\
+Updating and loading repositories:
+ testrepo                               100% |  75.3 KiB/s |   3.4 KiB |  00m00s
+Repositories loaded.
+Failed to resolve the transaction:
+Package "xs-host-1.0-1.noarch" is already installed.
+Problem: cannot install the best candidate for the job
+  - nothing provides xs-platform >= 2.0 needed by xs-host-2.0-1.noarch from testrepo
+You can try to add to command line:
+  --no-best to not limit the transaction to the best candidates
+  --skip-broken to skip uninstallable packages
+"""
+
+PREREQ_MISSING = """\
+Updating and loading repositories:
+Repositories loaded.
+Failed to resolve the transaction:
+Problem: conflicting requests
+  - nothing provides missing-lib needed by xs-prereq-1.0-1.noarch from testrepo
+You can try to add to command line:
+  --skip-broken to skip uninstallable packages
+"""
+
+NONEXISTENT = """\
+Updating and loading repositories:
+Repositories loaded.
+Failed to resolve the transaction:
+No match for argument: no-such-pkg-xyz
+You can try to add to command line:
+  --skip-unavailable to skip unavailable packages
+"""
+
+# Librepo emits "GPG signature verification error" on first access to a repo
+# whose key is not yet trusted, before dnf5 auto-imports the key. The same
+# line therefore also appears in front of unrelated solver failures, so the
+# precheck plugin must only raise GpgkeyNotImported when no "Failed to
+# resolve" block follows. The two fixtures below are condensed XenRT
+# captures (jobs 31109885 / 31109895) used to exercise that gate.
+
+LIBREPO_GPG_THEN_PREREQ = """\
+Updating and loading repositories:
+>>> Librepo error: repomd.xml GPG signature verification error: Bad GPG signature
+Importing PGP key 0xDEADBEEF:
+ UserID     : "XenServer Updates <security@xenserver.com>"
+Key imported.
+Repositories loaded.
+Failed to resolve the transaction:
+Problem: conflicting requests
+  - nothing provides update-test-hotfix-basic-1 needed by test-hotfix-depend-1-1.0-1.noarch from updates
+You can try to add to command line:
+  --skip-broken to skip uninstallable packages
+"""
+
+LIBREPO_GPG_THEN_WRONG_VERSION = """\
+Updating and loading repositories:
+>>> Librepo error: repomd.xml GPG signature verification error: Bad GPG signature
+Importing PGP key 0xDEADBEEF:
+Key imported.
+Repositories loaded.
+Failed to resolve the transaction:
+Problem: cannot install the best candidate for the job
+  - nothing provides platform-version = 0.73.2 needed by control-test-hotfix-basic-4-1.0-1.noarch from updates
+You can try to add to command line:
+  --no-best to not limit the transaction to the best candidates
+"""
+
+
+class TestDnf5OutputParser(unittest.TestCase):
+    """Parser tests against captured dnf5 5.2.12 output."""
+
+    def test_conflict(self):
+        with self.assertRaises(precheck.ConflictPresent) as ctx:
+            precheck.classify_dnf_failure(CONFLICT)
+        # First "conflicts with" token in the captured output.
+        self.assertIn("xs-host", ctx.exception.args[0])
+
+    def test_wrong_server_version(self):
+        with self.assertRaises(precheck.WrongServerVersion) as ctx:
+            precheck.classify_dnf_failure(WRONG_VERSION)
+        self.assertEqual(
+            ctx.exception.args,
+            ("xs-platform >= 2.0", "xs-host-2.0-1.noarch"),
+        )
+
+    def test_prerequisite_missing(self):
+        with self.assertRaises(precheck.PrerequisiteMissing) as ctx:
+            precheck.classify_dnf_failure(PREREQ_MISSING)
+        self.assertEqual(ctx.exception.args, ("missing-lib",))
+
+    def test_nonexistent_package_falls_through(self):
+        # No conflict / nothing-provides / requires pattern: classifier
+        # raises PrecheckFailure with the cleaned errmsg.
+        with self.assertRaises(precheck.PrecheckFailure) as ctx:
+            precheck.classify_dnf_failure(NONEXISTENT)
+        self.assertIn("No match for argument: no-such-pkg-xyz",
+                      ctx.exception.args[0])
+
+    def test_download_failure_short_circuits(self):
+        output = "Some preamble\nFailed to download packages\nmore noise\n"
+        with self.assertRaises(precheck.InvalidUpdate):
+            precheck.classify_dnf_failure(output)
+
+    def test_gpgkey_patterns_short_circuit(self):
+        # Each GPG marker alone (no "Failed to resolve" block) must classify
+        # as GpgkeyNotImported.
+        for pattern in precheck.ERROR_MESSAGE_GPGKEY_NOT_IMPORTED_PATTERNS:
+            with self.subTest(pattern=pattern):
+                with self.assertRaises(precheck.GpgkeyNotImported):
+                    precheck.classify_dnf_failure("preamble\n" + pattern + "\n")
+
+    def test_librepo_gpg_noise_does_not_mask_prereq(self):
+        """Regression for XenRT 31109885 / 31109895.
+
+        Librepo prints a transient GPG verification error before dnf5
+        auto-imports the repo key; the run then fails at the solver stage
+        for an unrelated reason. The plugin must surface the real reason
+        (PrerequisiteMissing here) rather than GpgkeyNotImported.
+        """
+        with self.assertRaises(precheck.PrerequisiteMissing) as ctx:
+            precheck.classify_dnf_failure(LIBREPO_GPG_THEN_PREREQ)
+        self.assertEqual(
+            ctx.exception.args, ("update-test-hotfix-basic-1",),
+        )
+
+    def test_librepo_gpg_noise_does_not_mask_wrong_version(self):
+        """Same regression, wrong-version variant."""
+        with self.assertRaises(precheck.WrongServerVersion) as ctx:
+            precheck.classify_dnf_failure(LIBREPO_GPG_THEN_WRONG_VERSION)
+        self.assertEqual(
+            ctx.exception.args,
+            ("platform-version = 0.73.2",
+             "control-test-hotfix-basic-4-1.0-1.noarch"),
+        )
+
+    def test_iso_mounted(self):
+        output = "noise\n" + precheck.PATCH_PRECHECK_FAILED_ISO_MOUNTED + "\n"
+        with self.assertRaises(precheck.IsoMounted):
+            precheck.classify_dnf_failure(output)
+
+    def test_vm_running(self):
+        output = "noise\n" + precheck.PATCH_PRECHECK_FAILED_VM_RUNNING + "\n"
+        with self.assertRaises(precheck.VmRunning):
+            precheck.classify_dnf_failure(output)
+
+    def test_unrecognised_output_returns_silently(self):
+        # When the output matches none of the patterns the classifier just
+        # returns; execute_precheck then raises PrecheckFailure(output).
+        self.assertIsNone(precheck.classify_dnf_failure("totally unrelated\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
dnf was upgraded to dnf5, which prints transaction errors in a new format. The existing parsers in pool_update.precheck and pool_update.apply were written against dnf4 and silently fell through to a generic "unknown error" for every failure mode, hiding the real reason from XAPI.


Tested and passed:
4648126 updatenegative.seq
4648212 supppackduringhostinstall.seq
4648128 supppackduringhostupgrade.seq

Also did manual tests for typical dnf5 transaction errors (conflict, non-existent pacakge, missing provides)