### PR TITLE
Configure LLDP advertising on physical NICs

### DIFF
--- a/ocaml/networkd/bin/network_monitor_thread.ml
+++ b/ocaml/networkd/bin/network_monitor_thread.ml
@@ -270,6 +270,7 @@ let watcher_m = Mutex.create ()
 let watcher_pid = ref None
 
 let signal_networking_change () =
+  Lldp.set_tlv_management_address () ;
   let module XenAPI = Client.Client in
   let session_id =
     XenAPI.Session.slave_local_login_with_password ~rpc ~uname:"" ~pwd:""

--- a/ocaml/networkd/bin/network_server.ml
+++ b/ocaml/networkd/bin/network_server.ml
@@ -183,6 +183,7 @@ let on_shutdown signal =
     (fun () ->
       debug "xcp-networkd caught signal %a; performing cleanup actions."
         Debug.Pp.signal signal ;
+      Lldp.stop () ;
       write_config ()
     )
     ()
@@ -805,6 +806,14 @@ module Interface = struct
       )
       ()
 
+  let set_lldp _ dbg ~name ~params =
+    Debug.with_thread_associated dbg
+      (fun () ->
+        debug "Configuring LLDP for %s" name ;
+        Lldp.set_conf name params
+      )
+      ()
+
   let get_capabilities dbg name =
     Debug.with_thread_associated dbg
       (fun () -> Fcoe.get_capabilities name @ Sriov.get_capabilities name)
@@ -920,6 +929,7 @@ module Interface = struct
                   ; mtu
                   ; ethtool_settings
                   ; ethtool_offload
+                  ; lldp
                   ; _
                   } as c
                 ) ) ->
@@ -962,6 +972,7 @@ module Interface = struct
                 ) ;
                 exec (fun () -> set_ipv4_routes () dbg ~name ~routes:ipv4_routes) ;
                 exec (fun () -> set_mtu () dbg ~name ~mtu) ;
