### PR TITLE
Add rate limiting feature to xapi

### DIFF
--- a/doc/content/design/rate_limit.md
+++ b/doc/content/design/rate_limit.md
@@ -2,8 +2,8 @@
 title: Rate Limiting
 layout: default
 design_doc: true
-revision: 2
-status: draft
+revision: 3
+status: confirmed
 ---
 
 <!--toc:start-->
@@ -172,13 +172,21 @@ code by storing direct references to objects where possible.
 
 ### API functions
 We define the following API functions for the caller datamodel:
-- `Caller.create(name_label, name_description, user_agent, client_ip)`: Create a new caller.
-- `Caller.set_name_label(caller, name_label)`: Set name label on the caller
-- `Caller.destroy(caller)`: Destroy the caller
-- `Caller.add_group(caller, group)`: Add caller to group
-- `Caller.remove_group(caller, group)`: Remove caller from group
-- `Caller.query_usage(caller, time_period)`: Obtain usage statistics for an individual caller
-- `Caller.query_group_usage(group, time_period)`: Obtain usage statistics for a group of callers
+- `Caller.create`/`Caller.destroy`: Auto-generated constructor and destructor
+  for callers.
+- `Caller.add_group(self, group)`: Add a caller to a group.
+- `Caller.remove_group(self, group)`: Remove a caller from a group.
+- `Caller.query_token_usage(self)`: Return tokens used by this caller since Xapi
+  startup.
+- `Caller.query_call_count(self)`: Return number of calls made by this caller
+  since Xapi startup.
+- `Caller.query_group_token_usage(group)`: Return tokens used since Xapi startup
+  by the callers in the named group.
+- `Caller.query_group_call_count(group)`: Return number of calls made since Xapi
+  startup by the callers in the named group.
+- `Caller.query_all_usage()`: Return per-caller usage (rows of `[uuid;
+  name_label; tokens; calls]`) for every known caller, sorted by token use
+  descending.
 
 And the following functions for the rate limiter datamodel:
 - `Rate_limit.create(name_label, callers, burst_size, fill_rate)`: Create a

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -10609,6 +10609,8 @@ let all_system =
   ; Datamodel_vm_group.t
   ; Datamodel_host_driver.t
   ; Datamodel_driver_variant.t
+  ; Datamodel_caller.t
+  ; Datamodel_rate_limit.t
   ]
 
 (* If the relation is one-to-many, the "many" nodes (one edge each) must come before the "one" node (many edges) *)
@@ -10702,6 +10704,7 @@ let all_relations =
   ; ((_certificate, "host"), (_host, "certificates"))
   ; ((_vm, "groups"), (_vm_group, "VMs"))
   ; ((_driver_variant, "driver"), (_host_driver, "variants"))
+  ; ((_caller, "rate_limit"), (_rate_limit, "callers"))
   ]
 
 let update_lifecycles =
@@ -10860,6 +10863,8 @@ let expose_get_all_messages_for =
   ; _observer
   ; _host_driver
   ; _driver_variant
+  ; _caller
+  ; _rate_limit
   ]
 
 let no_task_id_for = [_task; (* _alert; *) _event]
@@ -11215,6 +11220,11 @@ let http_actions =
     )
   ; ("put_bundle", (Put, Constants.put_bundle_uri, true, [], _R_POOL_OP, []))
   ]
+
+(* Actions that incorporate the rate limiter from Xapi_rate_limiting within
+   their handler - handlers not listed here get rate limited when accessed *)
+let custom_rate_limit_http_actions =
+  ["post_root"; "post_RPC2"; "post_jsonrpc"; "post_cli"]
 
 (* these public http actions will NOT be checked by RBAC *)
 (* they are meant to be used in exceptional cases where RBAC is already *)

