### PR TITLE
xapi_pci: Disallow passthrough for boot devices

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -459,6 +459,9 @@ let _ =
   error Api_errors.nvidia_sriov_misconfigured ["host"; "device_name"]
     ~doc:"The NVidia GPU is not configured for SR-IOV as expected" () ;
 
+  error Api_errors.boot_device_passthrough_disallowed ["device"]
+    ~doc:"Passing through a PCI device backing a boot disk is disallowed" () ;
+
   error Api_errors.openvswitch_not_active []
     ~doc:
       "This operation needs the OpenVSwitch networking backend to be enabled \

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1462,3 +1462,6 @@ let not_allowed_when_ntp_is_enabled =
 let not_trusted_certificate = add_error "NOT_TRUSTED_CERTIFICATE"
 
 let certificate_lacks_purpose = add_error "CERTIFICATE_LACKS_PURPOSE"
+
+let boot_device_passthrough_disallowed =
+  add_error "BOOT_DEVICE_PASSTHROUGH_DISALLOWED"

--- a/ocaml/xapi/xapi_pci.ml
+++ b/ocaml/xapi/xapi_pci.ml
@@ -323,7 +323,14 @@ let get_system_display_device () =
   with _ -> None
 
 let disable_dom0_access ~__context ~self =
-  Xapi_pci_helpers.update_dom0_access ~__context ~self ~action:`disable
+  (* Disallow passing through a dom0 boot device *)
+  let pci_id = Db.PCI.get_pci_id ~__context ~self in
+  match Xapi_pci_helpers.find_boot_device () with
+  | Some (boot_device, path) when pci_id = boot_device ->
+      raise
+        Api_errors.(Server_error (boot_device_passthrough_disallowed, [path]))
+  | _ ->
+      Xapi_pci_helpers.update_dom0_access ~__context ~self ~action:`disable
 
 let enable_dom0_access ~__context ~self =
   Xapi_pci_helpers.update_dom0_access ~__context ~self ~action:`enable

--- a/ocaml/xapi/xapi_pci_helpers.ml
+++ b/ocaml/xapi/xapi_pci_helpers.ml
@@ -240,3 +240,24 @@ let update_dom0_access ~__context ~self ~action =
     pgpus ;
 
   new_access
+
+let find_boot_device () =
+  try
+    let open Forkhelpers in
+    let source_device, _ =
+      execute_command_get_output "/usr/bin/findmnt" ["-no"; "source"; "/"]
+    in
+    let source_device = String.trim source_device in
+    let path, _ =
+      execute_command_get_output !Xapi_globs.udevadm
+        ["info"; "-q"; "path"; "-n"; source_device]
+    in
+    match String.split_on_char '/' path with
+    | _ :: _ :: _ :: dev :: _ ->
+        Some (dev, source_device)
+    | _ ->
+        None
+  with e ->
+    warn "Couldn't find the PCI device behind the root drive: %s"
+      (Printexc.to_string e) ;
+    None


### PR DESCRIPTION
It is currently possible to accidentally pass through a PCI device backing the boot drive, making the system unbootable and requiring manual intervention (since dom0 will no longer be able to access the PCI device).

Fix this at least for the drive behind '/', refusing to pass through its PCI device.

As an example, for `00:1f.2` SATA controller behind '/':

    $ /usr/bin/findmnt -no source /
    /dev/sda1
    $ udevadm info -q path -n /dev/sda1
    /devices/pci0000:00/0000:00:1f.2/ata5/host4/target4:0:0/4:0:0:0/block/sda/sda1

Disabling dom0 access before this commit:

    $ xe pci-disable-dom0-access uuid=$UUID
    disable_on_reboot
    $ /opt/xensource/libexec/xen-cmdline --get-dom0 xen-pciback.hide
    xen-pciback.hide=(0000:00:1f.2)

After:

    $ xe pci-disable-dom0-access uuid=$UUID
    Passing through a PCI device backing a boot disk is disallowed
    device: /dev/sda1
    $ /opt/xensource/libexec/xen-cmdline --get-dom0 xen-pciback.hide
    <empty>