### PR TITLE
xapi_vm_snapshot: do not leak CD VBDs 

### DIFF
--- a/ocaml/quicktest/quicktest_vm_snapshot.ml
+++ b/ocaml/quicktest/quicktest_vm_snapshot.ml
@@ -162,12 +162,17 @@ let test_revert rpc session_id vm vdi vdi2 ~change =
 
 let test_revert_cds rpc session_id vm vdi vdi2 =
   let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
+
+  let snap_vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:snapshot in
+  Alcotest.(check int) "Snapshot must only have 2 VBDs" 2 (List.length snap_vbds) ;
+
   Client.Client.VM.revert ~rpc ~session_id ~snapshot ;
 
   let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:vm in
   let vdi_after = get_vdi_with_user_device rpc session_id vbds "0" in
   let vdi_after2 = get_vdi_with_user_device rpc session_id vbds "1" in
 
+  Alcotest.(check int) "VM must only have 2 VBDs" 2 (List.length vbds) ;
   (* CD VDIs are considered immutable and the clone code ignores them *)
   check_vdis_same vdi vdi_after ;
   check_vdis_same vdi2 vdi_after2

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -253,9 +253,9 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
   let snap_disks_snapshot_of = VDISet.map get_snapshot_of snap_disks_all in
 
   let vm_VBDs_all = Db.VM.get_VBDs ~__context ~self:vm |> VBDSet.of_list in
-  let vm_VBDs_disk =
+  let vm_VBDs_disk, vm_VBDs_CD =
     (* Filter VBDs to ensure that we don't read empty CDROMs *)
-    VBDSet.filter
+    VBDSet.partition
       (fun vbd -> Db.VBD.get_type ~__context ~self:vbd = `Disk)
       vm_VBDs_all
   in
@@ -309,7 +309,8 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
   in
 
   let vm_vbds_to_be_destroyed =
-    filter_vbds_from_vdis vm_VBDs_all vm_disks_to_be_destroyed
+    let ( +++ ) = VBDSet.union in
+    filter_vbds_from_vdis vm_VBDs_all vm_disks_to_be_destroyed +++ vm_VBDs_CD
   in
 
   let snap_VBDs_reverted =


### PR DESCRIPTION
Because all the snapshot's CD VBDs are cloned in all cases, the reverted
VM's CD VBDs must be destroyed in all cases, add them unconditionally to
the VBDs being destroyed.

The quicktests make sure of this