### PR TITLE
Prepare for VDI.revert: add tests and robustify error paths (26.1-lcm)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _build/
+_mock/
 *.bak
 *.native
 .merlin

--- a/ocaml/quicktest/qt.ml
+++ b/ocaml/quicktest/qt.ml
@@ -192,7 +192,9 @@ module VDI = struct
 
   let with_destroyed rpc session_id self f =
     Xapi_stdext_pervasives.Pervasiveext.finally f (fun () ->
-        Client.Client.VDI.destroy ~rpc ~session_id ~self
+        try Client.Client.VDI.destroy ~rpc ~session_id ~self
+        with Api_errors.Server_error ("HANDLE_INVALID", _) ->
+          (* Already destroyed, ignore *) ()
     )
 
   let with_new rpc session_id ?(virtual_size = Int64.(mul (mul 4L 1024L) 1024L))

--- a/ocaml/quicktest/qt.ml
+++ b/ocaml/quicktest/qt.ml
@@ -181,15 +181,14 @@ module VDI = struct
   let test_vdi_name_description = "VDI for storage quicktest"
 
   let make rpc session_id ?(virtual_size = Int64.(mul (mul 4L 1024L) 1024L))
-      ?backing_format sR =
+      ?backing_format ?(name_label = test_vdi_name_label)
+      ?(name_description = test_vdi_name_description) sR =
     let sm_config =
       match backing_format with Some x -> [("image-format", x)] | None -> []
     in
-    Client.Client.VDI.create ~sR ~session_id ~rpc
-      ~name_label:test_vdi_name_label
-      ~name_description:test_vdi_name_description ~_type:`user ~sharable:false
-      ~read_only:false ~virtual_size ~xenstore_data:[] ~other_config:[] ~tags:[]
-      ~sm_config
+    Client.Client.VDI.create ~sR ~session_id ~rpc ~name_label ~name_description
+      ~_type:`user ~sharable:false ~read_only:false ~virtual_size
+      ~xenstore_data:[] ~other_config:[] ~tags:[] ~sm_config
 
   let with_destroyed rpc session_id self f =
     Xapi_stdext_pervasives.Pervasiveext.finally f (fun () ->
@@ -197,8 +196,11 @@ module VDI = struct
     )
 
   let with_new rpc session_id ?(virtual_size = Int64.(mul (mul 4L 1024L) 1024L))
-      ?backing_format sr f =
-    let self = make rpc session_id ~virtual_size ?backing_format sr in
+      ?backing_format ?name_label ?name_description sr f =
+    let self =
+      make rpc session_id ~virtual_size ?backing_format ?name_label
+        ?name_description sr
+    in
     with_destroyed rpc session_id self (fun () -> f self)
 
   let with_any rpc session_id sr_info f =

--- a/ocaml/quicktest/qt.mli
+++ b/ocaml/quicktest/qt.mli
@@ -74,6 +74,8 @@ module VDI : sig
     -> API.ref_session
     -> ?virtual_size:int64
     -> ?backing_format:string
+    -> ?name_label:string
+    -> ?name_description:string
     -> API.ref_SR
     -> (API.ref_VDI -> 'a)
     -> 'a

--- a/ocaml/quicktest/quicktest_vm_snapshot.ml
+++ b/ocaml/quicktest/quicktest_vm_snapshot.ml
@@ -44,6 +44,38 @@ let with_setup rpc session_id sr vm_template f =
   ignore (create_vbd_disk rpc session_id vm vdi2 "1") ;
   f rpc session_id vm vdi vdi2
 
+let create_vbd_cd rpc session_id vm vdi n =
+  Client.Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:vdi ~userdevice:n
+    ~bootable:false ~mode:`RO ~_type:`CD ~unpluggable:true ~empty:false
+    ~other_config:[] ~qos_algorithm_type:"" ~qos_algorithm_params:[] ~device:""
+    ~currently_attached:true
+
+let with_cd_setup rpc session_id sr vm_template f =
+  print_endline (Printf.sprintf "%s: Setting up VM" __FUNCTION__) ;
+  let uuid = Client.Client.VM.get_uuid ~rpc ~session_id ~self:vm_template in
+  print_endline (Printf.sprintf "Template has uuid: %s%!" uuid) ;
+  let@ vm = Qt.VM.with_new rpc session_id ~template:vm_template ~sr in
+  print_endline (Printf.sprintf "Installed new VM") ;
+  print_endline
+    (Printf.sprintf "Using SR: %s"
+       (Client.Client.SR.get_name_label ~rpc ~session_id ~self:sr)
+    ) ;
+  let@ vdi =
+    Qt.VDI.with_new rpc session_id ~name_label:"small CD"
+      ~name_description:__LOC__
+      ~virtual_size:Int64.(mul (mul 4L 1024L) 1024L)
+      sr
+  in
+  ignore (create_vbd_cd rpc session_id vm vdi "0") ;
+  let@ vdi2 =
+    Qt.VDI.with_new rpc session_id ~name_label:"small CD 2"
+      ~name_description:__LOC__
+      ~virtual_size:Int64.(mul (mul 4L 1024L) 1024L)
+      sr
+  in
+  ignore (create_vbd_cd rpc session_id vm vdi2 "1") ;
+  f rpc session_id vm vdi vdi2
+
 let take_snapshot ?(ignore_vdis = []) rpc session_id vm ~origin =
   Client.Client.VM.snapshot ~rpc ~session_id ~vm
     ~new_name:(Printf.sprintf "Snapshot:%s" origin)
@@ -86,6 +118,10 @@ let check_vdis_different expected result =
   Alcotest.(check @@ neg vdi_ref)
     "The VDIs after a reverting a snapshot must not be the same" expected result
 
+let check_vdis_same expected result =
+  Alcotest.(check vdi_ref)
+    "The VDIs after a reverting a snapshot must unchanged" expected result
+
 let test_snapshot rpc session_id vm vdi vdi2 =
   let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
   let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:snapshot in
@@ -119,6 +155,18 @@ let test_revert rpc session_id vm vdi vdi2 =
   check_vdis_different vdi vdi_after ;
   check_vdis_different vdi2 vdi_after2
 
+let test_revert_cds rpc session_id vm vdi vdi2 =
+  let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
+  Client.Client.VM.revert ~rpc ~session_id ~snapshot ;
+
+  let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:vm in
+  let vdi_after = get_vdi_with_user_device rpc session_id vbds "0" in
+  let vdi_after2 = get_vdi_with_user_device rpc session_id vbds "1" in
+
+  (* CD VDIs are considered immutable and the clone code ignores them *)
+  check_vdis_same vdi vdi_after ;
+  check_vdis_same vdi2 vdi_after2
+
 let a_test with_setup tests rpc session_id sr_info vm_template () =
   let sr = sr_info.Qt.sr in
   List.iter (with_setup rpc session_id sr vm_template) tests
@@ -137,4 +185,6 @@ let tests () =
         [test_snapshot; test_snapshot_ignore_vdi]
         [`vdi_create]
     ; suite "VM revert tests" with_setup [test_revert] [`vdi_create; `vdi_clone]
+    ; suite "VM revert with CD tests" with_cd_setup [test_revert_cds]
+        [`vdi_create; `vdi_clone]
     ]

--- a/ocaml/quicktest/quicktest_vm_snapshot.ml
+++ b/ocaml/quicktest/quicktest_vm_snapshot.ml
@@ -82,6 +82,10 @@ let check_vdi_snapshot_of rpc session vbds ~vdi n =
   Alcotest.(check vdi_ref)
     "The expected vdi is different from the one in snapshot_of" vdi snapshot_of
 
+let check_vdis_different expected result =
+  Alcotest.(check @@ neg vdi_ref)
+    "The VDIs after a reverting a snapshot must not be the same" expected result
+
 let test_snapshot rpc session_id vm vdi vdi2 =
   let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
   let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:snapshot in
@@ -103,15 +107,34 @@ let test_snapshot_ignore_vdi rpc session_id vm vdi vdi2 =
     (has_been_snapshot "1") ;
   check_vdi_snapshot_of rpc session_id vbds ~vdi "0"
 
-let test_snapshots rpc session_id sr_info vm_template () =
+let test_revert rpc session_id vm vdi vdi2 =
+  let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
+  Client.Client.VM.revert ~rpc ~session_id ~snapshot ;
+
+  let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:vm in
+  let vdi_after = get_vdi_with_user_device rpc session_id vbds "0" in
+  let vdi_after2 = get_vdi_with_user_device rpc session_id vbds "1" in
+
+  (* Xapi forces VDI clones, the VDIs' IDs will always change *)
+  check_vdis_different vdi vdi_after ;
+  check_vdis_different vdi2 vdi_after2
+
+let a_test with_setup tests rpc session_id sr_info vm_template () =
   let sr = sr_info.Qt.sr in
-  List.iter
-    (with_setup rpc session_id sr vm_template)
-    [test_snapshot; test_snapshot_ignore_vdi]
+  List.iter (with_setup rpc session_id sr vm_template) tests
+
+let suite name with_setup tests sr_ops =
+  let open Qt_filter in
+  [(name, `Slow, a_test with_setup tests)]
+  |> conn
+  |> sr SR.(all |> allowed_operations sr_ops)
+  |> vm_template Qt.VM.Template.other
 
 let tests () =
