### PR TITLE
CP-311530 Bump up api_version to 2.23

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -58,7 +58,7 @@ let args =
   ; flag "yumpluginconfdir" ~doc:"DIR YUM plugins conf dir"
       ~default:"/etc/yum/pluginconf.d"
   ; flag "xapi_api_version_major" ~doc:"xapi api major version" ~default:"2"
-  ; flag "xapi_api_version_minor" ~doc:"xapi api minor version" ~default:"21"
+  ; flag "xapi_api_version_minor" ~doc:"xapi api minor version" ~default:"23"
   ]
   |> Arg.align
 

--- a/ocaml/idl/api_version.ml
+++ b/ocaml/idl/api_version.ml
@@ -18,4 +18,4 @@
 
 let api_version_major = 2L
 
-let api_version_minor = 21L
+let api_version_minor = 23L

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -101,6 +101,8 @@ let rel_nile_preview = "nile-preview"
 
 let rel_nile = "nile"
 
+let rel_orinoco = "orinoco"
+
 type api_release = {
     code_name: string option
   ; version_major: int
@@ -350,6 +352,13 @@ let release_order_full =
     ; version_major= 2
     ; version_minor= 21
     ; branding= "XenServer 8"
+    ; release_date= None
+    }
+  ; {
+      code_name= Some rel_orinoco
+    ; version_major= 2
+    ; version_minor= 23
+    ; branding= "XenServer 9"
     ; release_date= None
     }
   ]

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "19eb067e98133189f1dc2c55f7ccec70"
+let last_known_schema_hash = "fe75fa03d7ce97f9e51426bfb9b078fe"
 
 let current_schema_hash : string =
   let open Datamodel_types in


### PR DESCRIPTION
The api_version is actually rewriten by flag passed by `--xapi_api_version_minor`. Here bump up the value for local build. Also add new version to `release_order_full` for sdk generate.