### PR TITLE
[backport] stunnel: assign the tests to the package

### DIFF
--- a/ocaml/libs/stunnel/test/dune
+++ b/ocaml/libs/stunnel/test/dune
@@ -1,5 +1,6 @@
 (test
  (name test_stunnel_log_scanner)
+ (package stunnel)
  (libraries
   alcotest
   astring


### PR DESCRIPTION
Otherwise the tests are run as part of all the packages in the repository
Backport of PR #7057

(cherry picked from commit 18e0e0b3a13dcadaa5fbd232684dcf928b2e6698)