--- a/ocaml/idl/datamodel_caller.ml
+++ b/ocaml/idl/datamodel_caller.ml
@@ -1,0 +1,126 @@
+(*
+ * Copyright (C) Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Datamodel_types
+open Datamodel_common
+open Datamodel_roles
+
+let lifecycle = []
+
+let add_group =
+  call ~name:"add_group" ~doc:"Add a caller to a group" ~in_oss_since:None
+    ~lifecycle
+    ~params:
+      [
+        (Ref _caller, "self", "The caller to update")
+      ; (String, "group", "Group the caller is being added to")
+      ]
+    ~allowed_roles:_R_POOL_OP ()
+
+let remove_group =
+  call ~name:"remove_group" ~doc:"Remove a caller from a group"
+    ~in_oss_since:None ~lifecycle
+    ~params:
+      [
+        (Ref _caller, "self", "The caller to update")
+      ; (String, "group", "Group the caller is removed from")
+      ]
+    ~allowed_roles:_R_POOL_OP ()
+
+let query_token_usage =
+  call ~name:"query_token_usage"
+    ~doc:"Return tokens used by this caller since Xapi startup"
+    ~in_oss_since:None ~lifecycle
+    ~params:[(Ref _caller, "self", "The caller to query")]
+    ~result:(Float, "Tokens used by the caller since Xapi startup")
+    ~allowed_roles:_R_POOL_OP ()
+
+let query_call_count =
+  call ~name:"query_call_count"
+    ~doc:"Return number of calls made by this caller since Xapi startup"
+    ~in_oss_since:None ~lifecycle
+    ~params:[(Ref _caller, "self", "The caller to query")]
+    ~result:(Int, "Calls made by the caller since Xapi startup")
+    ~allowed_roles:_R_POOL_OP ()
+
+let query_group_token_usage =
+  call ~name:"query_group_token_usage"
+    ~doc:
+      "Return tokens used since Xapi startup by the callers in the named group."
+    ~in_oss_since:None ~lifecycle
+    ~params:[(String, "group", "Caller group to aggregate over")]
+    ~result:(Float, "Tokens used by the group since Xapi startup")
+    ~allowed_roles:_R_POOL_OP ()
+
+let query_group_call_count =
+  call ~name:"query_group_call_count"
+    ~doc:
+      "Return number of calls made since Xapi startup by the callers in the \
+       named group."
+    ~in_oss_since:None ~lifecycle
+    ~params:[(String, "group", "Caller group to aggregate over")]
+    ~result:(Int, "Number of calls made by the callers in the group")
+    ~allowed_roles:_R_POOL_OP ()
+
+let query_all_usage =
+  call ~name:"query_all_usage"
+    ~doc:
+      "Return per-caller usage for every known caller, sorted by token use \
+       descending."
+    ~in_oss_since:None ~lifecycle ~params:[]
+    ~result:
+      ( Set (Set String)
+      , "Rows of [uuid; name_label; tokens; calls], highest tokens first"
+      )
+    ~allowed_roles:_R_POOL_OP ()
+
+let t =
+  create_obj ~name:_caller ~descr:"XAPI caller description and rate limiting"
+    ~doccomments:[] ~gen_constructor_destructor:true ~gen_events:true
+    ~in_db:true ~lifecycle ~persist:PersistEverything ~in_oss_since:None
+    ~messages_default_allowed_roles:_R_POOL_ADMIN
+    ~contents:
+      [
+        uid _caller ~lifecycle
+      ; namespace ~name:"name" ~contents:(names None RW ~lifecycle) ()
+      ; field ~qualifier:StaticRO ~ty:String ~lifecycle "user_agent"
+          "User agent matching pattern. Empty string is a full wildcard; a \
+           trailing '*' makes the field a prefix pattern; otherwise the field \
+           is matched exactly."
+          ~default_value:(Some (VString ""))
+      ; field ~qualifier:StaticRO ~ty:String ~lifecycle "client_ip"
+          "Client IP matching pattern. Same wildcard semantics as user_agent."
+          ~default_value:(Some (VString ""))
+      ; field ~qualifier:DynamicRO ~ty:DateTime ~lifecycle "last_access"
+          "Last time a call was received from this caller"
+          ~default_value:(Some (VDateTime Date.epoch))
+      ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle "groups"
+          "Groups to which this caller has been assigned"
+          ~default_value:(Some (VSet []))
+      ; field ~qualifier:DynamicRO ~ty:(Ref _rate_limit) ~lifecycle "rate_limit"
+          "Rate limiter attached to this caller, if any. Populated via \
+           Rate_limit.add_caller rather than set directly."
+          ~default_value:(Some (VRef null_ref))
+      ]
+    ~messages:
+      [
+        add_group
+      ; remove_group
+      ; query_token_usage
+      ; query_call_count
+      ; query_group_token_usage
+      ; query_group_call_count
+      ; query_all_usage
+      ]
+    ()

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 906
+let schema_minor_vsn = 905
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5
@@ -314,6 +314,10 @@ let _observer = "Observer"
 let _host_driver = "Host_driver"
 
 let _driver_variant = "Driver_variant"
+
+let _caller = "Caller"
+
+let _rate_limit = "Rate_limit"
 
 let update_guidances =
   Enum

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -1,4 +1,8 @@
 let prototyped_of_class = function
+  | "Rate_limit" ->
+      Some "26.14.0"
+  | "Caller" ->
+      Some "26.14.0"
   | "Driver_variant" ->
       Some "25.2.0"
   | "Host_driver" ->
@@ -13,6 +17,34 @@ let prototyped_of_class = function
       None
 
 let prototyped_of_field = function
+  | "Rate_limit", "fill_rate" ->
+      Some "26.14.0"
+  | "Rate_limit", "burst_size" ->
+      Some "26.14.0"
+  | "Rate_limit", "callers" ->
+      Some "26.7.0"
+  | "Rate_limit", "name__description" ->
+      Some "26.7.0"
+  | "Rate_limit", "name__label" ->
+      Some "26.7.0"
+  | "Rate_limit", "uuid" ->
+      Some "26.14.0"
+  | "Caller", "rate_limit" ->
+      Some "26.7.0"
+  | "Caller", "groups" ->
+      Some "26.7.0"
+  | "Caller", "last_access" ->
+      Some "26.7.0"
+  | "Caller", "client_ip" ->
+      Some "26.7.0"
+  | "Caller", "user_agent" ->
+      Some "26.14.0"
+  | "Caller", "name__description" ->
+      Some "26.7.0"
+  | "Caller", "name__label" ->
+      Some "26.7.0"
+  | "Caller", "uuid" ->
+      Some "26.14.0"
   | "Driver_variant", "status" ->
       Some "25.2.0"
   | "Driver_variant", "priority" ->
@@ -203,6 +235,28 @@ let prototyped_of_field = function
       None
 
 let prototyped_of_message = function
+  | "Rate_limit", "set_fill_rate" ->
+      Some "26.7.0"
+  | "Rate_limit", "set_burst_size" ->
+      Some "26.7.0"
+  | "Rate_limit", "remove_caller" ->
+      Some "26.7.0"
+  | "Rate_limit", "add_caller" ->
+      Some "26.7.0"
+  | "Caller", "query_all_usage" ->
+      Some "26.7.0"
+  | "Caller", "query_group_call_count" ->
+      Some "26.15.0"
+  | "Caller", "query_group_token_usage" ->
+      Some "26.15.0"
+  | "Caller", "query_call_count" ->
+      Some "26.15.0"
+  | "Caller", "query_token_usage" ->
+      Some "26.15.0"
+  | "Caller", "remove_group" ->
+      Some "26.7.0"
+  | "Caller", "add_group" ->
+      Some "26.7.0"
   | "Driver_variant", "select" ->
       Some "25.2.0"
   | "Host_driver", "rescan" ->

--- a/ocaml/idl/datamodel_rate_limit.ml
+++ b/ocaml/idl/datamodel_rate_limit.ml
@@ -1,0 +1,85 @@
+(*
+ * Copyright (C) Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Datamodel_types
+open Datamodel_common
+open Datamodel_roles
+
+let lifecycle = []
+
+let add_caller =
+  call ~name:"add_caller"
+    ~doc:
+      "Attach the given caller to this rate limiter. Replaces any rate limiter \
+       previously attached to the caller."
+    ~in_oss_since:None ~lifecycle
+    ~params:
+      [
+        (Ref _rate_limit, "self", "The rate limiter")
+      ; (Ref _caller, "caller", "The caller to attach")
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let remove_caller =
+  call ~name:"remove_caller"
+    ~doc:"Detach the given caller from this rate limiter" ~in_oss_since:None
+    ~lifecycle
+    ~params:
+      [
+        (Ref _rate_limit, "self", "The rate limiter")
+      ; (Ref _caller, "caller", "The caller to detach")
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let set_burst_size =
+  call ~name:"set_burst_size" ~doc:"Set the burst size of the rate limiter"
+    ~in_oss_since:None ~lifecycle
+    ~params:
+      [
+        (Ref _rate_limit, "self", "The rate limiter")
+      ; (Float, "value", "The new burst size, must be positive")
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let set_fill_rate =
+  call ~name:"set_fill_rate" ~doc:"Set the fill rate of the rate limiter"
+    ~in_oss_since:None ~lifecycle
+    ~params:
+      [
+        (Ref _rate_limit, "self", "The rate limiter")
+      ; (Float, "value", "The new fill rate (tokens/second), must be positive")
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let t =
+  create_obj ~name:_rate_limit
+    ~descr:"A rate limiter associated with one or more callers" ~doccomments:[]
+    ~gen_constructor_destructor:true ~gen_events:true ~in_db:true ~lifecycle
+    ~persist:PersistEverything ~in_oss_since:None
+    ~messages_default_allowed_roles:_R_POOL_ADMIN
+    ~contents:
+      [
+        uid _rate_limit ~lifecycle
+      ; namespace ~name:"name" ~contents:(names None RW ~lifecycle) ()
+      ; field ~qualifier:DynamicRO ~ty:(Set (Ref _caller)) ~lifecycle "callers"
+          "The set of callers attached to this rate limiter"
+      ; field ~qualifier:StaticRO ~ty:Float ~lifecycle "burst_size"
+          "Maximum tokens that the bucket can hold"
+          ~default_value:(Some (VFloat 0.))
+      ; field ~qualifier:StaticRO ~ty:Float ~lifecycle "fill_rate"
+          "Tokens added to the bucket per second"
+          ~default_value:(Some (VFloat 0.))
+      ]
+    ~messages:[add_caller; remove_caller; set_burst_size; set_fill_rate]
+    ()

--- a/ocaml/idl/dune
+++ b/ocaml/idl/dune
@@ -7,7 +7,9 @@
     datamodel_values datamodel_schema datamodel_certificate
     datamodel_diagnostics datamodel_repository datamodel_lifecycle
     datamodel_vtpm datamodel_observer datamodel_vm_group api_version
-    datamodel_host_driver datamodel_driver_variant)
+    datamodel_host_driver datamodel_driver_variant datamodel_caller
+    datamodel_rate_limit
+    )
   (libraries
     rpclib.core
     sexplib0

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "981fd4b2f96e75ee70540759ebd0f37d"
+let last_known_schema_hash = "4d830e625f1634684e871f0924d6c13a"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/libs/rate-limit/caller_table.ml
+++ b/ocaml/libs/rate-limit/caller_table.ml
@@ -162,3 +162,5 @@ let get_exact t ~pattern =
   let {table; _} = Atomic.get t in
   Option.map snd
     (List.find_opt (fun (key, _) -> Key.equal_pattern key pattern) table)
+
+let to_list t = (Atomic.get t).table

--- a/ocaml/libs/rate-limit/caller_table.mli
+++ b/ocaml/libs/rate-limit/caller_table.mli
@@ -37,6 +37,10 @@ module Key : sig
   val compare : pattern_key -> pattern_key -> int
   (** Total order on patterns: fewer wildcards first, then lexicographic
       by patterns. *)
+
+  val is_all_wildcard : pattern_key -> bool
+  (** [is_all_wildcard k] returns true if every field of [k] is a full
+      wildcard ([Prefix ""]). Such patterns are rejected by [insert]. *)
 end
 
 (** List of entries mapping patterns to values.
@@ -69,3 +73,7 @@ val get_exact : 'a t -> pattern:Key.pattern_key -> 'a option
 (** [get_exact t ~pattern] returns the value for the entry whose pattern
     is exactly equal to [pattern], or [None]. Does not use wildcard
     matching. *)
+
+val to_list : 'a t -> (Key.pattern_key * 'a) list
+(** [to_list t] returns a snapshot of all entries in [t], most specific
+    first. *)

--- a/ocaml/libs/rate-limit/dune
+++ b/ocaml/libs/rate-limit/dune
@@ -1,5 +1,5 @@
 (library
- (name xapi_rate_limit)
+ (name rate_limit_lib)
  (public_name xapi-rate-limit)
 
  (libraries threads.posix mtime mtime.clock.os xapi-log xapi-stdext-threads clock)

--- a/ocaml/libs/rate-limit/rate_limit.ml
+++ b/ocaml/libs/rate-limit/rate_limit.ml
@@ -32,26 +32,36 @@ let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
    amount becomes available *)
 let rec worker_loop ~bucket ~process_queue ~process_queue_lock
     ~worker_thread_cond ~should_terminate =
-  let process_item cost callback =
-    Token_bucket.delay_then_consume bucket cost ;
-    callback ()
-  in
-  let item_opt =
+  let peeked =
     with_lock process_queue_lock (fun () ->
         while
           Queue.is_empty process_queue && not (Atomic.get should_terminate)
         do
           Condition.wait worker_thread_cond process_queue_lock
         done ;
-        Queue.take_opt process_queue
+        match Queue.peek_opt process_queue with
+        | None ->
+            None
+        | Some (cost, _) ->
+            let delay = Token_bucket.get_delay_until_available bucket cost in
+            Some (cost, delay)
     )
   in
-  match item_opt with
+  match peeked with
   | None ->
       (* Queue is empty only when termination was signalled *)
       D.debug "%s: queue empty in deleted rate limiter; exiting" __FUNCTION__
-  | Some (cost, callback) ->
-      process_item cost callback ;
+  | Some (cost, delay) ->
+      if delay > 0. then Thread.delay delay ;
+      let callback_opt =
+        with_lock process_queue_lock (fun () ->
+            if Token_bucket.consume bucket cost then
+              Option.map snd (Queue.take_opt process_queue)
+            else
+              None
+        )
+      in
+      Option.iter (fun cb -> cb ()) callback_opt ;
       worker_loop ~bucket ~process_queue ~process_queue_lock ~worker_thread_cond
         ~should_terminate
 

--- a/ocaml/libs/rate-limit/test/dune
+++ b/ocaml/libs/rate-limit/test/dune
@@ -1,4 +1,4 @@
 (tests
  (names test_token_bucket test_rate_limit test_linked_list test_lru test_caller_table test_caller_statistics)
  (package xapi-rate-limit)
- (libraries xapi_rate_limit alcotest qcheck-core qcheck-alcotest mtime mtime.clock.os fmt xapi-log threads.posix))
+ (libraries rate_limit_lib alcotest qcheck-core qcheck-alcotest mtime mtime.clock.os fmt xapi-log threads.posix))

--- a/ocaml/libs/rate-limit/test/test_caller_statistics.ml
+++ b/ocaml/libs/rate-limit/test/test_caller_statistics.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module Caller_statistics = Xapi_rate_limit.Caller_statistics
+module Caller_statistics = Rate_limit_lib.Caller_statistics
 
 let test_initial_state () =
   let cs = Caller_statistics.create ~caller_uuid:"uuid-1" in

--- a/ocaml/libs/rate-limit/test/test_caller_table.ml
+++ b/ocaml/libs/rate-limit/test/test_caller_table.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module Caller_table = Xapi_rate_limit.Caller_table
+module Caller_table = Rate_limit_lib.Caller_table
 open Caller_table.Key
 
 (* Build a target (Key.t) from a single string for the user_agent field. *)

--- a/ocaml/libs/rate-limit/test/test_linked_list.ml
+++ b/ocaml/libs/rate-limit/test/test_linked_list.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module LL = Xapi_rate_limit.Linked_list
+module LL = Rate_limit_lib.Linked_list
 
 (* Generators *)
 let chars =

--- a/ocaml/libs/rate-limit/test/test_lru.ml
+++ b/ocaml/libs/rate-limit/test/test_lru.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module LRU = Xapi_rate_limit.Lru
+module LRU = Rate_limit_lib.Lru
 
 (* Generators *)
 let kvs =

--- a/ocaml/libs/rate-limit/test/test_rate_limit.ml
+++ b/ocaml/libs/rate-limit/test/test_rate_limit.ml
@@ -132,6 +132,30 @@ let test_submit_sync_concurrent () =
   done ;
   Rate_limit.delete rl
 
+let test_no_skip_ahead_during_worker_delay () =
+  (* A caller arriving while the worker is delaying the only queued item
+     must not skip ahead of it. The queued item has a large cost so the
+     worker's delay is long enough for the bucket to refill enough that a
+     newly-arriving cheap caller could opportunistically consume without
+     the fix. *)
+  let rl = Rate_limit.create ~burst_size:10.0 ~fill_rate:100.0 in
+  Rate_limit.submit_async rl ~callback:(fun () -> ()) 10.0 ;
+  let execution_order = ref [] in
+  let order_mutex = Mutex.create () in
+  let record_execution id =
+    Mutex.lock order_mutex ;
+    execution_order := id :: !execution_order ;
+    Mutex.unlock order_mutex
+  in
+  Rate_limit.submit_async rl ~callback:(fun () -> record_execution 1) 10.0 ;
+  Thread.delay 0.02 ;
+  Rate_limit.submit_async rl ~callback:(fun () -> record_execution 2) 1.0 ;
+  Thread.delay 0.2 ;
+  let order = List.rev !execution_order in
+  Alcotest.(check (list int))
+    "late arrival does not overtake queued item" [1; 2] order ;
+  Rate_limit.delete rl
+
 let test_submit_sync_interleaved () =
   (* Test interleaving submit and submit_sync *)
   let rl = Rate_limit.create ~burst_size:2.0 ~fill_rate:10.0 in
@@ -157,6 +181,10 @@ let test =
   ; ("Submit sync with queue", `Slow, test_submit_sync_with_queued_items)
   ; ("Submit sync concurrent", `Slow, test_submit_sync_concurrent)
   ; ("Submit sync interleaved", `Slow, test_submit_sync_interleaved)
+  ; ( "No skip-ahead during worker delay"
+    , `Slow
+    , test_no_skip_ahead_during_worker_delay
+    )
   ]
 
 let () = Alcotest.run "Rate limit library" [("Rate limit tests", test)]

--- a/ocaml/libs/rate-limit/test/test_rate_limit.ml
+++ b/ocaml/libs/rate-limit/test/test_rate_limit.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module Rate_limit = Xapi_rate_limit.Rate_limit
+module Rate_limit = Rate_limit_lib.Rate_limit
 
 let test_create_invalid () =
   Alcotest.match_raises "Creating with zero fill rate should raise"

--- a/ocaml/libs/rate-limit/test/test_token_bucket.ml
+++ b/ocaml/libs/rate-limit/test/test_token_bucket.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module Token_bucket = Xapi_rate_limit.Token_bucket
+module Token_bucket = Rate_limit_lib.Token_bucket
 
 let test_bad_fill_rate () =
   Alcotest.match_raises "Creating a token bucket with 0 fill rate should fail"

--- a/ocaml/libs/uuid/uuidx.ml
+++ b/ocaml/libs/uuid/uuidx.ml
@@ -64,6 +64,8 @@ type without_secret =
   | `sr_stat
   | `subject
   | `task
+  | `Caller
+  | `Rate_limit
   | `tunnel
   | `USB_group
   | `user

--- a/ocaml/libs/uuid/uuidx.mli
+++ b/ocaml/libs/uuid/uuidx.mli
@@ -75,6 +75,8 @@ type without_secret =
   | `sr_stat
   | `subject
   | `task
+  | `Caller
+  | `Rate_limit
   | `tunnel
   | `USB_group
   | `user

--- a/ocaml/quicktest/quicktest.ml
+++ b/ocaml/quicktest/quicktest.ml
@@ -78,6 +78,7 @@ let () =
         ; ("Quicktest_static_vdis", Quicktest_static_vdis.tests ())
         ; ("Quicktest_date", Quicktest_date.tests ())
         ; ("Quicktest_crypt_r", Quicktest_crypt_r.tests ())
+        ; ("Quicktest_rate_limit", Quicktest_rate_limit.tests ())
         ]
         @ ( if not !Quicktest_args.using_unix_domain_socket then
               [("http", Quicktest_http.tests)]

--- a/ocaml/quicktest/quicktest_rate_limit.ml
+++ b/ocaml/quicktest/quicktest_rate_limit.ml
@@ -1,0 +1,177 @@
+module Caller = Client.Client.Caller
+module Rate_limit = Client.Client.Rate_limit
+module Pool = Client.Client.Pool
+
+(* Create an RPC function that uses a specific User-Agent header *)
+let make_rpc_with_user_agent user_agent =
+  let http =
+    Http.Request.make ~user_agent ~version:"1.1" ~keep_alive:false Http.Post "/"
+  in
+  fun xml ->
+    Xmlrpc_client.XMLRPC_protocol.rpc ~srcstr:"quicktest" ~dststr:"xapi"
+      ~transport:(Unix Xapi_globs.unix_domain_socket) ~http xml
+
+(* Build a caller + rate-limit pair and link them. Returns a cleanup
+   thunk that tears them down in dependency order. *)
+let with_throttled_caller rpc session_id ~name ~user_agent ~burst_size
+    ~fill_rate k =
+  let caller_ref =
+    Caller.create ~rpc ~session_id ~name_label:name ~name_description:""
+      ~user_agent ~client_ip:""
+  in
+  let rate_limit_ref =
+    Rate_limit.create ~rpc ~session_id ~name_label:name ~name_description:""
+      ~burst_size ~fill_rate
+  in
+  Rate_limit.add_caller ~rpc ~session_id ~self:rate_limit_ref ~caller:caller_ref ;
+  let cleanup () =
+    (* destroy clears each caller's rate_limit pointer first. *)
+    (try Rate_limit.destroy ~rpc ~session_id ~self:rate_limit_ref with _ -> ()) ;
+    try Caller.destroy ~rpc ~session_id ~self:caller_ref with _ -> ()
+  in
+  Fun.protect ~finally:cleanup (fun () -> k caller_ref rate_limit_ref)
+
+(* Detect whether the server has rate limiting enabled. The Caller datamodel
+   API works regardless of the feature flag (validation and DB CRUD always
+   run), but dispatch-time bookkeeping (which feeds Caller.query_usage) only
+   happens when rate_limit=true in xapi.conf. So if a probe of throttled calls
+   leaves the caller's "calls" counter at 0, the server is running with the
+   feature disabled and the throttling assertions cannot be meaningfully run. *)
+let rate_limiting_active rpc session_id caller_ref ~throttled_rpc =
+  for _ = 1 to 5 do
+    ignore (Client.Client.Pool.get_all ~rpc:throttled_rpc ~session_id)
+  done ;
+  let usage =
+    Client.Client.Caller.query_call_count ~rpc ~session_id ~self:caller_ref
+  in
+  usage > 0L
+
+let rate_limit_throttling_test rpc session_id () =
+  let test_user_agent =
+    "quicktest-rate-limit-throttle-" ^ Uuidx.(to_string (make ()))
+  in
+  let burst_size = 0.5 in
+  let fill_rate = 2.0 in
+  (* Token cost for pool.get_all from xapi_caller.ml (default_token_cost) *)
+  let call_cost = 0.1 in
+  with_throttled_caller rpc session_id ~name:"quicktest-throttle"
+    ~user_agent:test_user_agent ~burst_size ~fill_rate (fun caller_ref _ ->
+      let throttled_rpc = make_rpc_with_user_agent test_user_agent in
+      if not (rate_limiting_active rpc session_id caller_ref ~throttled_rpc)
+      then
+        Printf.printf
+          "Rate limiting disabled on server (rate_limit=false in xapi.conf); \
+           skipping throttling assertions\n\
+           %!"
+      else
+        let make_call () =
+          ignore (Client.Client.Pool.get_all ~rpc:throttled_rpc ~session_id)
+        in
+        (* Measure baseline: unthrottled calls *)
+        let num_calls = 100 in
+        let start_unthrottled = Mtime_clock.counter () in
+        for _ = 1 to num_calls do
+          ignore (Client.Client.Pool.get_all ~rpc ~session_id)
+        done ;
+        let elapsed_unthrottled =
+          Mtime.Span.to_float_ns (Mtime_clock.count start_unthrottled) *. 1e-9
+        in
+        Printf.printf "%d unthrottled calls took %.3f seconds\n%!" num_calls
+          elapsed_unthrottled ;
+        let start_throttled = Mtime_clock.counter () in
+        for _ = 1 to num_calls do
+          make_call ()
+        done ;
+        let elapsed_throttled =
+          Mtime.Span.to_float_ns (Mtime_clock.count start_throttled) *. 1e-9
+        in
+        Printf.printf "%d throttled calls took %.3f seconds\n%!" num_calls
+          elapsed_throttled ;
+        let throttle_ratio =
+          elapsed_throttled /. max elapsed_unthrottled 0.001
+        in
+        Printf.printf "Throttle ratio: %.2fx slower\n%!" throttle_ratio ;
+        (* Throttled calls should take noticeably longer - at least 2x slower *)
+        Alcotest.(check bool)
+          "Rate limiting causes observable slowdown" true (throttle_ratio > 2.0) ;
+        (* Absolute upper bound: time should not exceed theoretical maximum
+           based on token bucket math: (total_cost - burst) / fill_rate *)
+        let num_calls_f = Float.of_int num_calls in
+        let total_cost = num_calls_f *. call_cost in
+        let max_time = (total_cost -. burst_size) /. fill_rate in
+        Printf.printf "Max expected time: %.3f seconds\n%!" max_time ;
+        Alcotest.(check bool)
+          "Execution time within theoretical bound" true
+          (elapsed_throttled <= max_time)
+  )
+
+(* Test that invalid rate limits are rejected *)
+let rate_limit_invalid_test rpc session_id () =
+  let is_invalid_value f =
+    try f () ; false
+    with Api_errors.Server_error (code, _) -> code = Api_errors.invalid_value
+  in
+  (* Creating with non-positive fill_rate or burst_size must fail before any
+     state is left behind. *)
+  Alcotest.(check bool)
+    "Zero fill rate rejected at create" true
+    (is_invalid_value (fun () ->
+         let r =
+           Rate_limit.create ~rpc ~session_id ~name_label:"invalid"
+             ~name_description:"" ~burst_size:10.0 ~fill_rate:0.0
+         in
+         Rate_limit.destroy ~rpc ~session_id ~self:r
+     )
+    ) ;
+  Alcotest.(check bool)
+    "Negative fill rate rejected at create" true
+    (is_invalid_value (fun () ->
+         let r =
+           Rate_limit.create ~rpc ~session_id ~name_label:"invalid"
+             ~name_description:"" ~burst_size:10.0 ~fill_rate:(-1.0)
+         in
+         Rate_limit.destroy ~rpc ~session_id ~self:r
+     )
+    ) ;
+  Alcotest.(check bool)
+    "Zero burst rejected at create" true
+    (is_invalid_value (fun () ->
+         let r =
+           Rate_limit.create ~rpc ~session_id ~name_label:"invalid"
+             ~name_description:"" ~burst_size:0.0 ~fill_rate:1.0
+         in
+         Rate_limit.destroy ~rpc ~session_id ~self:r
+     )
+    ) ;
+  (* Once a valid rate limit exists, setters must reject invalid updates. *)
+  let r =
+    Rate_limit.create ~rpc ~session_id ~name_label:"invalid-setters"
+      ~name_description:"" ~burst_size:10.0 ~fill_rate:1.0
+  in
+  Fun.protect
+    ~finally:(fun () -> Rate_limit.destroy ~rpc ~session_id ~self:r)
+    (fun () ->
+      Alcotest.(check bool)
+        "set_fill_rate rejects zero" true
+        (is_invalid_value (fun () ->
+             Rate_limit.set_fill_rate ~rpc ~session_id ~self:r ~value:0.0
+         )
+        ) ;
+      Alcotest.(check bool)
+        "set_burst_size rejects negative" true
+        (is_invalid_value (fun () ->
+             Rate_limit.set_burst_size ~rpc ~session_id ~self:r ~value:(-1.0)
+         )
+        )
+    )
+
+let tests () =
+  let open Qt_filter in
+  [
+    [
+      ("rate_limit_throttling", `Slow, rate_limit_throttling_test)
+    ; ("rate_limit_invalid_rejected", `Quick, rate_limit_invalid_test)
+    ]
+    |> conn
+  ]
+  |> List.concat

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -3933,6 +3933,85 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "caller-create"
+    , {
+        reqd= []
+      ; optn= ["name-label"; "name-description"; "user-agent"; "client-ip"]
+      ; help=
+          "Create a caller record. Either user-agent or client-ip must be \
+           non-empty."
+      ; implementation= No_fd Cli_operations.Caller.create
+      ; flags= []
+      }
+    )
+  ; ( "caller-destroy"
+    , {
+        reqd= ["uuid"]
+      ; optn= []
+      ; help= "Destroy the given caller."
+      ; implementation= No_fd Cli_operations.Caller.destroy
+      ; flags= []
+      }
+    )
+  ; ( "caller-query-usage"
+    , {
+        reqd= []
+      ; optn= ["uuid"; "group"]
+      ; help=
+          "Return cumulative token and call count statistics for a caller. \
+           Specify exactly one of uuid= or group=. Counters are taken from the \
+           in-memory table since XAPI startup."
+      ; implementation= No_fd Cli_operations.Caller.query_usage
+      ; flags= []
+      }
+    )
+  ; ( "caller-list-usage"
+    , {
+        reqd= []
+      ; optn= []
+      ; help=
+          "List every known caller (uuid, name-label, tokens, calls) ranked by \
+           token use, highest first."
+      ; implementation= No_fd Cli_operations.Caller.list_usage
+      ; flags= []
+      }
+    )
+  ; ( "rate-limit-create"
+    , {
+        reqd= ["burst-size"; "fill-rate"]
+      ; optn= ["name-label"; "name-description"; "caller-uuids"]
+      ; help= "Create a rate limiter."
+      ; implementation= No_fd Cli_operations.Rate_limit.create
+      ; flags= []
+      }
+    )
+  ; ( "rate-limit-destroy"
+    , {
+        reqd= ["uuid"]
+      ; optn= []
+      ; help= "Destroy the given rate limiter."
+      ; implementation= No_fd Cli_operations.Rate_limit.destroy
+      ; flags= []
+      }
+    )
+  ; ( "rate-limit-add-caller"
+    , {
+        reqd= ["uuid"; "caller-uuid"]
+      ; optn= []
+      ; help= "Attach a caller to a rate limiter."
+      ; implementation= No_fd Cli_operations.Rate_limit.add_caller
+      ; flags= []
+      }
+    )
+  ; ( "rate-limit-remove-caller"
+    , {
+        reqd= ["uuid"; "caller-uuid"]
+      ; optn= []
+      ; help= "Detach a caller from a rate limiter."
+      ; implementation= No_fd Cli_operations.Rate_limit.remove_caller
+      ; flags= []
+      }
+    )
   ]
 
 let cmdtable : (string, cmd_spec) Hashtbl.t = Hashtbl.create 50

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1410,6 +1410,25 @@ let gen_cmds rpc session_id =
           ["uuid"; "vendor-name"; "device-name"; "pci-id"]
           rpc session_id
       )
+    ; Client.Caller.(
+        mk get_all_records_where get_by_uuid caller_record "caller" []
+          [
+            "uuid"
+          ; "name-label"
+          ; "name-description"
+          ; "user-agent"
+          ; "client-ip"
+          ; "last-access"
+          ; "groups"
+          ; "rate-limit"
+          ]
+          rpc session_id
+      )
+    ; Client.Rate_limit.(
+        mk get_all_records_where get_by_uuid rate_limit_record "rate-limit" []
+          ["uuid"; "name-label"; "callers"; "burst-size"; "fill-rate"]
+          rpc session_id
+      )
     ]
 
 let message_create (_ : printer) rpc session_id params =