-  let open Qt_filter in
-  [("VM snapshot tests", `Slow, test_snapshots)]
-  |> conn
-  |> sr SR.(all |> allowed_operations [`vdi_create])
-  |> vm_template Qt.VM.Template.other
+  List.concat
+    [
+      suite "VM snapshot tests" with_setup
+        [test_snapshot; test_snapshot_ignore_vdi]
+        [`vdi_create]
+    ; suite "VM revert tests" with_setup [test_revert] [`vdi_create; `vdi_clone]
+    ]

--- a/ocaml/quicktest/quicktest_vm_snapshot.ml
+++ b/ocaml/quicktest/quicktest_vm_snapshot.ml
@@ -66,14 +66,27 @@ let get_snapshot_of_vdi rpc session_id vbds n =
   let snap = get_vdi_with_user_device rpc session_id vbds n in
   Client.Client.VDI.get_snapshot_of ~rpc ~session_id ~self:snap
 
-let check_vdi_snapshot_of rpc session_id vbds ~vdi n =
-  let snapshot_of = get_snapshot_of_vdi rpc session_id vbds n in
-  assert (snapshot_of = vdi)
+let vm_ref : [`VM] Ref.t Alcotest.testable = Alcotest.testable Ref.pp ( = )
+
+let vdi_ref : [`VDI] Ref.t Alcotest.testable = Alcotest.testable Ref.pp ( = )
+
+let check_vm_snapshot_of rpc session_id ~snapshot ~vm =
+  let snapshot_of =
+    Client.Client.VM.get_snapshot_of ~rpc ~session_id ~self:snapshot
+  in
+  Alcotest.(check vm_ref)
+    "The expected VM is different from the one in snapshot_of" vm snapshot_of
+
+let check_vdi_snapshot_of rpc session vbds ~vdi n =
+  let snapshot_of = get_snapshot_of_vdi rpc session vbds n in
+  Alcotest.(check vdi_ref)
+    "The expected vdi is different from the one in snapshot_of" vdi snapshot_of
 
 let test_snapshot rpc session_id vm vdi vdi2 =
   let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
   let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:snapshot in
 
+  check_vm_snapshot_of rpc session_id ~snapshot ~vm ;
   check_vdi_snapshot_of rpc session_id vbds ~vdi "0" ;
   check_vdi_snapshot_of rpc session_id vbds ~vdi:vdi2 "1"
 
@@ -85,8 +98,9 @@ let test_snapshot_ignore_vdi rpc session_id vm vdi vdi2 =
   let has_been_snapshot n =
     List.exists (is_user_device rpc session_id n) vbds
   in
-
-  assert (not (has_been_snapshot "1")) ;
+  Alcotest.(check bool)
+    "The vbd with user_device 1 cannot be present in the snapshot" false
+    (has_been_snapshot "1") ;
   check_vdi_snapshot_of rpc session_id vbds ~vdi "0"
 
 let test_snapshots rpc session_id sr_info vm_template () =

--- a/ocaml/quicktest/quicktest_vm_snapshot.ml
+++ b/ocaml/quicktest/quicktest_vm_snapshot.ml
@@ -1,125 +1,95 @@
+(* Copyright (C) 2026 Vates.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; version 2.1 only. with the special
+   exception on linking described in file LICENSE.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+*)
+let ( let@ ) f x = f x
+
+let create_vbd_disk rpc session_id vm vdi n =
+  Client.Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:vdi ~userdevice:n
+    ~bootable:false ~mode:`RW ~_type:`Disk ~unpluggable:true ~empty:false
+    ~other_config:[] ~qos_algorithm_type:"" ~qos_algorithm_params:[] ~device:""
+    ~currently_attached:true
+
 (** Set up snapshot test: create a small VM with a selection of VBDs *)
 let with_setup rpc session_id sr vm_template f =
   print_endline "Setting up test VM" ;
   let uuid = Client.Client.VM.get_uuid ~rpc ~session_id ~self:vm_template in
   print_endline (Printf.sprintf "Template has uuid: %s%!" uuid) ;
-  let vdi =
-    Client.Client.VDI.create ~rpc ~session_id ~name_label:"small"
-      ~name_description:__LOC__ ~sR:sr
+  let@ vm = Qt.VM.with_new rpc session_id ~template:vm_template ~sr in
+  print_endline (Printf.sprintf "Installed new VM") ;
+  print_endline
+    (Printf.sprintf "Using SR: %s"
+       (Client.Client.SR.get_name_label ~rpc ~session_id ~self:sr)
+    ) ;
+  let@ vdi =
+    Qt.VDI.with_new rpc session_id ~name_label:"small" ~name_description:__LOC__
       ~virtual_size:Int64.(mul (mul 4L 1024L) 1024L)
-      ~_type:`user ~sharable:false ~read_only:false ~other_config:[]
-      ~xenstore_data:[] ~sm_config:[] ~tags:[]
+      sr
   in
-  let vdi2 =
-    Client.Client.VDI.create ~rpc ~session_id ~name_label:"small2"
-      ~name_description:__LOC__ ~sR:sr
+  ignore (create_vbd_disk rpc session_id vm vdi "0") ;
+  let@ vdi2 =
+    Qt.VDI.with_new rpc session_id ~name_label:"small2"
+      ~name_description:__LOC__
       ~virtual_size:Int64.(mul (mul 4L 1024L) 1024L)
-      ~_type:`user ~sharable:false ~read_only:false ~other_config:[]
-      ~xenstore_data:[] ~sm_config:[] ~tags:[]
+      sr
   in
-  Qt.VM.with_new rpc session_id ~template:vm_template (fun vm ->
-      print_endline (Printf.sprintf "Installed new VM") ;
-      print_endline
-        (Printf.sprintf "Using SR: %s"
-           (Client.Client.SR.get_name_label ~rpc ~session_id ~self:sr)
-        ) ;
-      ignore
-        (Client.Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:vdi
-           ~userdevice:"0" ~bootable:false ~mode:`RW ~_type:`Disk
-           ~unpluggable:true ~empty:false ~other_config:[]
-           ~qos_algorithm_type:"" ~qos_algorithm_params:[] ~device:""
-           ~currently_attached:true
-        ) ;
-      ignore
-        (Client.Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:vdi2
-           ~userdevice:"1" ~bootable:false ~mode:`RW ~_type:`Disk
-           ~unpluggable:true ~empty:false ~other_config:[]
-           ~qos_algorithm_type:"" ~qos_algorithm_params:[] ~device:""
-           ~currently_attached:true
-        ) ;
-      f rpc session_id vm vdi vdi2 ;
-      Client.Client.VDI.destroy ~rpc ~session_id ~self:vdi ;
-      Client.Client.VDI.destroy ~rpc ~session_id ~self:vdi2
-  )
+  ignore (create_vbd_disk rpc session_id vm vdi2 "1") ;
+  f rpc session_id vm vdi vdi2
+
+let take_snapshot ?(ignore_vdis = []) rpc session_id vm ~origin =
+  Client.Client.VM.snapshot ~rpc ~session_id ~vm
+    ~new_name:(Printf.sprintf "Snapshot:%s" origin)
+    ~ignore_vdis
+
+let is_user_device rpc session_id n vbd =
+  Client.Client.VBD.get_userdevice ~rpc ~session_id ~self:vbd = n
+
+let get_vdi_with_user_device rpc session_id vbds n =
+  let vbd =
+    match List.find_opt (is_user_device rpc session_id n) vbds with
+    | None ->
+        Alcotest.fail (Printf.sprintf "Couldn't find VBD on snapshot %s" n)
+    | Some vbd ->
+        vbd
+  in
+  Client.Client.VBD.get_VDI ~rpc ~session_id ~self:vbd
+
+let get_snapshot_of_vdi rpc session_id vbds n =
+  let snap = get_vdi_with_user_device rpc session_id vbds n in
+  Client.Client.VDI.get_snapshot_of ~rpc ~session_id ~self:snap
+
+let check_vdi_snapshot_of rpc session_id vbds ~vdi n =
+  let snapshot_of = get_snapshot_of_vdi rpc session_id vbds n in
+  assert (snapshot_of = vdi)
 
 let test_snapshot rpc session_id vm vdi vdi2 =
-  let snapshot =
-    Client.Client.VM.snapshot ~rpc ~session_id ~vm ~new_name:"Snapshot"
-      ~ignore_vdis:[]
-  in
+  let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
   let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:snapshot in
-  let snap_vbd =
-    match
-      List.find_opt
-        (fun vbd ->
-          Client.Client.VBD.get_userdevice ~rpc ~session_id ~self:vbd = "0"
-        )
-        vbds
-    with
-    | None ->
-        Alcotest.fail "Couldn't find VBD on snapshot"
-    | Some vbd ->
-        vbd
-  in
-  let snap_vbd2 =
-    match
-      List.find_opt
-        (fun vbd ->
-          Client.Client.VBD.get_userdevice ~rpc ~session_id ~self:vbd = "1"
-        )
-        vbds
-    with
-    | None ->
-        Alcotest.fail "Couldn't find VBD on snapshot"
-    | Some vbd ->
-        vbd
-  in
-  let snap_vdi = Client.Client.VBD.get_VDI ~rpc ~session_id ~self:snap_vbd in
-  let snap_vdi2 = Client.Client.VBD.get_VDI ~rpc ~session_id ~self:snap_vbd2 in
-  let orig_vdi =
-    Client.Client.VDI.get_snapshot_of ~rpc ~session_id ~self:snap_vdi
-  in
-  let orig_vdi2 =
-    Client.Client.VDI.get_snapshot_of ~rpc ~session_id ~self:snap_vdi2
-  in
-  assert (orig_vdi = vdi) ;
-  assert (orig_vdi2 = vdi2)
+
+  check_vdi_snapshot_of rpc session_id vbds ~vdi "0" ;
+  check_vdi_snapshot_of rpc session_id vbds ~vdi:vdi2 "1"
 
 let test_snapshot_ignore_vdi rpc session_id vm vdi vdi2 =
   let snapshot =
-    Client.Client.VM.snapshot ~rpc ~session_id ~vm ~new_name:"Snapshot"
-      ~ignore_vdis:[vdi2]
+    take_snapshot rpc session_id vm ~origin:__FUNCTION__ ~ignore_vdis:[vdi2]
   in
   let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:snapshot in
-  let snap_vbd =
-    match
-      List.find_opt
-        (fun vbd ->
-          Client.Client.VBD.get_userdevice ~rpc ~session_id ~self:vbd = "0"
-        )
-        vbds
-    with
-    | None ->
-        Alcotest.fail "Couldn't find VBD on snapshot"
-    | Some vbd ->
-        vbd
+  let has_been_snapshot n =
+    List.exists (is_user_device rpc session_id n) vbds
   in
-  assert (
-    not
-      (List.exists
-         (fun vbd ->
-           Client.Client.VBD.get_userdevice ~rpc ~session_id ~self:vbd = "1"
-         )
-         vbds
-      )
-  ) ;
-  let snap_vdi = Client.Client.VBD.get_VDI ~rpc ~session_id ~self:snap_vbd in
-  let orig_vdi =
-    Client.Client.VDI.get_snapshot_of ~rpc ~session_id ~self:snap_vdi
-  in
-  assert (orig_vdi = vdi)
 
-let test rpc session_id sr_info vm_template () =
+  assert (not (has_been_snapshot "1")) ;
+  check_vdi_snapshot_of rpc session_id vbds ~vdi "0"
+
+let test_snapshots rpc session_id sr_info vm_template () =
   let sr = sr_info.Qt.sr in
   List.iter
     (with_setup rpc session_id sr vm_template)
@@ -127,10 +97,7 @@ let test rpc session_id sr_info vm_template () =
 
 let tests () =
   let open Qt_filter in
-  [
-    [("VM snapshot tests", `Slow, test)]
-    |> conn
-    |> sr SR.(all |> allowed_operations [`vdi_create])
-    |> vm_template Qt.VM.Template.other
-  ]
-  |> List.concat
+  [("VM snapshot tests", `Slow, test_snapshots)]
+  |> conn
+  |> sr SR.(all |> allowed_operations [`vdi_create])
+  |> vm_template Qt.VM.Template.other

--- a/ocaml/quicktest/quicktest_vm_snapshot.mli
+++ b/ocaml/quicktest/quicktest_vm_snapshot.mli
@@ -1,0 +1,13 @@
+(* Copyright (C) 2026 Vates.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; version 2.1 only. with the special
+   exception on linking described in file LICENSE.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+*)
+val tests : unit -> (unit -> unit) Qt_filter.test_case list

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -132,12 +132,18 @@
   (preprocess (per_module ((pps ppx_deriving_rpc) Test_cluster_host)))
 )
 
-(test
-(name test_storage_smapiv1_wrapper)
+(tests
+(names test_storage_smapiv1_wrapper test_xapi_sr_operations)
 (modes exe)
 (package xapi)
-(modules test_storage_smapiv1_wrapper)
-(libraries alcotest xapi_internal fmt xapi-idl.storage.interface xapi-idl.storage.interface.types))
+(modules test_storage_smapiv1_wrapper test_xapi_sr_operations)
+(libraries
+  alcotest
+  fmt
+  record_util
+  xapi-idl.storage.interface
+  xapi-idl.storage.interface.types
+  xapi_internal))
 
 (test
 (name test_storage_quicktest)

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -23,6 +23,7 @@
     mirage-crypto
     mtime
     pam
+    record_util
     result
     rpclib.core
     rpclib.json
@@ -99,6 +100,7 @@
     pam
     ptime
     result
+    record_util
     rpclib.core
     rpclib.json
     rresult

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -9,7 +9,7 @@
       test_vm_placement test_vm_helpers test_repository test_repository_helpers
       test_ref test_xapi_helpers test_vm_group
       test_livepatch test_rpm test_updateinfo test_storage_smapiv1_wrapper test_storage_quicktest test_observer
-      test_pool_periodic_update_sync test_pkg_mgr test_tar_ext test_pool_repository))
+      test_pool_periodic_update_sync test_pkg_mgr test_tar_ext test_pool_repository test_sr_allowed_operations))
   (libraries
     alcotest
     angstrom
@@ -84,14 +84,14 @@
   (names test_vm_helpers test_vm_placement test_network_sriov test_vdi_cbt test_bounded_psq test_auth_cache
     test_clustering test_pusb test_daemon_manager test_repository test_repository_helpers
     test_livepatch test_rpm test_updateinfo test_pool_periodic_update_sync test_pkg_mgr
-    test_xapi_helpers test_tar_ext test_pool_repository)
+      test_xapi_helpers test_tar_ext test_pool_repository test_sr_allowed_operations)
   (package xapi)
   (modes exe)
   (modules test_vm_helpers test_vm_placement test_network_sriov test_vdi_cbt test_bounded_psq test_auth_cache
     test_event test_clustering test_cluster_host test_cluster test_pusb
     test_daemon_manager test_repository test_repository_helpers test_livepatch test_rpm
     test_updateinfo test_pool_periodic_update_sync test_pkg_mgr
-    test_xapi_helpers test_tar_ext test_pool_repository)
+    test_xapi_helpers test_tar_ext test_pool_repository test_sr_allowed_operations)
   (libraries
     alcotest
     bos
@@ -116,6 +116,7 @@
     xapi-idl.storage.interface
     xapi-idl.xen
     clock
+    xapi-log
     xapi-stdext-threads
     xapi-stdext-threads.scheduler
     xapi-stdext-unix

--- a/ocaml/tests/record_util/dune
+++ b/ocaml/tests/record_util/dune
@@ -1,6 +1,14 @@
 (test
-	(name test_record_util)
-	(package xapi)
-	(libraries alcotest xapi_cli_server rpclib.core xapi_consts xapi_types astring fmt)
-	(action (run %{test} --show-errors))
+  (name test_record_util)
+  (package xapi)
+  (libraries
+    alcotest
+    astring
+    fmt
+    record_util
+    rpclib.core
+    xapi_consts 
+    xapi_types
+    )
+  (action (run %{test} --show-errors))
 )

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -8,7 +8,6 @@ let () =
        ("Test_sdn_controller", Test_sdn_controller.test)
      ; ("Test_pci_helpers", Test_pci_helpers.test)
      ; ("Test_vdi_allowed_operations", Test_vdi_allowed_operations.test)
-     ; ("Test_sr_allowed_operations", Test_sr_allowed_operations.test)
      ; ("Test_vm_migrate", Test_vm_migrate.test)
      ; ("Test_no_migrate", Test_no_migrate.test)
      ; ("Test_vm_check_operation_error", Test_vm_check_operation_error.test)

--- a/ocaml/tests/test_sr_allowed_operations.ml
+++ b/ocaml/tests/test_sr_allowed_operations.ml
@@ -72,3 +72,8 @@ let test_operations_restricted_during_rpu =
   [("test_check_operation_error", `Quick, test_check_operation_error)]
 
 let test = test_operations_restricted_during_rpu
