### PR TITLE
CA-427419 Add timeout in fetch_server_cert

### DIFF
--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -146,7 +146,7 @@ let prototyped_of_field = function
   | "VM_metrics", "numa_optimised" ->
       Some "26.2.0"
   | "VM", "secureboot_certificates_state" ->
-      Some "26.13.0-next"
+      Some "26.14.0"
   | "VM", "groups" ->
       Some "24.19.1"
   | "VM", "pending_guidances_full" ->
@@ -292,7 +292,7 @@ let prototyped_of_message = function
   | "VM", "sysprep" ->
       Some "25.24.0"
   | "VM", "update_secureboot_certificates_on_boot" ->
-      Some "26.13.0-next"
+      Some "26.14.0"
   | "VM", "get_secureboot_readiness" ->
       Some "24.17.0"
   | "VM", "set_uefi_mode" ->

--- a/ocaml/libs/stunnel/dune
+++ b/ocaml/libs/stunnel/dune
@@ -1,21 +1,19 @@
 (library
-  (name stunnel)
-  (public_name stunnel)
-  (wrapped false)
-  (libraries
-    astring
-    forkexec
-    safe-resources
-    threads.posix
-    unix
-    uuid
-    xapi-consts
-    xapi-inventory
-    xapi-log
-    xapi-stdext-pervasives
-    xapi-stdext-std
-    xapi-stdext-threads
-    xapi-stdext-unix
-  )
-)
-
+ (name stunnel)
+ (public_name stunnel)
+ (wrapped false)
+ (libraries
+  astring
+  forkexec
+  mtime
+  safe-resources
+  threads.posix
+  unix
+  uuid
+  xapi-consts
+  xapi-inventory
+  xapi-log
+  xapi-stdext-pervasives
+  xapi-stdext-std
+  xapi-stdext-threads
+  xapi-stdext-unix))

--- a/ocaml/libs/stunnel/stunnel.ml
+++ b/ocaml/libs/stunnel/stunnel.ml
@@ -639,6 +639,7 @@ end
     This is useful for TOFU (Trust-On-First-Use) scenarios. *)
 let fetch_server_cert ~remote_host ~remote_port =
   try
+    let timeout = Mtime.Span.(30 * s) in
     let openssl = !Constants.openssl_path in
     (* First get the certificate with s_client *)
     let s_client_args =
@@ -650,13 +651,14 @@ let fetch_server_cert ~remote_host ~remote_port =
       ]
     in
     let cert_output, _ =
-      Forkhelpers.execute_command_get_output_send_stdin openssl s_client_args ""
+      Forkhelpers.execute_command_get_output_send_stdin ~timeout openssl
+        s_client_args ""
     in
     (* Then parse it with x509 to get PEM format *)
     let x509_args = ["x509"; "-outform"; "PEM"] in
     let pem_output, _ =
-      Forkhelpers.execute_command_get_output_send_stdin openssl x509_args
-        cert_output
+      Forkhelpers.execute_command_get_output_send_stdin ~timeout openssl
+        x509_args cert_output
     in
     if
       String.length pem_output > 0


### PR DESCRIPTION
In some rare cases, if peer server port is open, replys TCP SYN but doesn't reply TLS hello, the openssl s_client command in `fetch_server_cert` may hang infinitely. Add a timeout to address this.