### PR TITLE
CA-428461: make trusted-domain attribute enrichment best-effort

### DIFF
--- a/ocaml/xapi/extauth_plugin_ADwinbind.ml
+++ b/ocaml/xapi/extauth_plugin_ADwinbind.ml
@@ -1623,9 +1623,11 @@ module AuthADWinbind : Auth_signature.AUTH_MODULE = struct
              information" ;
           Ok default_account
       | Some domain -> (
-          let* dc = Wbinfo.kdc_of_domain domain in
           let timeout = !Xapi_globs.winbind_ldap_query_subject_timeout in
-          match Ldap.query_user sid domain_netbios dc ~timeout with
+          match
+            let* dc = Wbinfo.kdc_of_domain domain in
+            Ldap.query_user sid domain_netbios dc ~timeout
+          with
           | Ok user ->
               Ok user
           | _ ->


### PR DESCRIPTION
Fold Wbinfo.kdc_of_domain (wbinfo --getdcname) into the same match as Ldap.query_user in query_subject_information_user, so a DC-location or LDAP query failure falls back to default_account instead of aborting subject creation via let*. Fixes subject-add for one-way trusted-domain users when getdcname cannot locate the trusted DC; attributes are refreshed later by update_all_subjects.