### PR TITLE
CA-427727: Failed to join host to pool due to ldaps sync failed

### DIFF
--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2078,23 +2078,19 @@ let join_common ~__context ~master_address ~master_username ~master_password
           "Error whilst syncing ldaps status with pool coordinator. The \
            pool-join operation will continue as only the pool coordinator is \
            used for ldap query. Use pool-external-auth-set-ldaps --force to \
-           fix up"
-      @@ fun () ->
-      let coordinator_ldaps =
-        Client.Host.get_external_auth_configuration ~rpc ~session_id
-          ~self:remote_coordinator
-        |> fun config -> Helpers.ldaps_enabled_in_config ~config
-      in
-      let local_ldaps =
-        Db.Host.get_external_auth_configuration ~__context ~self:me
-        |> fun config -> Helpers.ldaps_enabled_in_config ~config
-      in
-      ( match coordinator_ldaps = local_ldaps with
-      | true ->
-          ()
-      | false ->
-          Xapi_host.external_auth_set_ldaps ~__context ~host:me
-            ~ldaps:coordinator_ldaps ~force:true
+           fix up" (fun () ->
+          let coordinator_ldaps =
+            Client.Host.get_external_auth_configuration ~rpc ~session_id
+              ~self:remote_coordinator
+            |> fun config -> Helpers.ldaps_enabled_in_config ~config
+          in
+          let local_ldaps =
+            Db.Host.get_external_auth_configuration ~__context ~self:me
+            |> fun config -> Helpers.ldaps_enabled_in_config ~config
+          in
+          if coordinator_ldaps <> local_ldaps then
+            Xapi_host.external_auth_set_ldaps ~__context ~host:me
+              ~ldaps:coordinator_ldaps ~force:true
       ) ;
       (* this is where we try and sync up as much state as we can
          with the master. This is "best effort" rather than
@@ -2104,13 +2100,13 @@ let join_common ~__context ~master_address ~master_username ~master_password
         ~warn:
           "Error whilst importing db objects to master. The pool-join \
            operation will continue, but some of the slave's VMs may not be \
-           available on the master."
-      @@ fun () ->
-      update_non_vm_metadata ~__context ~rpc ~session_id ;
-      ignore
-        (Importexport.remote_metadata_export_import ~__context ~rpc ~session_id
-           ~remote_address:master_address ~restore:true `All
-        )
+           available on the master." (fun () ->
+          update_non_vm_metadata ~__context ~rpc ~session_id ;
+          ignore
+            (Importexport.remote_metadata_export_import ~__context ~rpc
+               ~session_id ~remote_address:master_address ~restore:true `All
+            )
+      )
     )
     (fun () -> Client.Session.logout ~rpc ~session_id) ;
 


### PR DESCRIPTION
ldaps sync failed is ignored by ignore_error by intention, however, `@@` is right-associative low-precedence application and the fun () -> body greedily absorbs every following statement until the enclosing delimiter, the second ignore_error is part of the first lambda's body, thus, the exception in first ignore_error(sync ldaps) skiped the second ignore_error function body, e.g: update_non_vm_metadata and later got no change to execute.

The issue is fixed by removing `@@` and providing function body enclosed