+                exec (fun () -> set_lldp () dbg ~name ~params:lldp) ;
                 exec (fun () -> bring_up () dbg ~name) ;
                 exec (fun () ->
                     set_ethtool_settings () dbg ~name ~params:ethtool_settings

--- a/ocaml/networkd/lib/lldp.ml
+++ b/ocaml/networkd/lib/lldp.ml
@@ -287,6 +287,84 @@ module Lldpd : AGENT = struct
     Cache.set conf ; Ok ()
 end
 
+module Blocklist = struct
+  let conf_dir = ref "/etc/xensource/lldp-nic-driver-blocklist.d"
+
+  let is_valid dir path =
+    match Unix.lstat (Filename.concat dir path) with
+    | exception e ->
+        warn "%s: cannot stat file %s: %s" __FUNCTION__ path
+          (Printexc.to_string e) ;
+        false
+    | {Unix.st_kind= Unix.S_LNK; _} ->
+        debug "%s: ignoring symlink %s" __FUNCTION__ path ;
+        false
+    | {Unix.st_kind; _} when st_kind <> Unix.S_REG ->
+        debug "%s: ignoring non-regular entry %s" __FUNCTION__ path ;
+        false
+    | _ ->
+        Filename.check_suffix path ".conf"
+
+  let read_file path =
+    match Xapi_stdext_unix.Unixext.string_of_file path with
+    | exception e ->
+        warn "%s: ignoring unreadable blocklist file %s: %s" __FUNCTION__ path
+          (Printexc.to_string e) ;
+        None
+    | content ->
+        Some content
+
+  let drivers_of_file dir path =
+    match read_file (Filename.concat dir path) with
+    | None ->
+        []
+    | Some s ->
+        Astring.String.cuts ~empty:false ~sep:"\n" s
+        |> List.filter_map (fun line ->
+            match String.trim line with
+            | "" ->
+                None
+            | line when line.[0] = '#' ->
+                None
+            | driver ->
+                Some driver
+        )
+
+  let blocked_drivers : string list option Atomic.t = Atomic.make None
+
+  let load () =
+    match Sys.readdir !conf_dir with
+    | entries ->
+        let drivers =
+          Array.to_list entries
+          |> List.filter (fun f -> is_valid !conf_dir f)
+          |> List.concat_map (fun f -> drivers_of_file !conf_dir f)
+        in
+        debug "%s: blocked drivers: %s" __FUNCTION__ (String.concat ", " drivers) ;
+        (* It's fine to override an updated list.
+           The source data in [!conf_dir] rarely changes when being read. *)
+        Atomic.set blocked_drivers (Some drivers) ;
+        drivers
+    | exception e ->
+        warn "%s: Could not read block list under %s: %s" __FUNCTION__ !conf_dir
+          (Printexc.to_string e) ;
+        []
+
+  let blocked () =
+    match Atomic.get blocked_drivers with
+    | None ->
+        load ()
+    | Some drivers ->
+        drivers
+
+  let mem dev =
+    match Network_utils.Sysfs.get_driver_name dev with
+    | None ->
+        false
+    | Some driver ->
+        List.mem driver (blocked ())
+end
+
 module Make (Agent : AGENT) = struct
   let ( let* ) = Result.bind
 

--- a/ocaml/networkd/lib/lldp.ml
+++ b/ocaml/networkd/lib/lldp.ml
@@ -17,6 +17,9 @@ module D = Debug.Make (struct let name = __MODULE__ end)
 open D
 module I = Network_interface
 
+let string_of_addresses addresses =
+  addresses |> List.map Unix.string_of_inet_addr |> String.concat ","
+
 module Lldp_types = struct
   type error = Command_failed of string * string | Internal of string
 
@@ -42,6 +45,7 @@ module Lldp_types = struct
     | Port_description of dev * port_description
     | System_name of string
     | System_description of string
+    | Management_address of Unix.inet_addr list
     | System_capability of system_capability list
     | Multicast_address of I.lldp_multicast_address list
 end
@@ -67,6 +71,31 @@ module type AGENT = sig
   val disable : string -> (unit, error) result
   (** Stop LLDP (rx-and-tx) on [dev]. *)
 end
+
+let management_ip_address =
+  let cache : Unix.inet_addr list Atomic.t = Atomic.make [] in
+  fun ~force () ->
+    match (force, Atomic.get cache) with
+    | true, seen | false, ([] as seen) -> (
+        let addrs =
+          let iface = Inventory.lookup Inventory._management_interface in
+          let open Network_utils in
+          Ip.get_ipv4 iface @ Ip.get_ipv6 iface |> List.map fst
+        in
+        match Atomic.compare_and_set cache seen addrs with
+        | true ->
+            debug "%s: set management IP address: [%s]" __FUNCTION__
+              (string_of_addresses addrs) ;
+            addrs
+        | false ->
+            let addrs = Atomic.get cache in
+            warn "%s: management IP address updated by others: [%s]"
+              __FUNCTION__
+              (string_of_addresses addrs) ;
+            addrs
+      )
+    | false, addrs ->
+        addrs
 
 module Lldpd : AGENT = struct
   open Lldp_types
@@ -113,6 +142,7 @@ module Lldpd : AGENT = struct
     ; Chassis_id (Local config.chassis_id)
     ; System_name config.system_name
     ; System_description config.system_description
+    ; Management_address (management_ip_address ~force:false ())
     ; System_capability [Bridge]
     ; Port_id (dev, Default)
     ; Port_description (dev, Default)
@@ -178,6 +208,12 @@ module Lldpd : AGENT = struct
           |> string_of_multicast_address
         in
         call_cli ["configure"; "lldp"; "agent-type"; addr_str]
+    | Management_address addrs ->
+        let addrs_str =
+          match addrs with [] -> {|""|} | _ :: _ -> string_of_addresses addrs
+        in
+        call_cli
+          ["configure"; "system"; "ip"; "management"; "pattern"; addrs_str]
 
   module Cache = struct
     let cache_chassis_id : conf option Atomic.t = Atomic.make None
@@ -189,6 +225,8 @@ module Lldpd : AGENT = struct
     let cache_sys_cap : conf option Atomic.t = Atomic.make None
 
     let cache_mc_addr : conf option Atomic.t = Atomic.make None
+
+    let cache_mgmt_addr : conf option Atomic.t = Atomic.make None
 
     (* Check out cache before calling cli *)
     let checkout cache f =
@@ -215,6 +253,8 @@ module Lldpd : AGENT = struct
             Atomic.get cache_sys_cap
         | Multicast_address _ ->
             Atomic.get cache_mc_addr
+        | Management_address _ ->
+            Atomic.get cache_mgmt_addr
       in
       (cached, conf)
 
@@ -235,6 +275,8 @@ module Lldpd : AGENT = struct
           Atomic.set cache_sys_cap (Some conf)
       | Multicast_address _ ->
           Atomic.set cache_mc_addr (Some conf)
+      | Management_address _ ->
+          Atomic.set cache_mgmt_addr (Some conf)
   end
 
   let set_advertising_conf conf =
@@ -294,6 +336,12 @@ module Make (Agent : AGENT) = struct
         warn "%s: Could not stop LLDP agent: %s" __FUNCTION__
           (Lldp_types.string_of_error e)
     )