+
+let () =
+  Suite_init.harness_init () ;
+  Debug.log_to_stdout () ;
+  Alcotest.run "Base suite" [("Test_sr_allowed_operations", test)]

--- a/ocaml/tests/test_xapi_sr_operations.ml
+++ b/ocaml/tests/test_xapi_sr_operations.ml
@@ -1,0 +1,44 @@
+(*
+  Copyright (C) 2026 Vates.
+ 
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published
+  by the Free Software Foundation; version 2.1 only. with the special
+  exception on linking described in file LICENSE.
+ 
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+ *)
+
+module Ops = Xapi_sr_operations
+
+let contained_tables =
+  [
+    (Ops.all_rpu_ops, "all_rpu_ops")
+  ; (Ops.disallowed_during_rpu, "disallowed_during_rpu")
+  ; (Ops.sm_cap_table |> List.map fst, "sm_cap_table")
+  ]
+
+let not_contained element =
+  if not (List.mem element Ops.all_ops) then
+    Some (Record_util.storage_operations_to_string element)
+  else
+    None
+
+let test_tables =
+  List.map
+    (fun (input, name) ->
+      let test () =
+        let not_contained = List.filter_map not_contained input in
+        Alcotest.(check @@ list string)
+          "There cannot be operations missing from all_ops" [] not_contained
+      in
+      (Printf.sprintf {|%s is a subset of all_ops|} name, `Quick, test)
+    )
+    contained_tables
+
+let () =
+  Alcotest.run "Test XAPI Helpers suite"
+    [("SR operation tables all are complete ", test_tables)]

--- a/ocaml/xapi-cli-server/dune
+++ b/ocaml/xapi-cli-server/dune
@@ -9,8 +9,15 @@
 )
 
 (library
+  (name record_util)
+  (modules generated_record_utils record_util)
+  (libraries rpclib.core xapi-consts xapi-types)
+)
+
+(library
   (name xapi_cli_server)
   (modes best)
+  (modules (:standard \ generated_record_utils record_util))
   (libraries
     astring
     base64
@@ -19,6 +26,7 @@
     rpclib.core
     rpclib.xml
     re
+    record_util
     result
     rresult
     sexplib

--- a/ocaml/xapi-storage/generator/lib/common.ml
+++ b/ocaml/xapi-storage/generator/lib/common.ml
@@ -22,18 +22,7 @@ let dbg =
 
 let unit = Param.mk Types.unit
 
-let task_id = Param.mk ~name:"task_id" Types.string
-
-(** A URI representing the means for accessing the volume data. The
-    interpretation of the URI is specific to the implementation. Xapi will
-    choose which implementation to use based on the URI scheme. *)
 type uri = string [@@deriving rpcty]
 
-(** List of blocks for copying. *)
-type blocklist = {
-    blocksize: int  (** Size of the individual blocks. *)
-  ; ranges: (int64 * int64) list
-        (** List of block ranges, where a range is a (start,length) pair,
-          measured in units of [blocksize] *)
-}
+type blocklist = {blocksize: int; ranges: (int64 * int64) list}
 [@@deriving rpcty]

--- a/ocaml/xapi-storage/generator/lib/common.mli
+++ b/ocaml/xapi-storage/generator/lib/common.mli
@@ -1,0 +1,28 @@
+type exnt = Unimplemented of string
+
+val typ_of_exnt : exnt Rpc.Types.typ
+
+val exnt : exnt Rpc.Types.def
+
+exception DataExn of exnt
+
+val error : exnt Idl.Error.t
+
+val dbg : string Idl.Param.t
+
+val unit : unit Idl.Param.t
+
+val uri : string Rpc.Types.def
+(** A URI representing the means for accessing the volume data. The
+    interpretation of the URI is specific to the implementation. Xapi will
+    choose which implementation to use based on the URI scheme. *)
+
+(** List of blocks for copying. *)
+type blocklist = {
+    blocksize: int  (** Size of the individual blocks. *)
+  ; ranges: (int64 * int64) list
+        (** List of block ranges, where a range is a (start,length) pair,
+          measured in units of [blocksize] *)
+}
+
+val blocklist : blocklist Rpc.Types.def

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -170,6 +170,7 @@
   rpclib.json
   rpclib.xml
   re
+  record_util
   result
   rresult
   rrd-transport.lib
@@ -297,6 +298,7 @@
   forkexec
   http_lib
   httpsvr
+  record_util
   rpclib.core
   rpclib.json
   rpclib.xml

--- a/ocaml/xapi/xapi_sr_operations.ml
+++ b/ocaml/xapi/xapi_sr_operations.ml
@@ -271,13 +271,9 @@ let valid_operations ~__context ?op record _ref' : table =
 
 let throw_error (table : table) op =
   match Hashtbl.find_opt table op with
-  | None ->
-      Helpers.internal_error
-        "xapi_sr.assert_operation_valid unknown operation: %s"
-        (sr_operation_to_string op)
   | Some (Error ex) ->
       raise ex
-  | Some (Ok ()) ->
+  | None | Some (Ok ()) ->
       ()
 
 let assert_operation_valid ~__context ~self ~(op : API.storage_operations) =

--- a/ocaml/xapi/xapi_sr_operations.ml
+++ b/ocaml/xapi/xapi_sr_operations.ml
@@ -93,7 +93,7 @@ let sm_cap_table : (API.storage_operations * _) list =
     (`vdi_snapshot, Vdi_snapshot)
   ]
 
