### PR TITLE
CP-310388: Change name used for temporary files during exports.

### DIFF
--- a/ocaml/sdk-gen/csharp/autogen/src/HTTP.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/HTTP.cs
@@ -817,20 +817,17 @@ namespace XenAPI
             if (string.IsNullOrWhiteSpace(path))
                 throw new ArgumentException(nameof(path));
 
-            var tmpFile = Path.GetTempFileName();
+            var dir = Path.GetDirectoryName(path);
+            if (dir == null) //path is root directory
+                throw new ArgumentException(nameof(path));
 
-            if (Path.GetPathRoot(path) != Path.GetPathRoot(tmpFile))
+            var filename = Path.GetFileNameWithoutExtension(path);
+            string tmpFile = Path.Combine(dir, $"{filename}.part");
+
+            while (File.Exists(tmpFile))
             {
-                //CA-365905: if the target path is under a root different from
-                //the temp file, use instead a temp file under the target root,
-                //otherwise there may not be enough space for the download
-
-                var dir = Path.GetDirectoryName(path);
-                if (dir == null) //path is root directory
-                    throw new ArgumentException(nameof(path));
-
-                tmpFile = Path.Combine(dir, Path.GetRandomFileName());
-                File.Delete(tmpFile);
+                var random = Path.GetExtension(Path.GetRandomFileName());
+                tmpFile = Path.Combine(dir, $"{filename}{random}");
             }
 
             try


### PR DESCRIPTION
Also:  place the temporary file in the target folder in all cases and not only when the latter is under a different root from the client application,