+
+  let set_tlv_management_address addrs =
+    Agent.set_advertising_conf (Management_address addrs)
+    |> Result.iter_error (fun e ->
+        warn "%s: %s" __FUNCTION__ (Lldp_types.string_of_error e)
+    )
 end
 
 module Lldp_agent = Make (Lldpd)
@@ -301,3 +349,6 @@ module Lldp_agent = Make (Lldpd)
 let set_conf dev (config : I.lldp option) = Lldp_agent.set_conf dev config
 
 let stop = Lldp_agent.stop
+
+let set_tlv_management_address () =
+  management_ip_address ~force:true () |> Lldp_agent.set_tlv_management_address

--- a/ocaml/networkd/lib/lldp.ml
+++ b/ocaml/networkd/lib/lldp.ml
@@ -1,0 +1,303 @@
+(*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module D = Debug.Make (struct let name = __MODULE__ end)
+
+open D
+module I = Network_interface
+
+module Lldp_types = struct
+  type error = Command_failed of string * string | Internal of string
+
+  let string_of_error = function
+    | Command_failed (cmd, msg) ->
+        Printf.sprintf "command %S failed: %s" cmd msg
+    | Internal msg ->
+        Printf.sprintf "Internal error: %s" msg
+
+  type chassis_id = Local of string
+
+  type port_id = Default
+
+  type port_description = Default
+
+  type system_capability = Bridge
+
+  type dev = string
+
+  type conf =
+    | Chassis_id of chassis_id
+    | Port_id of dev * port_id
+    | Port_description of dev * port_description
+    | System_name of string
+    | System_description of string
+    | System_capability of system_capability list
+    | Multicast_address of I.lldp_multicast_address list
+end
+
+module type AGENT = sig
+  type error = Lldp_types.error
+
+  val start : unit -> (unit, error) result
+  (** Ensure the agent is running. *)
+
+  val stop : unit -> (unit, error) result
+  (** Stop the agent. *)
+
+  val set_advertising_conf : Lldp_types.conf -> (unit, error) result
+  (** Configure a TLV to the agent's advertised configuration. *)
+
+  val advertising_confs : string -> I.lldp -> Lldp_types.conf list
+  (** The list of TLVs to advertise based on the given configuration. *)
+
+  val enable : string -> (unit, error) result
+  (** Start LLDP (rx-and-tx) on [dev]. *)
+
+  val disable : string -> (unit, error) result
+  (** Stop LLDP (rx-and-tx) on [dev]. *)
+end
+
+module Lldpd : AGENT = struct
+  open Lldp_types
+
+  type error = Lldp_types.error
+
+  let cli = "/usr/sbin/lldpcli"
+
+  let systemctl = "/usr/bin/systemctl"
+
+  let service = "lldpd"
+
+  (* lldpd will create this. *)
+  let conf_dir = "/etc/lldpd.d"
+
+  let conf_path = Filename.concat conf_dir "00-networkd-default.conf"
+
+  let default_conf =
+    String.concat "\n"
+      [
+        "configure lldp status disabled"
+      ; "configure lldp capabilities-advertisements"
+      ; "configure system capabilities enabled bridge"
+      ; ""
+      ]
+
+  let run cmd args =
+    let cmdline = String.concat " " (cmd :: args) in
+    try
+      ignore (Network_utils.call_script ~log:true cmd args) ;
+      Ok ()
+    with e ->
+      let err_msg = Printexc.to_string e in
+      error "%s: %S failed: %s" __FUNCTION__ cmdline err_msg ;
+      Error (Command_failed (cmdline, err_msg))
+
+  let call_cli args = run cli args
+
+  let call_systemctl args = run systemctl args
+
+  let advertising_confs dev (config : I.lldp) : conf list =
+    [
+      Multicast_address config.address
+    ; Chassis_id (Local config.chassis_id)
+    ; System_name config.system_name
+    ; System_description config.system_description
+    ; System_capability [Bridge]
+    ; Port_id (dev, Default)
+    ; Port_description (dev, Default)
+    ]
+
+  let start () =
+    try
+      Xapi_stdext_unix.Unixext.write_string_to_file conf_path default_conf ;
+      if Fe_systemctl.is_active ~service then
+        Ok ()
+      else
+        call_systemctl ["start"; service]
+    with e -> Error (Internal (Printexc.to_string e))
+
+  let stop () =
+    try
+      if Fe_systemctl.is_active ~service then
+        call_systemctl ["stop"; service]
+      else
+        Ok ()
+    with e -> Error (Internal (Printexc.to_string e))
+
+  let enable dev =
+    call_cli ["configure"; "ports"; dev; "lldp"; "status"; "rx-and-tx"]
+
+  let disable dev =
+    call_cli ["configure"; "ports"; dev; "lldp"; "status"; "disabled"]
+
+  let string_of_multicast_address = function
+    | I.Nearest_bridge ->
+        "nearest-bridge"
+    | I.Nearest_non_tpmr_bridge ->
+        "nearest-non-tpmr-bridge"
+    | I.Nearest_customer_bridge ->
+        "nearest-customer-bridge"
+
+  let set_advertising_conf' conf =
+    match conf with
+    | Chassis_id (Local chassis_id) ->
+        call_cli ["configure"; "system"; "chassisid"; chassis_id]
+    | Port_id (_dev, Default) ->
+        (* MAC address *)
+        Ok ()
+    | Port_description (_dev, Default) ->
+        (* Interface name *)
+        Ok ()
+    | System_name sys_name ->
+        call_cli ["configure"; "system"; "hostname"; sys_name]
+    | System_description sys_desc ->
+        call_cli ["configure"; "system"; "description"; sys_desc]
+    | System_capability _ ->
+        (* In default conf *)
+        Ok ()
+    | Multicast_address addresses ->
+        let addr_str =
+          ( match addresses with
+            | [] ->
+                I.Nearest_bridge
+            | addr :: _ ->
+                (* lldpd only accepts one *)
+                addr
+            )
+          |> string_of_multicast_address
+        in
+        call_cli ["configure"; "lldp"; "agent-type"; addr_str]
+
+  module Cache = struct
+    let cache_chassis_id : conf option Atomic.t = Atomic.make None
+
+    let cache_sys_name : conf option Atomic.t = Atomic.make None
+
+    let cache_sys_desc : conf option Atomic.t = Atomic.make None
+
+    let cache_sys_cap : conf option Atomic.t = Atomic.make None
+
+    let cache_mc_addr : conf option Atomic.t = Atomic.make None
+
+    (* Check out cache before calling cli *)
+    let checkout cache f =
+      match cache with
+      | Some cached, conf when cached = conf ->
+          (* short-circuit as it has been set *)
+          Ok ()
+      | _ ->
+          (* cache missed, continue calling the setter *)
+          f ()
+
+    let get conf =
+      let cached =
+        match conf with
+        | Port_id _ | Port_description _ ->
+            None
+        | Chassis_id _ ->
+            Atomic.get cache_chassis_id
+        | System_name _ ->
+            Atomic.get cache_sys_name
+        | System_description _ ->
+            Atomic.get cache_sys_desc
+        | System_capability _ ->
+            Atomic.get cache_sys_cap
+        | Multicast_address _ ->
+            Atomic.get cache_mc_addr
+      in
+      (cached, conf)
+
+    (* It's fine to set directly as these are shared by all NICs. The cache
+       will be consistent eventually.
+       Here focuses on the integrity of the data. *)
+    let set conf =
+      match conf with
+      | Port_id _ | Port_description _ ->
+          ()
+      | Chassis_id _ ->
+          Atomic.set cache_chassis_id (Some conf)
+      | System_name _ ->
+          Atomic.set cache_sys_name (Some conf)
+      | System_description _ ->
+          Atomic.set cache_sys_desc (Some conf)
+      | System_capability _ ->
+          Atomic.set cache_sys_cap (Some conf)
+      | Multicast_address _ ->
+          Atomic.set cache_mc_addr (Some conf)
+  end
+
+  let set_advertising_conf conf =
+    let ( let@ ) = Cache.checkout in
+    let ( let* ) = Result.bind in
+    let@ () = Cache.get conf in
+    let* () = set_advertising_conf' conf in
+    Cache.set conf ; Ok ()
+end
+
+module Make (Agent : AGENT) = struct
+  let ( let* ) = Result.bind
+
+  let set_conf dev (config : I.lldp option) : unit =
+    let result =
+      match (Network_utils.Sysfs.is_physical dev, config) with
+      | false, _ ->
+          debug "%s: Skipping non-physical interface %s" __FUNCTION__ dev ;
+          Ok ()
+      | true, None ->
+          debug "%s: No LLDP config for interface %s" __FUNCTION__ dev ;
+          Ok ()
+      | true, Some lldp -> (
+          let blocked =
+            if lldp.force then
+              false
+            else
+              Blocklist.mem dev
+          in
+          match (blocked, lldp.enabled) with
+          | true, _ ->
+              debug "%s: Driver of %s is in blocklist." __FUNCTION__ dev ;
+              Agent.disable dev
+          | false, true ->
+              Network_utils.Ethtool.try_to_disable_firmware_lldp dev ;
+              let* () = Agent.start () in
+              let* () =
+                Agent.advertising_confs dev lldp
+                |> List.map Agent.set_advertising_conf
+                |> List.find_opt Result.is_error
+                |> Option.fold ~none:(Ok ()) ~some:Fun.id
+              in
+              Agent.enable dev
+          | false, false ->
+              Agent.disable dev
+        )
+    in
+    let error e =
+      warn "%s: Could not apply LLDP configuration on %s: %s" __FUNCTION__ dev
+        (Lldp_types.string_of_error e)
+    in
+    Result.iter_error error result
+
+  let stop () : unit =
+    Agent.stop ()
+    |> Result.iter_error (fun e ->
+        warn "%s: Could not stop LLDP agent: %s" __FUNCTION__
+          (Lldp_types.string_of_error e)
+    )
+end
+
+module Lldp_agent = Make (Lldpd)
+
+let set_conf dev (config : I.lldp option) = Lldp_agent.set_conf dev config
+
+let stop = Lldp_agent.stop

--- a/ocaml/networkd/lib/lldp.mli
+++ b/ocaml/networkd/lib/lldp.mli
@@ -1,0 +1,20 @@
+(*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+val set_conf : string -> Network_interface.lldp option -> unit
+(** [set_conf dev config] applies the LLDP configuration [config] to the
+    physical interface [dev]. *)
+
+val stop : unit -> unit
+(** [stop ()] stops the host's LLDP agent. *)

--- a/ocaml/networkd/lib/lldp.mli
+++ b/ocaml/networkd/lib/lldp.mli
@@ -18,3 +18,7 @@ val set_conf : string -> Network_interface.lldp option -> unit
 
 val stop : unit -> unit
 (** [stop ()] stops the host's LLDP agent. *)
+
+val set_tlv_management_address : unit -> unit
+(** [set_tlv_management_address ()] retrieves the management IP address(es) of
+    the host and configure them in the LLDP management address TLV for advertising. *)

--- a/ocaml/networkd/lib/network_utils.ml
+++ b/ocaml/networkd/lib/network_utils.ml
@@ -1915,6 +1915,66 @@ module Ethtool = struct
     if options <> [] then
       ignore
         (call ("-K" :: name :: List.concat_map (fun (k, v) -> [k; v]) options))
+
+  let get_priv_flags name : ((string * bool) list, string) result =
+    let ps = Printf.sprintf in
+    try
+      call ["--show-priv-flags"; name]
+      |> Astring.String.cuts ~empty:false ~sep:"\n"
+      |> Xapi_stdext_std.Listext.List.try_map (fun line ->
+          match Astring.String.cut ~sep:":" line with
+          | None ->
+              Error (ps "Unexpected line (no colon): %S" line)
+          | Some (flag, value) -> (
+              let flag = String.trim flag in
+              match String.trim value with
+              | "on" ->
+                  Ok (Some (flag, true))
+              | "off" ->
+                  Ok (Some (flag, false))
+              | "" ->
+                  Ok None
+              | v ->
+                  Error (ps "Unexpected value (neither 'on' nor 'off'): %S" v)
+            )
+      )
+      |> Result.map (List.filter_map Fun.id)
+    with e -> Error (Printexc.to_string e)
+
+  let set_priv_flag name flag enabled : (unit, string) result =
+    try
+      ignore
+        (call
+           [
+             "--set-priv-flags"
+           ; name
+           ; flag
+           ; ( if enabled then
+                 "on"
+               else
+                 "off"
+             )
+           ]
+        ) ;
+      Ok ()
+    with e -> Error (Printexc.to_string e)
+
+  let try_to_disable_firmware_lldp dev =
+    match get_priv_flags dev with
+    | Ok flags ->
+        let set flag enabled =
+          List.assoc_opt flag flags
+          |> Option.iter (fun value ->
+              if value <> enabled then
+                set_priv_flag dev flag enabled
+                |> Result.fold ~ok:Fun.id ~error:(fun e ->
+                    warn "%s: %s" __FUNCTION__ e
+                )
+          )
+        in
+        set "disable-fw-lldp" true ; set "fw-lldp-agent" false
+    | Error e ->
+        warn "%s: %s" __FUNCTION__ e
 end
 
 module Dracut = struct

--- a/ocaml/xapi-idl/network/network_interface.ml
+++ b/ocaml/xapi-idl/network/network_interface.ml
@@ -182,6 +182,30 @@ type bond_mode = Balance_slb | Active_backup | Lacp [@@deriving rpcty]
 
 type fail_mode = Standalone | Secure [@@deriving rpcty]
 
+(** LLDP multicast destination MAC address groups that 802.1D-compliant bridges
+    do not forward *)
+type lldp_multicast_address =
+  | Nearest_bridge
+      (** Nearest bridge group address — MAC [01:80:C2:00:00:0E].
+          LLDP frames reach only the immediate neighbor on the physical link. *)
+  | Nearest_non_tpmr_bridge
+      (** Nearest non-TPMR bridge group address — MAC [01:80:C2:00:00:03].
+          LLDP frames reach only the nearest non-TPMR bridge. The "TPMR" means
+          Two-Port MAC Relays. *)
+  | Nearest_customer_bridge
+      (** Nearest customer bridge group address — MAC [01:80:C2:00:00:00].
+          LLDP frames reach only the nearest Customer bridge. *)
+[@@deriving rpcty]
+
+type lldp = {
+    chassis_id: string [@default ""]
+  ; system_name: string [@default ""]
+  ; system_description: string [@default ""]
+  ; enabled: bool [@default false]
+  ; address: lldp_multicast_address list [@default [Nearest_bridge]]
+}
+[@@deriving rpcty]
+
 type interface_config_t = {
     ipv4_conf: ipv4 [@default None4]
   ; ipv4_gateway: Unix.inet_addr option [@default None]
@@ -196,6 +220,7 @@ type interface_config_t = {
   ; ethtool_settings: (string * string) list [@default []]
   ; ethtool_offload: (string * string) list [@default [("lro", "off")]]
   ; persistent_i: bool [@default false]
+  ; lldp: lldp option [@default None]
 }
 [@@deriving rpcty]
 
@@ -248,6 +273,7 @@ let default_interface =
   ; ethtool_settings= []
   ; ethtool_offload= [("lro", "off")]
   ; persistent_i= false
+  ; lldp= None
   }
 
 let default_bridge =

--- a/ocaml/xapi-idl/network/network_interface.ml
+++ b/ocaml/xapi-idl/network/network_interface.ml
@@ -198,7 +198,8 @@ type lldp_multicast_address =
 [@@deriving rpcty]
 
 type lldp = {
-    chassis_id: string [@default ""]
+    force: bool [@default false]
+  ; chassis_id: string [@default ""]
   ; system_name: string [@default ""]
   ; system_description: string [@default ""]
   ; enabled: bool [@default false]

--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -679,6 +679,7 @@ let bring_pif_up ~__context ?(management_interface = false) (pif : API.ref_PIF)
                     ; ethtool_offload
                     ; mtu
                     ; persistent_i= persistent
+                    ; lldp= None
                     }
                   )
                 ]


### PR DESCRIPTION
This is the first PR of LLDP feature. The overall design doc is https://github.com/xapi-project/xen-api/blob/master/doc/content/design/lldp.md

The PR is for managing a LLDP agent (and one implementation `lldpd`) and configuring for individual NICs through LLDP client. Cache is used to avoid unnecessary calls of LLDP client as most of configurations are shared by NICs.