@@ -8397,4 +8416,146 @@ module VM_group = struct
         ~uuid:(List.assoc "uuid" params)
     in
     Client.VM_group.destroy ~rpc ~session_id ~self:ref
+end
+
+module Caller = struct
+  let create printer rpc session_id params =
+    let user_agent = get_param params "user-agent" ~default:"" in
+    let client_ip = get_param params "client-ip" ~default:"" in
+
+    if user_agent = "" && client_ip = "" then
+      failwith "Either user-agent or client-ip must be specified" ;
+
+    let name_label = get_param params "name-label" ~default:"" in
+    let name_description = get_param params "name-description" ~default:"" in
+    let ref =
+      Client.Caller.create ~rpc ~session_id ~name_label ~name_description
+        ~user_agent ~client_ip
+    in
+    let uuid = Client.Caller.get_uuid ~rpc ~session_id ~self:ref in
+    printer (Cli_printer.PMsg uuid)
+
+  let destroy _printer rpc session_id params =
+    let ref =
+      Client.Caller.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    in
+    Client.Caller.destroy ~rpc ~session_id ~self:ref
+
+  let query_usage printer rpc session_id params =
+    let uuid = List.assoc_opt "uuid" params in
+    let group = List.assoc_opt "group" params in
+    let result =
+      match (uuid, group) with
+      | Some _, Some _ ->
+          failwith "Specify exactly one of uuid= or group=, not both"
+      | None, None ->
+          failwith "Specify exactly one of uuid= or group="
+      | Some uuid, None ->
+          let self = Client.Caller.get_by_uuid ~rpc ~session_id ~uuid in
+          let tokens = Client.Caller.query_token_usage ~rpc ~session_id ~self in
+          let call_count =
+            Client.Caller.query_call_count ~rpc ~session_id ~self
+          in
+          [
+            ("tokens", Float.to_string tokens)
+          ; ("call_count", Int64.to_string call_count)
+          ]
+      | None, Some group ->
+          let tokens =
+            Client.Caller.query_group_token_usage ~rpc ~session_id ~group
+          in
+          let call_count =
+            Client.Caller.query_group_call_count ~rpc ~session_id ~group
+          in
+          [
+            ("tokens", Float.to_string tokens)
+          ; ("call_count", Int64.to_string call_count)
+          ]
+    in
+    printer (Cli_printer.PTable [result])
+
+  let list_usage printer rpc session_id _params =
+    let rows = Client.Caller.query_all_usage ~rpc ~session_id in
+    let headers = ["uuid"; "name-label"; "tokens"; "calls"] in
+    let table =
+      List.map
+        (fun row ->
+          try List.combine headers row
+          with Invalid_argument _ ->
+            (* Defensive: server schema mismatch *)
+            List.mapi (fun i v -> (string_of_int i, v)) row
+        )
+        rows
+    in
+    printer (Cli_printer.PTable table)
+end
+
+module Rate_limit = struct
+  let create printer rpc session_id params =
+    let name_label = get_param params "name-label" ~default:"" in
+    let name_description = get_param params "name-description" ~default:"" in
+    let burst_size = float_of_string (List.assoc "burst-size" params) in
+    let fill_rate = float_of_string (List.assoc "fill-rate" params) in
+    let ref =
+      Client.Rate_limit.create ~rpc ~session_id ~name_label ~name_description
+        ~burst_size ~fill_rate
+    in
+    ( match List.assoc_opt "caller-uuids" params with
+    | None | Some "" ->
+        ()
+    | Some uuids ->
+        String.split_on_char ',' uuids
+        |> List.map String.trim
+        |> List.iter (fun uuid ->
+            let caller = Client.Caller.get_by_uuid ~rpc ~session_id ~uuid in
+            Client.Rate_limit.add_caller ~rpc ~session_id ~self:ref ~caller
+        )
+    ) ;
+    let uuid = Client.Rate_limit.get_uuid ~rpc ~session_id ~self:ref in
+    printer (Cli_printer.PMsg uuid)
+
+  let destroy _printer rpc session_id params =
+    let ref =
+      Client.Rate_limit.get_by_uuid ~rpc ~session_id
+        ~uuid:(List.assoc "uuid" params)
+    in
+    Client.Rate_limit.destroy ~rpc ~session_id ~self:ref
+
+  let add_caller _printer rpc session_id params =
+    let self =
+      Client.Rate_limit.get_by_uuid ~rpc ~session_id
+        ~uuid:(List.assoc "uuid" params)
+    in
+    let caller =
+      Client.Caller.get_by_uuid ~rpc ~session_id
+        ~uuid:(List.assoc "caller-uuid" params)
+    in
+    Client.Rate_limit.add_caller ~rpc ~session_id ~self ~caller
+
+  let remove_caller _printer rpc session_id params =
+    let self =
+      Client.Rate_limit.get_by_uuid ~rpc ~session_id
+        ~uuid:(List.assoc "uuid" params)
+    in
+    let caller =
+      Client.Caller.get_by_uuid ~rpc ~session_id
+        ~uuid:(List.assoc "caller-uuid" params)
+    in
+    Client.Rate_limit.remove_caller ~rpc ~session_id ~self ~caller
+
+  let set_burst_size _printer rpc session_id params =
+    let self =
+      Client.Rate_limit.get_by_uuid ~rpc ~session_id
+        ~uuid:(List.assoc "uuid" params)
+    in
+    let value = float_of_string (List.assoc "value" params) in
+    Client.Rate_limit.set_burst_size ~rpc ~session_id ~self ~value
+
+  let set_fill_rate _printer rpc session_id params =
+    let self =
+      Client.Rate_limit.get_by_uuid ~rpc ~session_id
+        ~uuid:(List.assoc "uuid" params)
+    in
+    let value = float_of_string (List.assoc "value" params) in
+    Client.Rate_limit.set_fill_rate ~rpc ~session_id ~self ~value
 end

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -6048,3 +6048,126 @@ let pci_record rpc session_id pci =
           ()
       ]
   }