-type table = (API.storage_operations, (string * string list) option) Hashtbl.t
+type table = (API.storage_operations, (unit, exn) Result.t) Hashtbl.t
 
 let features_of_sr_internal ~__context ~_type =
   match
@@ -113,22 +113,30 @@ let features_of_sr_internal ~__context ~_type =
 let features_of_sr ~__context record =
   features_of_sr_internal ~__context ~_type:record.Db_actions.sR_type
 
-(** Returns a table of operations -> API error options (None if the operation would be ok)
- * If op is specified, the table may omit reporting errors for ops other than that one. *)
+(** Returns a table of operations -> API error options (None if the operation
+    would be ok) If op is specified, the table may omit reporting errors for
+    ops other than that one. *)
 let valid_operations ~__context ?op record _ref' : table =
   let _ref = Ref.string_of _ref' in
   let current_ops = record.Db_actions.sR_current_operations in
   let table : table = Hashtbl.create 10 in
-  List.iter (fun x -> Hashtbl.replace table x None) all_ops ;
+  List.iter (fun x -> Hashtbl.replace table x (Ok ())) all_ops ;
   let set_errors (code : string) (params : string list)
       (ops : API.storage_operations_set) =
     List.iter
       (fun op ->
-        (* Exception can't be raised since the hash table is
-           pre-filled for all_ops, and set_errors is applied
-           to a subset of all_ops (disallowed_during_rpu) *)
-        if Hashtbl.find table op = None then
-          Hashtbl.replace table op (Some (code, params))
+        match Hashtbl.find_opt table op with
+        | Some (Ok ()) ->
+            Hashtbl.replace table op
+              (Error (Api_errors.Server_error (code, params)))
+        | Some (Error _) ->
+            (* Don't replace existing errors *)
+            ()
+        | None ->
+            (* Ignore order if the operation is not in table, this is a coding
+               error, as all calls to set_errors should be a subset of all_ops
+               *)
+            ()
       )
       ops
   in
@@ -143,7 +151,8 @@ let valid_operations ~__context ?op record _ref' : table =
     let open Smint.Feature in
     (* First consider the backend SM features *)
     let sm_features = features_of_sr ~__context record in
-    (* Then filter out the operations we don't want to see for the magic tools SR *)
+    (* Then filter out the operations we don't want to see for the magic tools
+       SR *)
     let sm_features =
       if record.Db_actions.sR_is_tools_sr then
         List.filter
@@ -163,7 +172,8 @@ let valid_operations ~__context ?op record _ref' : table =
     set_errors Api_errors.sr_operation_not_supported [_ref] forbidden_by_backend
   in
   let check_any_attached_pbds ~__context _record =
-    (* CA-70294: if the SR has any attached PBDs, destroy and forget operations are not allowed.*)
+    (* CA-70294: if the SR has any attached PBDs, destroy and forget operations
+       are not allowed.*)
     let all_pbds_attached_to_this_sr =
       Db.PBD.get_records_where ~__context
         ~expr:
@@ -237,7 +247,8 @@ let valid_operations ~__context ?op record _ref' : table =
       Cluster_stack_constraints.assert_cluster_stack_compatible ~__context _ref'
     with Api_errors.Server_error (e, args) -> set_errors e args [`plug]
   in
-  (* List of (operations * function which checks for errors relevant to those operations) *)
+  (* List of (operations * function which checks for errors relevant to those
+     operations) *)
   let relevant_functions =
     [
       (all_ops, check_sm_features)
@@ -264,9 +275,9 @@ let throw_error (table : table) op =
       Helpers.internal_error
         "xapi_sr.assert_operation_valid unknown operation: %s"
         (sr_operation_to_string op)
-  | Some (Some (code, params)) ->
-      raise (Api_errors.Server_error (code, params))
-  | Some None ->
+  | Some (Error ex) ->
+      raise ex
+  | Some (Ok ()) ->
       ()
 
 let assert_operation_valid ~__context ~self ~(op : API.storage_operations) =
@@ -280,7 +291,7 @@ let update_allowed_operations ~__context ~self : unit =
   let keys =
     Hashtbl.fold
       (fun k v acc ->
-        if v = None then
+        if v = Ok () then
           k :: acc
         else
           acc

--- a/ocaml/xapi/xapi_sr_operations.mli
+++ b/ocaml/xapi/xapi_sr_operations.mli
@@ -1,0 +1,40 @@
+type table = (API.storage_operations, (unit, exn) Result.t) Hashtbl.t
+
+val features_of_sr_internal :
+  __context:Context.t -> _type:string -> (Smint.Feature.capability * int64) list
+
+val features_of_sr :
+     __context:Context.t
+  -> Db_actions.sR_t
+  -> (Smint.Feature.capability * int64) list
+
+val assert_operation_valid :
+     __context:Context.t
+  -> self:[`SR] API.Ref.t
+  -> op:API.storage_operations
+  -> unit
+
+val update_allowed_operations :
+  __context:Context.t -> self:[`SR] API.Ref.t -> unit
+
+val cancel_tasks :
+     __context:Context.t
+  -> self:[`SR] API.Ref.t
+  -> all_tasks_in_db:[`task] Ref.t list
+  -> task_ids:string list
+  -> unit
+
+val sr_health_check : __context:Context.t -> self:[`SR] API.Ref.t -> unit
+
+val stop_health_check_thread :
+  __context:Context.t -> self:[`SR] API.Ref.t -> unit
+
+(**/**)
+
+val all_ops : API.storage_operations_set
+
+val all_rpu_ops : API.storage_operations_set
+
+val disallowed_during_rpu : API.storage_operations_set
+
+val sm_cap_table : (API.storage_operations * Smint.Feature.capability) list

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -532,36 +532,6 @@ let cancel_tasks ~__context ~self ~all_tasks_in_db ~task_ids =
 
 (**************************************************************************************)
 
-(* Helper function to create a new VDI record with all fields copied from
-   an original, except ref and *_operations, UUID and others supplied as optional arguments.
-   If a new UUID is not supplied, a fresh one is generated.
-   storage_lock defaults to false.
-   Parent defaults to Ref.null.
-*)
-(*let clone_record ~uuid ?name_label ?name_description ?sR ?virtual_size ?location
-    ?physical_utilisation ?_type ?sharable ?read_only ?storage_lock ?other_config ?parent
-    ?xenstore_data ?sm_config ~current_operations ~__context ~original () =
-  let a = Db.VDI.get_record_internal ~__context ~self:original in
-  let r = Ref.make () in
-  Db.VDI.create ~__context ~ref:r
-    ~uuid:(Uuidx.to_string uuid)
-    ~name_label:(default a.Db_actions.vDI_name_label name_label)
-    ~name_description:(default a.Db_actions.vDI_name_description name_description)
-    ~allowed_operations:[] ~current_operations
-    ~sR:(default a.Db_actions.vDI_SR sR)
-    ~virtual_size:(default a.Db_actions.vDI_virtual_size virtual_size)
-    ~physical_utilisation:(default a.Db_actions.vDI_physical_utilisation physical_utilisation)
-    ~_type:(default a.Db_actions.vDI_type _type)
-    ~sharable:(default a.Db_actions.vDI_sharable sharable)
-    ~read_only:(default a.Db_actions.vDI_read_only read_only)
-    ~other_config:(default a.Db_actions.vDI_other_config other_config)
-    ~storage_lock:(default false storage_lock)
-    ~location:(default a.Db_actions.vDI_location location) ~managed:true ~missing:false
-    ~xenstore_data:(default a.Db_actions.vDI_xenstore_data xenstore_data)
-    ~sm_config:(default a.Db_actions.vDI_sm_config sm_config)
-    ~parent:(default Ref.null parent);
-  r*)
-
 (* This function updates xapi's database for a single VDI. The row will be created if it doesn't exist *)
 let update_vdi_db ~__context ~sr newvdi =
   let open Xapi_database.Db_filter_types in

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -208,7 +208,13 @@ let safe_destroy_vusb ~__context ~rpc ~session_id vusb =
 
 (* Copy the VBDs and VIFs from a source VM to a dest VM and then delete the old
    disks. This operation destroys the data of the dest VM. *)
-let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
+type cloned = {
+    disks: ([`VBD] Ref.t * API.ref_VDI * bool) list
+  ; cds: ([`VBD] Ref.t * API.ref_VDI * bool) list
+  ; suspend_VDI: [`VDI] Ref.t
+}
+
+let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
   let snap_VBDs = Db.VM.get_VBDs ~__context ~self:snapshot in
   let snap_VBDs_disk, snap_VBDs_CD =
     List.partition
@@ -221,9 +227,8 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
   let snap_disks_snapshot_of =
     List.map (fun vdi -> Db.VDI.get_snapshot_of ~__context ~self:vdi) snap_disks
   in
-  let snap_VIFs = Db.VM.get_VIFs ~__context ~self:snapshot in
-  let snap_VGPUs = Db.VM.get_VGPUs ~__context ~self:snapshot in
   let snap_suspend_VDI = Db.VM.get_suspend_VDI ~__context ~self:snapshot in
+
   let vm_VBDs = Db.VM.get_VBDs ~__context ~self:vm in
   (* Filter VBDs to ensure that we don't read empty CDROMs *)
   let vm_VBDs_disk =
@@ -231,80 +236,85 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
       (fun vbd -> Db.VBD.get_type ~__context ~self:vbd = `Disk)
       vm_VBDs
   in
+  (* Filter out VM disks for which the snapshot does not have a corresponding
+     disk - these disks will be left unattached after the revert is complete. *)
   let vm_disks =
     List.map (fun vbd -> Db.VBD.get_VDI ~__context ~self:vbd) vm_VBDs_disk
   in
-  (* Filter out VM disks for which the snapshot does not have a corresponding
-     disk - these disks will be left unattached after the revert is complete. *)
   let vm_disks_with_snapshot =
     List.filter (fun vdi -> List.mem vdi snap_disks_snapshot_of) vm_disks
   in
+  let vm_suspend_VDI = Db.VM.get_suspend_VDI ~__context ~self:vm in
+
+  debug "Cleaning up the old VBDs and VDIs to have more free space" ;
+  List.iter (safe_destroy_vbd ~__context ~rpc ~session_id) vm_VBDs ;
+  List.iter
+    (safe_destroy_vdi ~__context ~rpc ~session_id)
+    (vm_suspend_VDI :: vm_disks_with_snapshot) ;
+  TaskHelper.set_progress ~__context 0.2 ;
+  debug "Cloning the snapshotted disks" ;
+  let driver_params = Xapi_vm_clone.make_driver_params () in
+  let cloned_disks =
+    Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone
+      ~__context snap_VBDs_disk driver_params
+  in
+  let cloned_CDs =
+    Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone
+      ~__context snap_VBDs_CD driver_params
+  in
+  TaskHelper.set_progress ~__context 0.5 ;
+  debug "Updating the snapshot_of fields for relevant VDIs" ;
+  List.iter2
+    (fun snap_disk (_, cloned_disk, _) ->
+      (* For each snapshot disk which was just cloned:
+         1) Find the value of snapshot_of
+         2) Find all snapshots with the same snapshot_of
+         3) Update each of these snapshots so that their snapshot_of points
+            to the new cloned disk. *)
+      let open Xapi_database.Db_filter_types in
+      let snapshot_of = Db.VDI.get_snapshot_of ~__context ~self:snap_disk in
+      let all_snaps_in_tree =
+        Db.VDI.get_refs_where ~__context
+          ~expr:(Eq (Field "snapshot_of", Literal (Ref.string_of snapshot_of)))
+      in
+      List.iter
+        (fun snapshot ->
+          Db.VDI.set_snapshot_of ~__context ~self:snapshot ~value:cloned_disk
+        )
+        all_snaps_in_tree
+    )
+    snap_disks cloned_disks ;
+  debug "Cloning the suspend VDI if needed" ;
+  let cloned_suspend_VDI =
+    if snap_suspend_VDI = Ref.null then
+      Ref.null
+    else
+      Xapi_vm_clone.clone_single_vdi rpc session_id Xapi_vm_clone.Disk_op_clone
+        ~__context snap_suspend_VDI driver_params
+  in
+  TaskHelper.set_progress ~__context 0.6 ;
+  {disks= cloned_disks; cds= cloned_CDs; suspend_VDI= cloned_suspend_VDI}
+
+let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
+  let snap_VIFs = Db.VM.get_VIFs ~__context ~self:snapshot in
+  let snap_VGPUs = Db.VM.get_VGPUs ~__context ~self:snapshot in
   let vm_VIFs = Db.VM.get_VIFs ~__context ~self:vm in
   let vm_VGPUs = Db.VM.get_VGPUs ~__context ~self:vm in
-  let vm_suspend_VDI = Db.VM.get_suspend_VDI ~__context ~self:vm in
   let vm_VUSBs = Db.VM.get_VUSBs ~__context ~self:vm in
+
   (* clone all the disks of the snapshot *)
   Helpers.call_api_functions ~__context (fun rpc session_id ->
-      debug "Cleaning up the old VBDs and VDIs to have more free space" ;
-      List.iter (safe_destroy_vbd ~__context ~rpc ~session_id) vm_VBDs ;
-      List.iter
-        (safe_destroy_vdi ~__context ~rpc ~session_id)
-        (vm_suspend_VDI :: vm_disks_with_snapshot) ;
-      TaskHelper.set_progress ~__context 0.2 ;
-      debug "Cloning the snapshotted disks" ;
-      let driver_params = Xapi_vm_clone.make_driver_params () in
-      let cloned_disks =
-        Xapi_vm_clone.safe_clone_disks rpc session_id
-          Xapi_vm_clone.Disk_op_clone ~__context snap_VBDs_disk driver_params
-      in
-      let cloned_CDs =
-        Xapi_vm_clone.safe_clone_disks rpc session_id
-          Xapi_vm_clone.Disk_op_clone ~__context snap_VBDs_CD driver_params
-      in
-      TaskHelper.set_progress ~__context 0.5 ;
-      debug "Updating the snapshot_of fields for relevant VDIs" ;
-      List.iter2
-        (fun snap_disk (_, cloned_disk, _) ->
-          (* For each snapshot disk which was just cloned:
-             1) Find the value of snapshot_of
-             2) Find all snapshots with the same snapshot_of
-             3) Update each of these snapshots so that their snapshot_of points
-                to the new cloned disk. *)
-          let open Xapi_database.Db_filter_types in
-          let snapshot_of = Db.VDI.get_snapshot_of ~__context ~self:snap_disk in
-          let all_snaps_in_tree =
-            Db.VDI.get_refs_where ~__context
-              ~expr:
-                (Eq (Field "snapshot_of", Literal (Ref.string_of snapshot_of)))
-          in
-          List.iter
-            (fun snapshot ->
-              Db.VDI.set_snapshot_of ~__context ~self:snapshot
-                ~value:cloned_disk
-            )
-            all_snaps_in_tree
-        )
-        snap_disks cloned_disks ;
-      debug "Cloning the suspend VDI if needed" ;
-      let cloned_suspend_VDI =
-        if snap_suspend_VDI = Ref.null then
-          Ref.null
-        else
-          Xapi_vm_clone.clone_single_vdi rpc session_id
-            Xapi_vm_clone.Disk_op_clone ~__context snap_suspend_VDI
-            driver_params
-      in
-      TaskHelper.set_progress ~__context 0.6 ;
+      let cloned = revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm in
       try
         debug "Copying the VBDs" ;
         let (_ : [`VBD] Ref.t list) =
           List.map
             (fun (vbd, vdi, _) -> Xapi_vbd_helpers.copy ~__context ~vm ~vdi vbd)
-            (cloned_disks @ cloned_CDs)
+            (cloned.disks @ cloned.cds)
         in
         TaskHelper.set_progress ~__context 0.7 ;
         debug "Update the suspend_VDI" ;
-        Db.VM.set_suspend_VDI ~__context ~self:vm ~value:cloned_suspend_VDI ;
+        Db.VM.set_suspend_VDI ~__context ~self:vm ~value:cloned.suspend_VDI ;
         debug "Cleaning up the old VIFs" ;
         List.iter (safe_destroy_vif ~__context ~rpc ~session_id) vm_VIFs ;
         debug "Setting up the new VIFs" ;
@@ -332,7 +342,7 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
           "Error while updating the new VBD, VDI, VIF and VGPU records. \
            Cleaning up the cloned VDIs." ;
         let vdis =
-          cloned_suspend_VDI
+          cloned.suspend_VDI
           :: List.fold_left
                (fun acc (_, vdi, on_error_delete) ->
                  if on_error_delete then
@@ -340,7 +350,7 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
                  else
                    acc
                )
-               [] cloned_disks
+               [] cloned.disks
         in
         List.iter (safe_destroy_vdi ~__context ~rpc ~session_id) vdis ;
         raise e

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -293,7 +293,24 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
         ~__context snap_suspend_VDI driver_params
   in
   TaskHelper.set_progress ~__context 0.6 ;
-  {disks= cloned_disks; cds= cloned_CDs; suspend_VDI= cloned_suspend_VDI}
+  debug "Copying the VBDs" ;
+  let (_ : [`VBD] Ref.t list) =
+    List.map
+      (fun (vbd, vdi, _) -> Xapi_vbd_helpers.copy ~__context ~vm ~vdi vbd)
+      (cloned_disks @ cloned_CDs)
+  in
+  debug "Update the suspend_VDI" ;
+  Db.VM.set_suspend_VDI ~__context ~self:vm ~value:cloned_suspend_VDI ;
+
+  cloned_suspend_VDI
+  :: List.fold_left
+       (fun acc (_, vdi, on_error_delete) ->
+         if on_error_delete then
+           vdi :: acc
+         else
+           acc
+       )
+       [] cloned_disks
 
 let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
   let snap_VIFs = Db.VM.get_VIFs ~__context ~self:snapshot in
@@ -304,17 +321,11 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
 
   (* clone all the disks of the snapshot *)
   Helpers.call_api_functions ~__context (fun rpc session_id ->
-      let cloned = revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm in
+      let vdis_to_cleanup =
+        revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm
+      in
+      TaskHelper.set_progress ~__context 0.7 ;
       try
-        debug "Copying the VBDs" ;
-        let (_ : [`VBD] Ref.t list) =
-          List.map
-            (fun (vbd, vdi, _) -> Xapi_vbd_helpers.copy ~__context ~vm ~vdi vbd)
-            (cloned.disks @ cloned.cds)
-        in
-        TaskHelper.set_progress ~__context 0.7 ;
-        debug "Update the suspend_VDI" ;
-        Db.VM.set_suspend_VDI ~__context ~self:vm ~value:cloned.suspend_VDI ;
         debug "Cleaning up the old VIFs" ;
         List.iter (safe_destroy_vif ~__context ~rpc ~session_id) vm_VIFs ;
         debug "Setting up the new VIFs" ;
@@ -341,18 +352,7 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
         error
           "Error while updating the new VBD, VDI, VIF and VGPU records. \
            Cleaning up the cloned VDIs." ;
-        let vdis =
-          cloned.suspend_VDI
-          :: List.fold_left
-               (fun acc (_, vdi, on_error_delete) ->
-                 if on_error_delete then
-                   vdi :: acc
-                 else
-                   acc
-               )
-               [] cloned.disks
-        in
-        List.iter (safe_destroy_vdi ~__context ~rpc ~session_id) vdis ;
+        List.iter (safe_destroy_vdi ~__context ~rpc ~session_id) vdis_to_cleanup ;
         raise e
   )
 

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -206,6 +206,10 @@ let safe_destroy_vusb ~__context ~rpc ~session_id vusb =
   if Db.is_valid_ref __context vusb then
     Client.VUSB.destroy ~rpc ~session_id ~self:vusb
 
