### PR TITLE
CA-428177: clarify ldaps trusted certificate error messages

### DIFF
--- a/doc/content/design/external-auth-ldaps.md
+++ b/doc/content/design/external-auth-ldaps.md
@@ -91,8 +91,8 @@ Given `ldaps` default to `false`, this feature is **NOT** enabled until explicit
 
 #### 3.1.2 Error code
 Following new error codes added to indicate ldaps enable related error
-- `POOL_AUTH_ENABLE_FAILED_NO_TRUSTED_CERTS`: no trusted certs can be used for ldaps, refer to 4.1.2 for certs finding.
-- `POOL_AUTH_ENABLE_FAILED_INVALID_TRUSTED_CERTS`: found trusted certs, but none of the certs can be used to connect to DC.
+- `POOL_AUTH_ENABLE_FAILED_NO_TRUSTED_CERTS`: no trusted certs can be used for ldaps, refer to 4.1.2 for trusted certs finding.
+- `POOL_AUTH_ENABLE_FAILED_INVALID_TRUSTED_CERTS`: found trusted certs, but none of the trusted certs can be used to connect to DC.
 - `POOL_AUTH_ENABLE_FAILED_SETUP_TLS_CONNECTION`: failed to set up TLS connection to DC (e.g. GnuTLS handshake failure such as `tstream_tls_sync_setup: GNUTLS ERROR`). The error message contains the underlying details reported by winbind.
 
 **Note**: Current error code handling infrastructure requires the error code prefix with `POOL_AUTH_ENABLE_FAILED`.
@@ -137,8 +137,8 @@ xe pool-external-auth-set-ldaps uuid=<uuid> ldaps=<true|false>
 
 #### 3.2.1.2 Error code
 This API may raise following errors
-- `AUTH_NO_TRUSTED_CERTS`: no trusted certs found to enable ldaps, refer to 4.1.2 for certs finding.
-- `AUTH_INVALID_TRUSTED_CERTS`: found trusted certs, but none of the certs can be used to connect to DC.
+- `AUTH_NO_TRUSTED_CERTS`: no trusted certs found to enable ldaps, refer to 4.1.2 for trusted certs finding.
+- `AUTH_INVALID_TRUSTED_CERTS`: found trusted certs, but none of the trusted certs can be used to connect to DC.
 - `AUTH_SETUP_TLS_CONNECTION`: failed to set up TLS CONNECTION to DC (e.g. GnuTLS handshake failure such as `tstream_tls_sync_setup: GNUTLS ERROR`). The error message contains the underlying details reported by winbind.
 - `AUTH_IS_DISABLED`: AD is not enabled.
 - `AUTH_SET_LDAPS_FAILED`: Failed to set ldaps, the error message contains the details like ldap query on domain failed.

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -737,11 +737,13 @@ let _ =
     ~doc:"External authentication is disabled" () ;
   error Api_errors.auth_invalid_trusted_certs ["message"]
     ~doc:
-      "The certificates are invalid to setup a TLS connection to Active \
-       Directory."
+      "The trusted certificates are invalid to setup a TLS connection to \
+       Active Directory."
     () ;
   error Api_errors.auth_no_trusted_certs ["message"]
-    ~doc:"No certificates found to setup a TLS connection to Active Directory"
+    ~doc:
+      "No trusted CA certificates found to setup a TLS connection to Active \
+       Directory"
     () ;
   error Api_errors.auth_enable_failed ["message"]
     ~doc:"The host failed to enable external authentication." () ;

--- a/ocaml/xapi/extauth_plugin_ADwinbind.ml
+++ b/ocaml/xapi/extauth_plugin_ADwinbind.ml
@@ -109,8 +109,8 @@ let assert_ca_exists = function
       |> Option.to_result
            ~none:
              (gen_ex E_NO_TRUSTED_CERTS
-                "No certs to setup TLS connection to DC. Note: ldaps does not \
-                 support non-CA certs"
+                "No trusted certs to setup TLS connection to DC. Note: ldaps \
+                 does not support non-CA certs"
              )
       |> maybe_raise
       |> ignore


### PR DESCRIPTION
Rename the user-facing "certs"/"certificates" wording to "trusted certs" in the ldaps external-auth error paths, and add a hint pointing at both possible causes for invalid trusted certificates.

- extauth_plugin_ADwinbind.ml: "No certs..." -> "No trusted certs..."
- AUTH_NO_TRUSTED_CERTS: "No certificates found..." ->
  "No trusted CA certificates found..."
- AUTH_INVALID_TRUSTED_CERTS and AUTH_ENABLE_FAILED_INVALID_TRUSTED_CERTS: reword to "trusted certificates" and append "This can be caused by trusted certificates on XenServer or certificates on Active Directory."
- external-auth-ldaps.md: align error-code descriptions.