### PR TITLE
CA-427607: Report no_support_encrypt_type error

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -879,6 +879,13 @@ let _ =
       "The pool failed to enable external authentication, no trusted \
        certificates."
     () ;
+  error Api_errors.pool_auth_enable_failed_no_supp_encrypt_type
+    ["host"; "message"]
+    ~doc:
+      "The pool failed to enable external authentication: domain does not \
+       support encryption type, make sure AES based encryption type is enabled \
+       in kerberos authentication in AD and Administrator is not in use"
+    () ;
   error Api_errors.pool_auth_enable_failed_setup_tls_connection
     ["host"; "message"]
     ~doc:

--- a/ocaml/tests/test_extauth_plugin_ADwinbind.ml
+++ b/ocaml/tests/test_extauth_plugin_ADwinbind.ml
@@ -96,6 +96,8 @@ module Errtag = Generic.MakeStateless (struct
           "E_NO_TRUSTED_CERTS"
       | E_FAILED_SETUP_TLS_CONNECTION ->
           "E_FAILED_SETUP_TLS_CONNECTION"
+      | E_NO_SUPPORT_ENCRYPT_TYPE ->
+          "E_NO_SUPPORT_ENCRYPT_TYPE"
   end
 
   let transform = Extauth_plugin_ADwinbind.tag_from_err_msg

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1048,6 +1048,8 @@ let auth_suffix_no_trusted_certs = "_NO_TRUSTED_CERTS"
 
 let auth_suffix_setup_tls_connection = "_SETUP_TLS_CONNECTION"
 
+let auth_suffix_no_support_encrypt_type = "_NO_SUPPORT_ENCRYPT_TYPE"
+
 let auth_setup_tls_connection = add_error "AUTH_SETUP_TLS_CONNECTION"
 
 let auth_enable_failed = add_error "AUTH_ENABLE_FAILED"
@@ -1075,6 +1077,9 @@ let auth_enable_failed_invalid_trusted_certs =
 
 let auth_enable_failed_no_trusted_certs =
   add_error $ auth_enable_failed ^ auth_suffix_no_trusted_certs
+
+let auth_enable_failed_no_supp_encrypt_type =
+  add_error $ auth_enable_failed ^ auth_suffix_no_support_encrypt_type
 
 let auth_disable_failed = add_error "AUTH_DISABLE_FAILED"
 
@@ -1113,6 +1118,9 @@ let pool_auth_enable_failed_invalid_trusted_certs =
 
 let pool_auth_enable_failed_no_trusted_certs =
   add_error $ pool_auth_enable_failed ^ auth_suffix_no_trusted_certs
+
+let pool_auth_enable_failed_no_supp_encrypt_type =
+  add_error $ pool_auth_enable_failed ^ auth_suffix_no_support_encrypt_type
 
 let pool_auth_enable_failed_setup_tls_connection =
   add_error $ pool_auth_enable_failed ^ auth_suffix_setup_tls_connection

--- a/ocaml/xapi/auth_signature.ml
+++ b/ocaml/xapi/auth_signature.ml
@@ -34,6 +34,7 @@ type auth_service_error_tag =
   | E_INVALID_TRUSTED_CERTS
   | E_NO_TRUSTED_CERTS
   | E_FAILED_SETUP_TLS_CONNECTION
+  | E_NO_SUPPORT_ENCRYPT_TYPE
 
 exception Auth_service_error of auth_service_error_tag * string
 
@@ -61,6 +62,8 @@ let suffix_of_tag errtag =
       Api_errors.auth_suffix_no_trusted_certs
   | E_FAILED_SETUP_TLS_CONNECTION ->
       Api_errors.auth_suffix_setup_tls_connection
+  | E_NO_SUPPORT_ENCRYPT_TYPE ->
+      Api_errors.auth_suffix_no_support_encrypt_type
 
 (* required fields in subject.other_config *)
 let subject_information_field_subject_name = "subject-name"

--- a/ocaml/xapi/extauth_plugin_ADwinbind.ml
+++ b/ocaml/xapi/extauth_plugin_ADwinbind.ml
@@ -132,6 +132,7 @@ let err_msg_to_tag_map =
     , E_INVALID_TRUSTED_CERTS
     )
   ; ("tstream_tls_sync_setup: GNUTLS ERROR", E_FAILED_SETUP_TLS_CONNECTION)
+  ; ("KDC has no support for encryption type", E_NO_SUPPORT_ENCRYPT_TYPE)
     (* Some other errors *)
   ]
 


### PR DESCRIPTION
XenServer9 has winbind_kerberos_encryption_type set to strong, This means only AES based encryption types are supported.

Capture this error details from output and report to user, so the encryption failures can be easily identified