+let with_vdis_on_error ~vdis f = try f () with e -> Error (e, vdis)
+
+let ( let@ ) f x = f x
+
 (* Copy the VBDs and VIFs from a source VM to a dest VM and then delete the old
    disks. This operation destroys the data of the dest VM. *)
 type cloned = {
@@ -258,6 +262,17 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
     Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone
       ~__context snap_VBDs_disk driver_params
   in
+  let destroy_vdis_on_error =
+    List.filter_map
+      (fun (_, vdi, on_error_delete) ->
+        if on_error_delete then
+          Some vdi
+        else
+          None
+      )
+      cloned_disks
+  in
+  let@ () = with_vdis_on_error ~vdis:destroy_vdis_on_error in
   let cloned_CDs =
     Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone
       ~__context snap_VBDs_CD driver_params
@@ -292,6 +307,8 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
       Xapi_vm_clone.clone_single_vdi rpc session_id Xapi_vm_clone.Disk_op_clone
         ~__context snap_suspend_VDI driver_params
   in
+  let destroy_vdis_on_error = cloned_suspend_VDI :: destroy_vdis_on_error in
+  let@ () = with_vdis_on_error ~vdis:destroy_vdis_on_error in
   TaskHelper.set_progress ~__context 0.6 ;
   debug "Copying the VBDs" ;
   let (_ : [`VBD] Ref.t list) =
@@ -301,16 +318,7 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
   in
   debug "Update the suspend_VDI" ;
   Db.VM.set_suspend_VDI ~__context ~self:vm ~value:cloned_suspend_VDI ;
-
-  cloned_suspend_VDI
-  :: List.fold_left
-       (fun acc (_, vdi, on_error_delete) ->
-         if on_error_delete then
-           vdi :: acc
-         else
-           acc
-       )
-       [] cloned_disks
+  Ok destroy_vdis_on_error
 
 let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
   let snap_VIFs = Db.VM.get_VIFs ~__context ~self:snapshot in
@@ -321,11 +329,11 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
 
   (* clone all the disks of the snapshot *)
   Helpers.call_api_functions ~__context (fun rpc session_id ->
-      let vdis_to_cleanup =
-        revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm
-      in
-      TaskHelper.set_progress ~__context 0.7 ;
-      try
+      let ( let* ) = Result.bind in
+      let destroy_error_vdis =
+        let* new_vdis = revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm in
+        let@ () = with_vdis_on_error ~vdis:new_vdis in
+        TaskHelper.set_progress ~__context 0.7 ;
         debug "Cleaning up the old VIFs" ;
         List.iter (safe_destroy_vif ~__context ~rpc ~session_id) vm_VIFs ;
         debug "Setting up the new VIFs" ;
@@ -347,13 +355,18 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
         let (_ : [`VGPU] Ref.t list) =
           List.map (fun vgpu -> Xapi_vgpu.copy ~__context ~vm vgpu) snap_VGPUs
         in
-        TaskHelper.set_progress ~__context 0.9
-      with e ->
-        error
-          "Error while updating the new VBD, VDI, VIF and VGPU records. \
-           Cleaning up the cloned VDIs." ;
-        List.iter (safe_destroy_vdi ~__context ~rpc ~session_id) vdis_to_cleanup ;
-        raise e
+        TaskHelper.set_progress ~__context 0.9 ;
+        Ok ()
+      in
+      match destroy_error_vdis with
+      | Ok () ->
+          ()
+      | Error (e, vdis) ->
+          error
+            "Error while updating the new VBD, VDI, VIF and VGPU records. \
+             Cleaning up the cloned VDIs." ;
+          List.iter (safe_destroy_vdi ~__context ~rpc ~session_id) vdis ;
+          raise e
   )
 
 let update_guest_metrics ~__context ~vm ~snapshot =

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -25,7 +25,7 @@ verify-cert () {
 }
 
 mli-files () {
-  N=456
+  N=455
   X="ocaml/tests"
   X+="|ocaml/quicktest"
   X+="|ocaml/message-switch/core_test"

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -25,7 +25,7 @@ verify-cert () {
 }
 
 mli-files () {
-  N=455
+  N=454
   X="ocaml/tests"
   X+="|ocaml/quicktest"
   X+="|ocaml/message-switch/core_test"

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -110,7 +110,7 @@ unixgetenv () {
 }
 
 hashtblfind () {
-  N=33
+  N=32
   # Looks for all .ml files except the ones using Core.Hashtbl.find,
   # which already returns Option
   HASHTBLFIND=$(git grep -P -r --count 'Hashtbl.find(?!_opt)' -- '**/*.ml' ':!ocaml/xapi-storage-script/main.ml' | cut -d ':' -f 2 | paste -sd+ - | bc)


### PR DESCRIPTION
These changes add both unit-tests and quicktests to make sure that regressions introduced with VDI.revert will be visible as early as possible.

In particular:
- unit tests have been added to make sure adding the VDI_REVERT SR operation doesn't break important internal properties.
- quicktests have been added to test behaviour for both Disks and CDs

Changes have been introduced in the error path, now VDIs are properly destroyed in some situation where they were meant to be destroyed, but the code failed to do so, making it more consistent.

This is preparation for the changes to make this proposal a reality: https://github.com/xapi-project/xen-api/blob/master/doc/content/design/snapshot-revert.md

I've run these tests on hosts.