+
+let caller_record rpc session_id caller =
+  let _ref = ref caller in
+  let empty_record =
+    ToGet (fun () -> Client.Caller.get_record ~rpc ~session_id ~self:!_ref)
+  in
+  let record = ref empty_record in
+  let x () = lzy_get record in
+  {
+    setref=
+      (fun r ->
+        _ref := r ;
+        record := empty_record
+      )
+  ; setrefrec=
+      (fun (a, b) ->
+        _ref := a ;
+        record := Got b
+      )
+  ; record= x
+  ; getref= (fun () -> !_ref)
+  ; fields=
+      [
+        make_field ~name:"uuid" ~get:(fun () -> (x ()).API.caller_uuid) ()
+      ; make_field ~name:"name-label"
+          ~get:(fun () -> (x ()).API.caller_name_label)
+          ~set:(fun s ->
+            Client.Caller.set_name_label ~rpc ~session_id ~self:!_ref ~value:s
+          )
+          ()
+      ; make_field ~name:"name-description"
+          ~get:(fun () -> (x ()).API.caller_name_description)
+          ~set:(fun s ->
+            Client.Caller.set_name_description ~rpc ~session_id ~self:!_ref
+              ~value:s
+          )
+          ()
+      ; make_field ~name:"user-agent"
+          ~get:(fun () -> (x ()).API.caller_user_agent)
+          ()
+      ; make_field ~name:"client-ip"
+          ~get:(fun () -> (x ()).API.caller_client_ip)
+          ()
+      ; make_field ~name:"last-access"
+          ~get:(fun () -> Date.to_rfc3339 (x ()).API.caller_last_access)
+          ()
+      ; make_field ~name:"groups"
+          ~get:(fun () -> String.concat "; " (x ()).API.caller_groups)
+          ~get_set:(fun () -> (x ()).API.caller_groups)
+          ~add_to_set:(fun s ->
+            Client.Caller.add_group ~rpc ~session_id ~self:!_ref ~group:s
+          )
+          ~remove_from_set:(fun s ->
+            Client.Caller.remove_group ~rpc ~session_id ~self:!_ref ~group:s
+          )
+          ()
+      ; make_field ~name:"rate-limit"
+          ~get:(fun () -> Ref.string_of (x ()).API.caller_rate_limit)
+          ()
+      ]
+  }
+
+let rate_limit_record rpc session_id rate_limit =
+  let _ref = ref rate_limit in
+  let empty_record =
+    ToGet (fun () -> Client.Rate_limit.get_record ~rpc ~session_id ~self:!_ref)
+  in
+  let record = ref empty_record in
+  let x () = lzy_get record in
+  {
+    setref=
+      (fun r ->
+        _ref := r ;
+        record := empty_record
+      )
+  ; setrefrec=
+      (fun (a, b) ->
+        _ref := a ;
+        record := Got b
+      )
+  ; record= x
+  ; getref= (fun () -> !_ref)
+  ; fields=
+      [
+        make_field ~name:"uuid" ~get:(fun () -> (x ()).API.rate_limit_uuid) ()
+      ; make_field ~name:"name-label"
+          ~get:(fun () -> (x ()).API.rate_limit_name_label)
+          ~set:(fun value ->
+            Client.Rate_limit.set_name_label ~rpc ~session_id ~self:!_ref ~value
+          )
+          ()
+      ; make_field ~name:"name-description"
+          ~get:(fun () -> (x ()).API.rate_limit_name_description)
+          ~set:(fun value ->
+            Client.Rate_limit.set_name_description ~rpc ~session_id ~self:!_ref
+              ~value
+          )
+          ()
+      ; make_field ~name:"callers"
+          ~get:(fun () ->
+            String.concat "; "
+              (List.map Ref.string_of (x ()).API.rate_limit_callers)
+          )
+          ~get_set:(fun () ->
+            List.map Ref.string_of (x ()).API.rate_limit_callers
+          )
+          ()
+      ; make_field ~name:"burst-size"
+          ~get:(fun () -> string_of_float (x ()).API.rate_limit_burst_size)
+          ~set:(fun value ->
+            Client.Rate_limit.set_burst_size ~rpc ~session_id ~self:!_ref
+              ~value:(float_of_string value)
+          )
+          ()
+      ; make_field ~name:"fill-rate"
+          ~get:(fun () -> string_of_float (x ()).API.rate_limit_fill_rate)
+          ~set:(fun value ->
+            Client.Rate_limit.set_fill_rate ~rpc ~session_id ~self:!_ref
+              ~value:(float_of_string value)
+          )
+          ()
+      ]
+  }

--- a/ocaml/xapi/api_server_common.ml
+++ b/ocaml/xapi/api_server_common.ml
@@ -132,6 +132,8 @@ module Actions = struct
   module Observer = Xapi_observer
   module Host_driver = Xapi_host_driver
   module Driver_variant = Xapi_host_driver.Variant
+  module Caller = Xapi_caller
+  module Rate_limit = Xapi_rate_limit
 end
 
 (** Use the server functor to make an XML-RPC dispatcher. *)

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -88,6 +88,8 @@ let task_in_database ctx = Ref.is_real ctx.task_id
 
 let get_origin ctx = string_of_origin ctx.origin
 
+let is_internal_origin ctx = ctx.origin = Internal
+
 let database_of x = x.database
 
 (** Calls coming in from the main unix socket are pre-authenticated.

--- a/ocaml/xapi/context.mli
+++ b/ocaml/xapi/context.mli
@@ -90,6 +90,9 @@ val task_in_database : t -> bool
 val get_origin : t -> string
 (** [get_origin __context] returns a string containing the origin of [__context]. *)
 
+val is_internal_origin : t -> bool
+(** [is_internal_origin __context] returns true if the context originated from an internal operation. *)
+
 val database_of : t -> Xapi_database.Db_ref.t
 (** [database_of __context] returns a database handle, which can be used by Db.* *)
 

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -65,6 +65,8 @@
   exnHelper
   rbac_static
   xapi_role
+  xapi_caller
+  xapi_rate_limit
   xapi_extensions
   db)
  (modes best)
@@ -92,7 +94,11 @@
   forkexec
   unix
   xapi-idl
+  xapi-idl.rrd
+  xapi-rrd
+  rrdd-plugin
   xapi_aux
+  xapi-rate-limit
   xapi-stdext-std
   xapi-stdext-pervasives
   xapi-log.backtrace
@@ -129,6 +135,8 @@
    locking_helpers
    exnHelper
    xapi_role
+   xapi_caller
+   xapi_rate_limit
    xapi_extensions
    db))
  (libraries
@@ -166,6 +174,7 @@
   psq
   ptime
   ptime.clock.os
+  xapi-rate-limit
   rpclib.core
   rpclib.json
   rpclib.xml

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -6982,6 +6982,9 @@ functor
         in
         Xapi_pool_helpers.call_fn_on_slaves_then_master ~__context fn
     end
+
+    module Caller = Xapi_caller
+    module Rate_limit = Xapi_rate_limit
   end
 
 (* for unit tests *)

--- a/ocaml/xapi/server_helpers.ml
+++ b/ocaml/xapi/server_helpers.ml
@@ -185,20 +185,46 @@ let do_dispatch ?session_id ?forward_op ?self:_ supports_async called_fn_name
                ~marshaller op_fn
            )
            ()
-        ) ;
-      (* Return task id immediately *)
-      Rpc.success (API.rpc_of_ref_task (Context.get_task_id __context))
+        )
     in
-    match sync_ty with
-    | `Sync ->
-        sync ()
-    | `Async ->
-        let need_complete = not (Context.forwarded_task __context) in
-        async ~need_complete
-    | `InternalAsync ->
-        async ~need_complete:true
-
-(* regardless of forwarding, we are expected to complete the task *)
+    let handle_request_internal () =
+      match sync_ty with
+      | `Sync ->
+          sync ()
+      | `Async ->
+          let need_complete = not (Context.forwarded_task __context) in
+          async ~need_complete ;
+          Rpc.success (API.rpc_of_ref_task (Context.get_task_id __context))
+      | `InternalAsync ->
+          async ~need_complete:true ;
+          Rpc.success (API.rpc_of_ref_task (Context.get_task_id __context))
+    in
+    let handle_request_external () =
+      let token_cost = Xapi_caller.get_token_cost called_fn_name in
+      let user_agent = Option.value http_req.user_agent ~default:"" in
+      let client_ip =
+        Option.value (Context.get_client_ip __context) ~default:""
+      in
+      match sync_ty with
+      | `Sync ->
+          Xapi_caller.submit_sync ~user_agent ~client_ip ~callback:sync
+            ~task_create:(fun f -> f __context)
+            token_cost
+      | `Async ->
+          let need_complete = not (Context.forwarded_task __context) in
+          Xapi_caller.submit_async ~user_agent ~client_ip
+            ~callback:(fun () -> async ~need_complete)
+            ~task_create:(fun f -> f __context)
+            token_cost ;
+          Rpc.success (API.rpc_of_ref_task (Context.get_task_id __context))
+      | `InternalAsync ->
+          async ~need_complete:true ;
+          Rpc.success (API.rpc_of_ref_task (Context.get_task_id __context))
+    in
+    if Context.is_internal_origin __context then
+      handle_request_internal ()
+    else
+      handle_request_external ()
 
 (* in the following functions, it is our responsibility to complete any tasks we create *)
 let exec_with_new_task ?http_other_config ?quiet ?subtask_of ?session_id

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -887,11 +887,9 @@ let listen_unix_socket sock_path =
   Unixext.mkdir_safe (Filename.dirname sock_path) 0o700 ;
   Unixext.unlink_safe sock_path ;
   let domain_sock = Xapi_http.bind (Unix.ADDR_UNIX sock_path) in
-  ignore
-    (Http_svr.start
-       ~conn_limit:!Xapi_globs.conn_limit_unix
-       Xapi_http.server domain_sock
-    )
+  Http_svr.start
+    ~conn_limit:!Xapi_globs.conn_limit_unix
+    Xapi_http.server domain_sock
 
 let set_stunnel_timeout () =
   try
@@ -1171,6 +1169,14 @@ let server_init () =
           ; ( "Update database state of TLS verification"
             , []
             , fun () -> report_tls_verification ~__context
+            )
+          ; ( "Registering rate limits"
+            , [Startup.OnlyMaster]
+            , fun () -> Xapi_rate_limit.register ~__context
+            )
+          ; ( "Registering callers"
+            , [Startup.OnlyMaster]
+            , fun () -> Xapi_caller.register ~__context
             )
           ; ( "Remote requests"
             , [Startup.OnThread]

--- a/ocaml/xapi/xapi_caller.ml
+++ b/ocaml/xapi/xapi_caller.ml
@@ -18,6 +18,8 @@ open D
 module Rate_limit = Rate_limit_lib.Rate_limit
 module Caller_table = Rate_limit_lib.Caller_table
 module Caller_statistics = Rate_limit_lib.Caller_statistics
+module Config_file = Xcp_service.Config_file
+module Unixext = Xapi_stdext_unix.Unixext
 
 (** A single in-memory caller_table entry. The pattern_key is the table's
     primary key; [caller_ref] records which DB row this entry mirrors;
@@ -231,102 +233,39 @@ let refresh_caller_rate_limit ~__context caller_ref =
         ~rate_limit_ref:record.API.caller_rate_limit
         ~caller_uuid:record.caller_uuid
 
-(* One token corresponds to a cheap DB read - expensive services are multiples *)
-let token_costs =
-  Hashtbl.of_seq
-    (List.to_seq
-       [
-         ("VDI.pool_migrate", 2500.)
-       ; ("VM.migrate_send", 2000.)
-       ; ("VM.suspend", 400.)
-       ; ("VM.resume_on", 400.)
-       ; ("SR.probe", 400.)
-       ; ("VM.copy", 300.)
-       ; ("pool.enable_ha", 300.)
-       ; ("VM.checkpoint", 200.)
-       ; ("host.ha_join_liveset", 200.)
-       ; ("Cluster.pool_create", 200.)
-       ; ("VDI.copy", 200.)
-       ; ("VM.pool_migrate", 200.)
-       ; ("VM.resume", 200.)
-       ; ("SR.destroy", 200.)
-       ; ("Cluster_host.create", 150.)
-       ; ("event.from", 150.)
-       ; ("pool.management_reconfigure", 100.)
-       ; ("pool.join", 100.)
-       ; ("pool.disable_ha", 100.)
-       ; ("host.prepare_for_poweroff", 100.)
-       ; ("VM.set_memory_dynamic_range", 100.)
-       ; ("host.evacuate", 75.)
-       ; ("VM.clean_reboot", 70.)
-       ; ("VM.restart_device_models", 70.)
-       ; ("pool_update.apply", 70.)
-       ; ("Bond.create", 60.)
-       ; ("VM.clean_shutdown", 60.)
-       ; ("VM.revert", 50.)
-       ; ("host.install_server_certificate", 50.)
-       ; ("pool.eject", 40.)
-       ; ("Cluster.create", 40.)
-       ; ("pool.sync_updates", 40.)
-       ; ("host.apply_updates", 40.)
-       ; ("SR.probe_ext", 40.)
-       ; ("host.ha_wait_for_shutdown_via_statefile", 40.)
-       ; ("pool_update.precheck", 30.)
-       ; ("event.next", 30.)
-       ; ("VDI.snapshot", 30.)
-       ; ("pool_update.introduce", 30.)
-       ; ("pool.enable_external_auth", 20.)
-       ; ("VM.start_on", 20.)
-       ; ("VM.hard_reboot", 20.)
-       ; ("SR.create", 20.)
-       ; ("VM.hard_shutdown", 20.)
-       ; ("pool.designate_new_master", 20.)
-       ; ("VM.start", 20.)
-       ; ("VDI.clone", 20.)
-       ; ("host.ha_release_resources", 15.)
-       ; ("VM.snapshot", 15.)
-       ; ("pool.is_slave", 15.)
-       ; ("pool.recover_slaves", 15.)
-       ; ("host.preconfigure_ha", 15.)
-       ; ("pool_update.detach", 15.)
-       ; ("pool_update.attach", 15.)
-       ; ("host.update_master", 15.)
-       ; ("PBD.plug", 15.)
-       ; ("Repository.apply", 12.)
-       ; ("pool.emergency_reset_master", 12.)
-       ; ("VBD.plug", 12.)
-       ; ("host.commit_new_master", 12.)
-       ; ("SR.scan", 10.)
-       ; ("VBD.unplug", 10.)
-       ; ("pool_update.pool_clean", 10.)
-       ; ("VM.clone", 10.)
-       ; ("VM.provision", 10.)
-       ; ("PIF.reconfigure_ip", 10.)
-       ; ("pool.create_VLAN_from_PIF", 8.)
-       ; ("pool.apply_edition", 8.)
-       ; ("pool.disable_external_auth", 7.)
-       ; ("VM.pool_migrate_complete", 7.)
-       ; ("host.call_plugin", 7.)
-       ; ("VLAN.create", 6.)
-       ; ("VDI.create", 6.)
-       ; ("host.update_firewalld_service_status", 6.)
-       ; ("VDI.destroy", 5.)
-       ; ("VIF.plug", 5.)
-       ; ("host.set_iscsi_iqn", 5.)
-       ; ("SR.update", 5.)
-       ; ("VDI.resize", 5.)
-       ; ("host.management_reconfigure", 4.)
-       ; ("VIF.unplug", 3.)
-       ; ("host.set_https_only", 3.)
-       ; ("PIF.plug", 3.)
-       ; ("host.disable_external_auth", 3.)
-       ; ("VDI.set_name_label", 3.)
-       ; ("VDI.set_name_description", 3.)
-       ; ("PIF.scan", 3.)
-       ]
-    )
+(* One token corresponds to a cheap DB read; expensive services cost multiples.
+   The costs are loaded at startup from [Xapi_globs.call_costs_file], one
+   "Class.method = cost" per line (key=value, '#' comments), so the values can be
+   tweaked and new calls added without recompiling xapi. Calls without an entry
+   fall back to [default_token_cost]. *)
+let token_costs : (string, float) Hashtbl.t = Hashtbl.create 256
 
 let default_token_cost = 1.
+
+let add_cost_line line =
+  match Config_file.parse_line line with
+  | Some (name, value) -> (
+    match float_of_string_opt (String.trim value) with
+    | Some cost ->
+        Hashtbl.replace token_costs name cost
+    | None ->
+        warn "Ignoring call cost for %s: %S is not a number" name value
+  )
+  | None ->
+      ()
+
+(* Reload [token_costs] from [path]. On any failure the table is left empty and
+   every call falls back to [default_token_cost]. *)
+let load_token_costs ?(path = !Xapi_globs.call_costs_file) () =
+  Hashtbl.reset token_costs ;
+  ( try Unixext.file_lines_iter add_cost_line path
+    with e ->
+      warn
+        "Could not load call costs from %s (%s); all calls will use the \
+         default cost of %g"
+        path (Printexc.to_string e) default_token_cost
+  ) ;
+  debug "Loaded %d call costs from %s" (Hashtbl.length token_costs) path
 
 let get_token_cost name =
   Option.value ~default:default_token_cost (Hashtbl.find_opt token_costs name)
@@ -473,6 +412,7 @@ let register ~__context =
     debug
       "Rate limiting disabled (rate_limit=false); skipping caller registration"
   else (
+    load_token_costs () ;
     Xapi_rate_limit.set_caller_refresh_callback refresh_caller_rate_limit ;
     List.iter
       (fun self ->

--- a/ocaml/xapi/xapi_caller.ml
+++ b/ocaml/xapi/xapi_caller.ml
@@ -1,0 +1,487 @@
+(*
+ * Copyright (C) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module D = Debug.Make (struct let name = "xapi_caller" end)
+
+open D
+module Rate_limit = Rate_limit_lib.Rate_limit
+module Caller_table = Rate_limit_lib.Caller_table
+module Caller_statistics = Rate_limit_lib.Caller_statistics
+
+(** A single in-memory caller_table entry. The pattern_key is the table's
+    primary key; [caller_ref] records which DB row this entry mirrors;
+    [stats] tracks call counts and token use since startup;
+    [rate_limit_ref] points at the rate-limit row (Ref.null when none),
+    resolved to a live bucket via [Xapi_rate_limit.find_bucket] at dispatch
+    time. *)
+type entry = {
+    caller_ref: API.ref_Caller
+  ; pattern_key: Caller_table.Key.pattern_key
+  ; stats: Caller_statistics.t
+  ; rate_limit_ref: API.ref_Rate_limit
+}
+
+let caller_table : entry Caller_table.t = Caller_table.create ()
+
+(* Serialises the read-then-create path that auto-populates unknown callers. *)
+let create_mutex = Mutex.create ()
+
+let pattern_of_db_string : string -> Caller_table.Key.match_pattern =
+ fun s ->
+  let len = String.length s in
+  if len = 0 then
+    Caller_table.Key.Prefix ""
+  else if s.[len - 1] = '*' then
+    Caller_table.Key.Prefix (String.sub s 0 (len - 1))
+  else
+    Caller_table.Key.Full s
+
+let pattern_key_of_record (record : API.caller_t) : Caller_table.Key.pattern_key
+    =
+  Caller_table.Key.
+    {
+      user_agent_pattern= pattern_of_db_string record.caller_user_agent
+    ; client_ip_pattern= pattern_of_db_string record.caller_client_ip
+    }
+
+let pattern_key_of_fields ~user_agent ~client_ip : Caller_table.Key.pattern_key
+    =
+  Caller_table.Key.
+    {
+      user_agent_pattern= pattern_of_db_string user_agent
+    ; client_ip_pattern= pattern_of_db_string client_ip
+    }
+
+let target_of_request ~user_agent ~client_ip : Caller_table.Key.t =
+  Caller_table.Key.{user_agent; client_ip}
+
+(** A pattern is "fully specified" when neither field is a wildcard prefix.
+    Auto-create only triggers if no fully-specified match is found. *)
+let pattern_fully_specified
+    ({user_agent_pattern; client_ip_pattern} : Caller_table.Key.pattern_key) =
+  let open Caller_table.Key in
+  let field_full = function Full _ -> true | Prefix _ -> false in
+  field_full user_agent_pattern && field_full client_ip_pattern
+
+let any_fully_specified entries =
+  List.exists (fun e -> pattern_fully_specified e.pattern_key) entries
+
+let validate_request_fields ~user_agent ~client_ip =
+  if user_agent = "" && client_ip = "" then
+    raise
+      Api_errors.(
+        Server_error
+          ( invalid_value
+          , [
+              "user_agent/client_ip"
+            ; "at least one of user_agent or client_ip must be set"
+            ]
+          )
+      )
+
+let insert_entry ~caller_ref ~caller_uuid ~pattern_key ~rate_limit_ref =
+  let entry =
+    {
+      caller_ref
+    ; pattern_key
+    ; stats= Caller_statistics.create ~caller_uuid
+    ; rate_limit_ref
+    }
+  in
+  if not (Caller_table.insert caller_table ~pattern:pattern_key entry) then
+    debug
+      "Caller_table.insert refused entry (duplicate or all-wildcard) for \
+       caller %s"
+      (Ref.string_of caller_ref)
+
+let create ~__context ~name_label ~name_description ~user_agent ~client_ip =
+  validate_request_fields ~user_agent ~client_ip ;
+  let pattern_key = pattern_key_of_fields ~user_agent ~client_ip in
+  if Caller_table.Key.is_all_wildcard pattern_key then
+    raise
+      Api_errors.(
+        Server_error
+          ( invalid_value
+          , ["user_agent/client_ip"; "all-wildcard pattern not allowed"]
+          )
+      ) ;
+  match Caller_table.get_exact caller_table ~pattern:pattern_key with
+  | Some entry ->
+      (* Idempotent: an in-memory entry already mirrors this pattern. Update
+         the DB-side name fields and return the existing ref. *)
+      Db.Caller.set_name_label ~__context ~self:entry.caller_ref
+        ~value:name_label ;
+      Db.Caller.set_name_description ~__context ~self:entry.caller_ref
+        ~value:name_description ;
+      entry.caller_ref
+  | None ->
+      let uuid = Uuidx.(to_string (make () : [`Caller] t)) in
+      let ref = Ref.make () in
+      Db.Caller.create ~__context ~ref ~uuid ~name_label ~name_description
+        ~user_agent ~client_ip ~last_access:Clock.Date.epoch ~groups:[]
+        ~rate_limit:Ref.null ;
+      insert_entry ~caller_ref:ref ~caller_uuid:uuid ~pattern_key
+        ~rate_limit_ref:Ref.null ;
+      ref
+
+let destroy ~__context ~self =
+  let record = Db.Caller.get_record ~__context ~self in
+  let pattern_key = pattern_key_of_record record in
+  Caller_table.delete caller_table ~pattern:pattern_key ;
+  Db.Caller.destroy ~__context ~self
+
+let add_group ~__context ~self ~group =
+  Db.Caller.add_groups ~__context ~self ~value:group
+
+let remove_group ~__context ~self ~group =
+  Db.Caller.remove_groups ~__context ~self ~value:group
+
+let entries_of_table () = Caller_table.to_list caller_table |> List.map snd
+
+let find_entry_by_ref self =
+  entries_of_table () |> List.find_opt (fun entry -> entry.caller_ref = self)
+
+let query_token_usage ~__context:_ ~self =
+  match find_entry_by_ref self with
+  | None ->
+      0.0
+  | Some entry ->
+      Caller_statistics.get_token_count entry.stats
+
+let query_call_count ~__context:_ ~self =
+  match find_entry_by_ref self with
+  | None ->
+      0L
+  | Some entry ->
+      Int64.of_int (Caller_statistics.get_call_count entry.stats)
+
+(* Entries for every caller currently assigned to [group]. Raises if the group
+   name is empty. *)
+let group_entries ~__context ~group =
+  if group = "" then
+    raise
+      Api_errors.(Server_error (invalid_value, ["group"; "empty group name"])) ;
+  let in_group entry =
+    try List.mem group (Db.Caller.get_groups ~__context ~self:entry.caller_ref)
+    with _ -> false
+  in
+  entries_of_table () |> List.filter in_group
+
+let query_group_token_usage ~__context ~group =
+  group_entries ~__context ~group
+  |> List.fold_left
+       (fun tot entry -> tot +. Caller_statistics.get_token_count entry.stats)
+       0.0
+
+let query_group_call_count ~__context ~group =
+  group_entries ~__context ~group
+  |> List.fold_left
+       (fun tot entry ->
+         Int64.add tot
+           (Int64.of_int (Caller_statistics.get_call_count entry.stats))
+       )
+       0L
+
+let query_all_usage ~__context =
+  entries_of_table ()
+  |> List.filter_map (fun entry ->
+      let tokens = Caller_statistics.get_token_count entry.stats in
+      let calls = float_of_int (Caller_statistics.get_call_count entry.stats) in
+      let uuid, name_label =
+        try
+          let record = Db.Caller.get_record ~__context ~self:entry.caller_ref in
+          (record.API.caller_uuid, record.API.caller_name_label)
+        with _ -> (Caller_statistics.get_uuid entry.stats, "")
+      in
+      Some (uuid, name_label, tokens, calls)
+  )
+  |> List.sort (fun (_, _, t1, _) (_, _, t2, _) -> compare t2 t1)
+  |> List.map (fun (uuid, name_label, tokens, calls) ->
+      [
+        uuid
+      ; name_label
+      ; Printf.sprintf "%.3f" tokens
+      ; Printf.sprintf "%.0f" calls
+      ]
+  )
+
+(** Re-read the caller's rate_limit ref from DB and rebuild its entry. Called
+    by Xapi_rate_limit whenever the caller's rate_limit field changes. *)
+let refresh_caller_rate_limit ~__context caller_ref =
+  match
+    try Some (Db.Caller.get_record ~__context ~self:caller_ref) with _ -> None
+  with
+  | None ->
+      ()
+  | Some record ->
+      let pattern_key = pattern_key_of_record record in
+      Caller_table.delete caller_table ~pattern:pattern_key ;
+      insert_entry ~caller_ref ~pattern_key
+        ~rate_limit_ref:record.API.caller_rate_limit
+        ~caller_uuid:record.caller_uuid
+
+(* One token corresponds to a cheap DB read - expensive services are multiples *)
+let token_costs =
+  Hashtbl.of_seq
+    (List.to_seq
+       [
+         ("VDI.pool_migrate", 2500.)
+       ; ("VM.migrate_send", 2000.)
+       ; ("VM.suspend", 400.)
+       ; ("VM.resume_on", 400.)
+       ; ("SR.probe", 400.)
+       ; ("VM.copy", 300.)
+       ; ("pool.enable_ha", 300.)
+       ; ("VM.checkpoint", 200.)
+       ; ("host.ha_join_liveset", 200.)
+       ; ("Cluster.pool_create", 200.)
+       ; ("VDI.copy", 200.)
+       ; ("VM.pool_migrate", 200.)
+       ; ("VM.resume", 200.)
+       ; ("SR.destroy", 200.)
+       ; ("Cluster_host.create", 150.)
+       ; ("event.from", 150.)
+       ; ("pool.management_reconfigure", 100.)
+       ; ("pool.join", 100.)
+       ; ("pool.disable_ha", 100.)
+       ; ("host.prepare_for_poweroff", 100.)
+       ; ("VM.set_memory_dynamic_range", 100.)
+       ; ("host.evacuate", 75.)
+       ; ("VM.clean_reboot", 70.)
+       ; ("VM.restart_device_models", 70.)
+       ; ("pool_update.apply", 70.)
+       ; ("Bond.create", 60.)
+       ; ("VM.clean_shutdown", 60.)
+       ; ("VM.revert", 50.)
+       ; ("host.install_server_certificate", 50.)
+       ; ("pool.eject", 40.)
+       ; ("Cluster.create", 40.)
+       ; ("pool.sync_updates", 40.)
+       ; ("host.apply_updates", 40.)
+       ; ("SR.probe_ext", 40.)
+       ; ("host.ha_wait_for_shutdown_via_statefile", 40.)
+       ; ("pool_update.precheck", 30.)
+       ; ("event.next", 30.)
+       ; ("VDI.snapshot", 30.)
+       ; ("pool_update.introduce", 30.)
+       ; ("pool.enable_external_auth", 20.)
+       ; ("VM.start_on", 20.)
+       ; ("VM.hard_reboot", 20.)
+       ; ("SR.create", 20.)
+       ; ("VM.hard_shutdown", 20.)
+       ; ("pool.designate_new_master", 20.)
+       ; ("VM.start", 20.)
+       ; ("VDI.clone", 20.)
+       ; ("host.ha_release_resources", 15.)
+       ; ("VM.snapshot", 15.)
+       ; ("pool.is_slave", 15.)
+       ; ("pool.recover_slaves", 15.)
+       ; ("host.preconfigure_ha", 15.)
+       ; ("pool_update.detach", 15.)
+       ; ("pool_update.attach", 15.)
+       ; ("host.update_master", 15.)
+       ; ("PBD.plug", 15.)
+       ; ("Repository.apply", 12.)
+       ; ("pool.emergency_reset_master", 12.)
+       ; ("VBD.plug", 12.)
+       ; ("host.commit_new_master", 12.)
+       ; ("SR.scan", 10.)
+       ; ("VBD.unplug", 10.)
+       ; ("pool_update.pool_clean", 10.)
+       ; ("VM.clone", 10.)
+       ; ("VM.provision", 10.)
+       ; ("PIF.reconfigure_ip", 10.)
+       ; ("pool.create_VLAN_from_PIF", 8.)
+       ; ("pool.apply_edition", 8.)
+       ; ("pool.disable_external_auth", 7.)
+       ; ("VM.pool_migrate_complete", 7.)
+       ; ("host.call_plugin", 7.)
+       ; ("VLAN.create", 6.)
+       ; ("VDI.create", 6.)
+       ; ("host.update_firewalld_service_status", 6.)
+       ; ("VDI.destroy", 5.)
+       ; ("VIF.plug", 5.)
+       ; ("host.set_iscsi_iqn", 5.)
+       ; ("SR.update", 5.)
+       ; ("VDI.resize", 5.)
+       ; ("host.management_reconfigure", 4.)
+       ; ("VIF.unplug", 3.)
+       ; ("host.set_https_only", 3.)
+       ; ("PIF.plug", 3.)
+       ; ("host.disable_external_auth", 3.)
+       ; ("VDI.set_name_label", 3.)
+       ; ("VDI.set_name_description", 3.)
+       ; ("PIF.scan", 3.)
+       ]
+    )
+
+let default_token_cost = 1.
+
+let get_token_cost name =
+  Option.value ~default:default_token_cost (Hashtbl.find_opt token_costs name)
+
+let bookkeeping_and_bucket ~task_create ~user_agent ~client_ip ~cost =
+  let target = target_of_request ~user_agent ~client_ip in
+  let matches = Caller_table.get caller_table ~caller_id:target in
+  List.iter
+    (fun entry -> Caller_statistics.register_call ~token_amount:cost entry.stats)
+    matches ;
+  if matches <> [] then
+    task_create (fun __context ->
+        let now = Clock.Date.now () in
+        List.iter
+          (fun entry ->
+            try
+              Db.Caller.set_last_access ~__context ~self:entry.caller_ref
+                ~value:now
+            with e ->
+              debug "Failed to update last_access for caller %s: %s"
+                (Ref.string_of entry.caller_ref)
+                (Printexc.to_string e)
+          )
+          matches
+    ) ;
+  let bucket =
+    List.find_map
+      (fun entry ->
+        if entry.rate_limit_ref = Ref.null then
+          None
+        else
+          Xapi_rate_limit.find_bucket entry.rate_limit_ref
+      )
+      matches
+  in
+  (matches, bucket)
+
+let maybe_autocreate ~task_create ~user_agent ~client_ip ~existing =
+  let fully_specified_request = user_agent <> "" && client_ip <> "" in
+  if (not fully_specified_request) || any_fully_specified existing then
+    ()
+  else (
+    Mutex.lock create_mutex ;
+    Fun.protect
+      ~finally:(fun () -> Mutex.unlock create_mutex)
+      (fun () ->
+        let target = target_of_request ~user_agent ~client_ip in
+        let existing = Caller_table.get caller_table ~caller_id:target in
+        if any_fully_specified existing then
+          ()
+        else
+          task_create (fun __context ->
+              try
+                let caller_ref =
+                  create ~__context
+                    ~name_label:
+                      (Printf.sprintf "user_agent: %s, client_ip: %s" user_agent
+                         client_ip
+                      )
+                    ~name_description:
+                      (Printf.sprintf
+                         "Autogenerated caller for user_agent %s, client_ip %s"
+                         user_agent client_ip
+                      )
+                    ~user_agent ~client_ip
+                in
+                Db.Caller.set_last_access ~__context ~self:caller_ref
+                  ~value:(Clock.Date.now ())
+              with e ->
+                warn "Auto-create of caller for (%s, %s) failed: %s" user_agent
+                  client_ip (Printexc.to_string e)
+          )
+      )
+  )
+
+let submit ~submit_fn ~user_agent ~client_ip ~callback ~task_create amount =
+  if not !Xapi_globs.rate_limit_enabled then
+    callback ()
+  else
+    let matches, bucket =
+      bookkeeping_and_bucket ~task_create ~user_agent ~client_ip ~cost:amount
+    in
+    maybe_autocreate ~task_create ~user_agent ~client_ip ~existing:matches ;
+    match bucket with
+    | Some rl ->
+        submit_fn rl ~callback amount
+    | None ->
+        callback ()
+
+let submit_sync ~user_agent ~client_ip ~callback ~task_create amount =
+  submit ~submit_fn:Rate_limit.submit_sync ~user_agent ~client_ip ~callback
+    ~task_create amount
+
+let submit_async ~user_agent ~client_ip ~callback ~task_create amount =
+  submit ~submit_fn:Rate_limit.submit_async ~user_agent ~client_ip ~callback
+    ~task_create amount
+
+(* We publish two derive data sources per known caller to xcp-rrdd: cumulative
+   tokens consumed and cumulative call count. *)
+
+let reporter_uid = "xapi-rate-limit-callers"
+
+let make_caller_dss () =
+  Caller_table.to_list caller_table
+  |> List.concat_map (fun (_pattern, entry) ->
+      let uuid = Caller_statistics.get_uuid entry.stats in
+      let tokens = Caller_statistics.get_token_count entry.stats in
+      let calls = Caller_statistics.get_call_count entry.stats in
+      [
+        ( Rrd.Host
+        , Ds.ds_make
+            ~name:(Printf.sprintf "caller_%s_tokens" uuid)
+            ~description:
+              (Printf.sprintf "Total tokens consumed by caller %s" uuid)
+            ~value:(Rrd.VT_Float tokens) ~ty:Rrd.Derive ~default:true
+            ~units:"tokens" ~min:0.0 ()
+        )
+      ; ( Rrd.Host
+        , Ds.ds_make
+            ~name:(Printf.sprintf "caller_%s_calls" uuid)
+            ~description:(Printf.sprintf "Total calls by caller %s" uuid)
+            ~value:(Rrd.VT_Int64 (Int64.of_int calls))
+            ~ty:Rrd.Derive ~default:true ~units:"calls" ~min:0.0 ()
+        )
+      ]
+  )
+
+let reporter : Rrdd_plugin.Reporter.t option ref = ref None
+
+let start_reporter () =
+  try
+    let r =
+      Rrdd_plugin.Reporter.start_async
+        (module D : Debug.DEBUG)
+        ~uid:reporter_uid ~neg_shift:0.5 ~target:(Rrdd_plugin.Reporter.Local 1)
+        ~protocol:Rrd_interface.V2 ~dss_f:make_caller_dss
+    in
+    reporter := Some r
+  with e ->
+    warn "Failed to start caller RRD reporter: %s" (Printexc.to_string e)
+
+let register ~__context =
+  if not !Xapi_globs.rate_limit_enabled then
+    debug
+      "Rate limiting disabled (rate_limit=false); skipping caller registration"
+  else (
+    Xapi_rate_limit.set_caller_refresh_callback refresh_caller_rate_limit ;
+    List.iter
+      (fun self ->
+        let record = Db.Caller.get_record ~__context ~self in
+        let pattern_key = pattern_key_of_record record in
+        insert_entry ~caller_ref:self ~pattern_key
+          ~rate_limit_ref:record.API.caller_rate_limit
+          ~caller_uuid:record.caller_uuid
+      )
+      (Db.Caller.get_all ~__context) ;
+    start_reporter ()
+  )

--- a/ocaml/xapi/xapi_caller.mli
+++ b/ocaml/xapi/xapi_caller.mli
@@ -1,0 +1,68 @@
+(*
+ * Copyright (C) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** In-memory caller_table mirroring the Caller DB rows, plus the entry
+    point used by [Server_helpers.do_dispatch] / [Xapi_http.add_handler] to
+    apply per-caller rate limiting. *)
+
+val default_token_cost : float
+
+val get_token_cost : string -> float
+
+val submit_sync :
+     user_agent:string
+  -> client_ip:string
+  -> callback:(unit -> 'a)
+  -> task_create:((Context.t -> unit) -> unit)
+  -> float
+  -> 'a
+
+val submit_async :
+     user_agent:string
+  -> client_ip:string
+  -> callback:(unit -> unit)
+  -> task_create:((Context.t -> unit) -> unit)
+  -> float
+  -> unit
+
+val create :
+     __context:Context.t
+  -> name_label:string
+  -> name_description:string
+  -> user_agent:string
+  -> client_ip:string
+  -> API.ref_Caller
+
+val destroy : __context:Context.t -> self:API.ref_Caller -> unit
+
+val add_group :
+  __context:Context.t -> self:API.ref_Caller -> group:string -> unit
+
+val remove_group :
+  __context:Context.t -> self:API.ref_Caller -> group:string -> unit
+
+val query_token_usage : __context:Context.t -> self:API.ref_Caller -> float
+
+val query_call_count : __context:Context.t -> self:API.ref_Caller -> int64
+
+val query_group_token_usage : __context:Context.t -> group:string -> float
+
+val query_group_call_count : __context:Context.t -> group:string -> int64
+
+val query_all_usage : __context:Context.t -> string list list
+
+val register : __context:Context.t -> unit
+(** Populate caller_table from persisted Caller rows and install
+    [Xapi_rate_limit]'s caller-refresh callback. Must run after
+    [Xapi_rate_limit.register] so that bucket lookups succeed. *)

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1438,6 +1438,11 @@ let factory_ntp_servers = ref []
 
 let legacy_factory_ntp_servers = ref []
 
+(** When false (default), per-caller rate limiting is disabled at runtime:
+    [Xapi_caller.register] and [Xapi_rate_limit.register] are no-ops, the
+    RRD reporter is not started, and dispatch bypasses the caller table. *)
+let rate_limit_enabled = ref false
+
 let other_options =
   [
     gen_list_option "sm-plugins"
@@ -1972,6 +1977,11 @@ let other_options =
       (fun s -> s)
       (fun s -> s)
       factory_ntp_servers
+  ; ( "rate_limit"
+    , Arg.Set rate_limit_enabled
+    , (fun () -> string_of_bool !rate_limit_enabled)
+    , "Enable per-caller rate limiting (Caller / Rate_limit datamodel)."
+    )
   ]
 
 (* The options can be set with the variable xapiflags in /etc/sysconfig/xapi.

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1443,6 +1443,11 @@ let legacy_factory_ntp_servers = ref []
     RRD reporter is not started, and dispatch bypasses the caller table. *)
 let rate_limit_enabled = ref false
 
+(** File mapping API calls to their rate-limiting token cost, in key=value
+    format ("Class.method = cost"), read by [Xapi_caller.register] at start of
+    day. *)
+let call_costs_file = ref "/etc/xensource/call-costs.conf"
+
 let other_options =
   [
     gen_list_option "sm-plugins"
@@ -2222,6 +2227,10 @@ module Resources = struct
     ; ( "iscsi_initiatorname"
       , iscsi_initiator_config_file
       , "Path to the initiatorname.iscsi file"
+      )
+    ; ( "call-costs-file"
+      , call_costs_file
+      , "File mapping API calls to their rate-limiting token cost"
       )
     ]
 

--- a/ocaml/xapi/xapi_http.ml
+++ b/ocaml/xapi/xapi_http.ml
@@ -352,25 +352,44 @@ let add_handler (name, handler) =
       failwith (Printf.sprintf "Unregistered HTTP handler: %s" name)
   in
   let check_rbac = Rbac.is_rbac_enabled_for_http_action name in
-  let h req ic context =
-    let client =
-      Http_svr.(client_of_req_and_fd req ic |> Option.map string_of_client)
+  let rate_limit (client_id_opt : (string * string) option) handler () =
+    if List.mem name Datamodel.custom_rate_limit_http_actions then
+      handler ()
+    else
+      match client_id_opt with
+      | None ->
+          handler ()
+      | Some (user_agent, client_ip) ->
+          debug "Rate limiting handler %s with user_agent %s client_ip %s" name
+            user_agent client_ip ;
+          Xapi_caller.submit_async ~user_agent ~client_ip ~callback:handler
+            ~task_create:(Server_helpers.exec_with_new_task "Add new caller")
+            Xapi_caller.default_token_cost
+  in
+  let h req ic () =
+    let client_info = Http_svr.client_of_req_and_fd req ic in
+    let client = Option.map Http_svr.string_of_client client_info in
+    let client_id =
+      match (req.Http.Request.user_agent, client_info) with
+      | Some user_agent, Some (_, ip) ->
+          Some (user_agent, Ipaddr.to_string ip)
+      | _ ->
+          None
     in
+    let rate_limited_handler = rate_limit client_id (handler req ic) in
     Debug.with_thread_associated ?client name
       (fun () ->
         try
           if check_rbac then (
             try
               (* session and rbac checks *)
-              assert_credentials_ok name req
-                ~fn:(fun () -> handler req ic context)
-                ic
+              assert_credentials_ok name req ~fn:rate_limited_handler ic
             with e ->
               debug "Leaving RBAC-handler in xapi_http after: %s"
                 (ExnHelper.string_of_exn e) ;
               raise e
           ) else (* no rbac checks *)
-            handler req ic context
+            rate_limited_handler ()
         with Api_errors.Server_error (name, params) as e ->
           error "Unhandled Api_errors.Server_error(%s, [ %s ])" name
             (String.concat "; " params) ;

--- a/ocaml/xapi/xapi_rate_limit.ml
+++ b/ocaml/xapi/xapi_rate_limit.ml
@@ -1,0 +1,146 @@
+(*
+ * Copyright (C) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+module D = Debug.Make (struct let name = "xapi_rate_limit" end)
+
+open D
+module Rate_limit = Rate_limit_lib.Rate_limit
+
+(** Map of Rate_limit ref -> in-memory token-bucket worker. Owned here;
+    Xapi_caller looks up workers by ref via [find_bucket]. *)
+let buckets : (API.ref_Rate_limit, Rate_limit.t) Hashtbl.t = Hashtbl.create 16
+
+let mutex = Mutex.create ()
+
+let with_mutex f =
+  Mutex.lock mutex ;
+  Fun.protect ~finally:(fun () -> Mutex.unlock mutex) f
+
+(** Callback invoked after a caller's rate_limit ref changes in the database,
+    so that the in-memory caller_table entry can be rebuilt to point at the
+    correct bucket. Set by [Xapi_caller.register]. Default is a no-op so
+    callbacks ordering during startup is not load-bearing. *)
+let on_caller_rate_limit_changed :
+    (__context:Context.t -> API.ref_Caller -> unit) ref =
+  ref (fun ~__context:_ _ -> ())
+
+let set_caller_refresh_callback f = on_caller_rate_limit_changed := f
+
+let notify_caller_changed ~__context caller_ref =
+  !on_caller_rate_limit_changed ~__context caller_ref
+
+let find_bucket rate_limit_ref =
+  with_mutex (fun () -> Hashtbl.find_opt buckets rate_limit_ref)
+
+let validate_params ~burst_size ~fill_rate =
+  if fill_rate <= 0. then
+    raise
+      Api_errors.(
+        Server_error (invalid_value, ["fill_rate"; string_of_float fill_rate])
+      ) ;
+  if burst_size <= 0. then
+    raise
+      Api_errors.(
+        Server_error (invalid_value, ["burst_size"; string_of_float burst_size])
+      )
+
+let build_bucket ~burst_size ~fill_rate =
+  try Rate_limit.create ~burst_size ~fill_rate
+  with Invalid_argument msg ->
+    raise Api_errors.(Server_error (invalid_value, [msg]))
+
+let install_bucket ~self ~burst_size ~fill_rate =
+  let bucket = build_bucket ~burst_size ~fill_rate in
+  with_mutex (fun () ->
+      Option.iter Rate_limit.delete (Hashtbl.find_opt buckets self) ;
+      Hashtbl.replace buckets self bucket
+  )
+
+let remove_bucket ~self =
+  with_mutex (fun () ->
+      Option.iter Rate_limit.delete (Hashtbl.find_opt buckets self) ;
+      Hashtbl.remove buckets self
+  )
+
+let create ~__context ~name_label ~name_description ~burst_size ~fill_rate =
+  validate_params ~burst_size ~fill_rate ;
+  let uuid = Uuidx.make () in
+  let ref = Ref.make () in
+  Db.Rate_limit.create ~__context ~ref ~uuid:(Uuidx.to_string uuid) ~name_label
+    ~name_description ~burst_size ~fill_rate ;
+  install_bucket ~self:ref ~burst_size ~fill_rate ;
+  ref
+
+let destroy ~__context ~self =
+  let attached_callers = Db.Rate_limit.get_callers ~__context ~self in
+  List.iter
+    (fun caller ->
+      Db.Caller.set_rate_limit ~__context ~self:caller ~value:Ref.null ;
+      notify_caller_changed ~__context caller
+    )
+    attached_callers ;
+  remove_bucket ~self ;
+  Db.Rate_limit.destroy ~__context ~self
+
+let add_caller ~__context ~self ~caller =
+  (* One rate limit per caller: clear any existing attachment first. *)
+  let previous = Db.Caller.get_rate_limit ~__context ~self:caller in
+  if previous <> Ref.null && previous <> self then (
+    Db.Caller.set_rate_limit ~__context ~self:caller ~value:Ref.null ;
+    notify_caller_changed ~__context caller
+  ) ;
+  Db.Caller.set_rate_limit ~__context ~self:caller ~value:self ;
+  notify_caller_changed ~__context caller
+
+let remove_caller ~__context ~self ~caller =
+  let current = Db.Caller.get_rate_limit ~__context ~self:caller in
+  if current = self then (
+    Db.Caller.set_rate_limit ~__context ~self:caller ~value:Ref.null ;
+    notify_caller_changed ~__context caller
+  )
+
+let set_burst_size ~__context ~self ~value =
+  let fill_rate = Db.Rate_limit.get_fill_rate ~__context ~self in
+  validate_params ~burst_size:value ~fill_rate ;
+  Db.Rate_limit.set_burst_size ~__context ~self ~value ;
+  install_bucket ~self ~burst_size:value ~fill_rate ;
+  List.iter
+    (notify_caller_changed ~__context)
+    (Db.Rate_limit.get_callers ~__context ~self)
+
+let set_fill_rate ~__context ~self ~value =
+  let burst_size = Db.Rate_limit.get_burst_size ~__context ~self in
+  validate_params ~burst_size ~fill_rate:value ;
+  Db.Rate_limit.set_fill_rate ~__context ~self ~value ;
+  install_bucket ~self ~burst_size ~fill_rate:value ;
+  List.iter
+    (notify_caller_changed ~__context)
+    (Db.Rate_limit.get_callers ~__context ~self)
+
+let register ~__context =
+  if not !Xapi_globs.rate_limit_enabled then
+    debug
+      "Rate limiting disabled (rate_limit=false); skipping bucket registration"
+  else
+    List.iter
+      (fun self ->
+        let record = Db.Rate_limit.get_record ~__context ~self in
+        let burst_size = record.API.rate_limit_burst_size in
+        let fill_rate = record.API.rate_limit_fill_rate in
+        if fill_rate > 0. && burst_size > 0. then
+          install_bucket ~self ~burst_size ~fill_rate
+        else
+          warn "Skipping rate_limit %s: invalid persisted parameters"
+            record.API.rate_limit_uuid
+      )
+      (Db.Rate_limit.get_all ~__context)

--- a/ocaml/xapi/xapi_rate_limit.mli
+++ b/ocaml/xapi/xapi_rate_limit.mli
@@ -1,0 +1,64 @@
+(*
+ * Copyright (C) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** In-memory store of rate-limit token-bucket workers, keyed by the
+    Rate_limit datamodel ref. Owns the worker lifecycle and exposes
+    {!find_bucket} for Xapi_caller's request-dispatch path. *)
+
+val find_bucket : API.ref_Rate_limit -> Rate_limit_lib.Rate_limit.t option
+(** Look up the in-memory bucket worker for a Rate_limit row. *)
+
+val set_caller_refresh_callback :
+  (__context:Context.t -> API.ref_Caller -> unit) -> unit
+(** Install the callback used to refresh in-memory state for a caller
+    whenever its rate_limit DB field changes. Called once at startup by
+    Xapi_caller. *)
+
+(** {2 Datamodel-message implementations.}
+
+    These are called by the generated dispatch layer via the
+    Custom_actions / message_forwarding wiring. *)
+
+val create :
+     __context:Context.t
+  -> name_label:string
+  -> name_description:string
+  -> burst_size:float
+  -> fill_rate:float
+  -> API.ref_Rate_limit
+
+val destroy : __context:Context.t -> self:API.ref_Rate_limit -> unit
+
+val add_caller :
+     __context:Context.t
+  -> self:API.ref_Rate_limit
+  -> caller:API.ref_Caller
+  -> unit
+
+val remove_caller :
+     __context:Context.t
+  -> self:API.ref_Rate_limit
+  -> caller:API.ref_Caller
+  -> unit
+
+val set_burst_size :
+  __context:Context.t -> self:API.ref_Rate_limit -> value:float -> unit
+
+val set_fill_rate :
+  __context:Context.t -> self:API.ref_Rate_limit -> value:float -> unit
+
+val register : __context:Context.t -> unit
+(** Load all persisted Rate_limit rows and build their in-memory workers.
+    Must run before Xapi_caller.register so that callers can attach to
+    existing buckets at startup. *)

--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -32,6 +32,26 @@ COMPLETION_SUGGESTIONS=0
 SHOW_DESCRIPTION=0
 REQD_OPTIONAL_PARAMS=0
 
+# Display helper for caller UUID completion. Prints the caller's
+# name-label when set, otherwise falls back to "<user-agent>@<client-ip>"
+# so auto-created records (which have no name-label) still show a
+# meaningful description. Empty fields render as '*' to match the
+# wildcard semantics of the underlying pattern.
+__xe_caller_display()
+{
+    local uuid="$1"
+    local nl
+    nl=$(xe caller-list params=name-label uuid="$uuid" --minimal 2>/dev/null)
+    if [ -n "$nl" ]; then
+        echo "$nl"
+    else
+        local ua ip
+        ua=$(xe caller-list params=user-agent uuid="$uuid" --minimal 2>/dev/null)
+        ip=$(xe caller-list params=client-ip uuid="$uuid" --minimal 2>/dev/null)
+        echo "${ua:-*}@${ip:-*}"
+    fi
+}
+
 _xe()
 {
     # CA-100561 Tab completion bug when grep_options is set different then default --color=auto
@@ -209,7 +229,8 @@ _xe()
                     sdn-controller-*|\
                     network-sriov-*|\
                     vm-group-*|\
-                    cluster-host-*)
+                    cluster-host-*|\
+                    rate-limit-*)
                         # Chop off at the second '-' and append 'list'
                         cmd="$(echo ${OLDSTYLE_WORDS[1]} | cut -d- -f1-2)-list";;
                     *)
@@ -223,7 +244,12 @@ _xe()
                 IFS=$'\n,'
 
                 SHOW_DESCRIPTION=1
-                local name_label_cmd="$xe $cmd params=name-label,number,vm-name-label,device 2>/dev/null --minimal uuid="
+                local name_label_cmd
+                if [ "$cmd" = "caller-list" ]; then
+                    name_label_cmd="__xe_caller_display "
+                else
+                    name_label_cmd="$xe $cmd params=name-label,number,vm-name-label,device 2>/dev/null --minimal uuid="
+                fi
                 __xe_debug "name_label_cmd is '$name_label_cmd'"
                 set_completions_for_names "$cmd" 'uuid' "$value" "$name_label_cmd"
                 return 1
@@ -377,6 +403,18 @@ _xe()
                 local name_label_cmd="$xe pif-list params=device 2>/dev/null --minimal uuid="
                 __xe_debug "name_label_cmd is '$name_label_cmd'"
                 set_completions_for_names 'pif-list' 'uuid' "$val" "$name_label_cmd"
+                return 0
+                ;;
+
+            caller-uuids) # rate-limit-create
+                __xe_debug "triggering autocompletion for caller-uuids"
+                IFS=$'\n,'
+                val=$(final_comma_separated_param "$value")
+
+                SHOW_DESCRIPTION=1
+                local name_label_cmd="__xe_caller_display "
+                __xe_debug "name_label_cmd is '$name_label_cmd'"
+                set_completions_for_names 'caller-list' 'uuid' "$val" "$name_label_cmd"
                 return 0
                 ;;
 

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -25,7 +25,7 @@ verify-cert () {
 }
 
 mli-files () {
-  N=453
+  N=455
   X="ocaml/tests"
   X+="|ocaml/quicktest"
   X+="|ocaml/message-switch/core_test"

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -109,6 +109,7 @@ install:
 	$(IPROG) pam.d-xapi $(DESTDIR)/etc/pam.d/xapi
 	$(IPROG) upload-wrapper logs-download $(DESTDIR)$(LIBEXECDIR)
 	$(IDATA) usb-policy.conf $(DESTDIR)$(ETCXENDIR)
+	$(IDATA) call-costs.conf $(DESTDIR)$(ETCXENDIR)
 	mkdir -p $(DESTDIR)$(OPTDIR)/packages/iso #omg XXX
 	$(IPROG) xapi-rolling-upgrade-miami $(DESTDIR)$(LIBEXECDIR)/xapi-rolling-upgrade
 	$(IPROG) set-hostname $(DESTDIR)$(LIBEXECDIR)

--- a/scripts/call-costs.conf
+++ b/scripts/call-costs.conf
@@ -1,0 +1,97 @@
+# Per-call token costs used by xapi's per-caller rate limiting.
+#
+# Each line maps an API call to the number of tokens it consumes against a
+# caller's rate-limit bucket, in "Class.method = cost" form. One token roughly
+# corresponds to a cheap DB read; expensive operations cost multiples. Lines
+# starting with '#' are comments. Calls without an entry here use a cost of 1.
+#
+# This file is read once, when xapi starts. Edit the values or add new calls and
+# restart xapi to apply the changes; no recompilation is required.
+
+VDI.pool_migrate = 2500
+VM.migrate_send = 2000
+VM.suspend = 400
+VM.resume_on = 400
+SR.probe = 400
+VM.copy = 300
+pool.enable_ha = 300
+VM.checkpoint = 200
+host.ha_join_liveset = 200
+Cluster.pool_create = 200
+VDI.copy = 200
+VM.pool_migrate = 200
+VM.resume = 200
+SR.destroy = 200
+Cluster_host.create = 150
+event.from = 150
+pool.management_reconfigure = 100
+pool.join = 100
+pool.disable_ha = 100
+host.prepare_for_poweroff = 100
+VM.set_memory_dynamic_range = 100
+host.evacuate = 75
+VM.clean_reboot = 70
+VM.restart_device_models = 70
+pool_update.apply = 70
+Bond.create = 60
+VM.clean_shutdown = 60
+VM.revert = 50
+host.install_server_certificate = 50
+pool.eject = 40
+Cluster.create = 40
+pool.sync_updates = 40
+host.apply_updates = 40
+SR.probe_ext = 40
+host.ha_wait_for_shutdown_via_statefile = 40
+pool_update.precheck = 30
+event.next = 30
+VDI.snapshot = 30
+pool_update.introduce = 30
+pool.enable_external_auth = 20
+VM.start_on = 20
+VM.hard_reboot = 20
+SR.create = 20
+VM.hard_shutdown = 20
+pool.designate_new_master = 20
+VM.start = 20
+VDI.clone = 20
+host.ha_release_resources = 15
+VM.snapshot = 15
+pool.is_slave = 15
+pool.recover_slaves = 15
+host.preconfigure_ha = 15
+pool_update.detach = 15
+pool_update.attach = 15
+host.update_master = 15
+PBD.plug = 15
+Repository.apply = 12
+pool.emergency_reset_master = 12
+VBD.plug = 12
+host.commit_new_master = 12
+SR.scan = 10
+VBD.unplug = 10
+pool_update.pool_clean = 10
+VM.clone = 10
+VM.provision = 10
+PIF.reconfigure_ip = 10
+pool.create_VLAN_from_PIF = 8
+pool.apply_edition = 8
+pool.disable_external_auth = 7
+VM.pool_migrate_complete = 7
+host.call_plugin = 7
+VLAN.create = 6
+VDI.create = 6
+host.update_firewalld_service_status = 6
+VDI.destroy = 5
+VIF.plug = 5
+host.set_iscsi_iqn = 5
+SR.update = 5
+VDI.resize = 5
+host.management_reconfigure = 4
+VIF.unplug = 3
+host.set_https_only = 3
+PIF.plug = 3
+host.disable_external_auth = 3
+VDI.set_name_label = 3
+VDI.set_name_description = 3
+PIF.scan = 3

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -47,6 +47,9 @@ inventory = /etc/xensource-inventory
 # Optional configuration file for udchp
 # udhcpd-conf = @ETCXENDIR@/udhcpd.conf
 
+# File mapping API calls to their rate-limiting token cost
+# call-costs-file = @ETCXENDIR@/call-costs.conf
+
 # Enable/disable the watchdog
 # nowatchdog = false
 


### PR DESCRIPTION
This commit implements the changes laid out in the rate_limit design document.
In particular, we add two datamodels:
- Caller: tracks every client who has called into xapi
- Rate_limit: allows admins to place usage limits on groups of callers

These changes include intercepting RPC calls as they arrive for logging and rate limiting purposes. The feature is currently behind a feature flag - to activate, write rate_limit=true into xapi.conf.