### PR TITLE
CA-428620: fix occasional vm suspend error

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -205,7 +205,7 @@ let check_op_for_feature ~__context ~vmr:_ ~vmmr ~vmgmr ~op ~ref ~strict =
   let some_err e = Some (e, [Ref.string_of ref]) in
   let lack_feature feature = not (has_feature ~vmgmr ~feature) in
   match op with
-  | (`suspend | `checkpoint | `pool_migrate | `migrate_send) when is_live -> (
+  | (`pool_migrate | `migrate_send) when is_live -> (
     match get_feature ~vmgmr ~feature:"data-cant-suspend-reason" with
     | Some reason ->
         Some (Api_errors.vm_non_suspendable, [Ref.string_of ref; reason])
@@ -215,6 +215,18 @@ let check_op_for_feature ~__context ~vmr:_ ~vmmr ~vmgmr ~op ~ref ~strict =
     | None ->
         None
   )
+  | (`suspend | `checkpoint) when is_live ->
+      (* Cannot gate suspend/checkpoint on the cached data-cant-suspend-reason:
+       that xenstore key is set by the QMP event thread whenever a QMP event
+       arrives and Query_migratable returns an error (e.g. NVMe has transient
+       in-flight I/O). By the time the actual suspend executes, the device may
+       be idle. xenopsd performs a fresh Query_migratable check via
+       assert_can_save before committing to the save sequence, which is the
+       authoritative check. *)
+      if (not implicit_support) && strict && lack_feature "feature-suspend" then
+        some_err Api_errors.vm_lacks_feature
+      else
+        None
   | _ when implicit_support ->
       None
   | `clean_shutdown

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -2307,6 +2307,13 @@ and perform_exn ?result (op : operation) (t : Xenops_task.task_handle) : unit =
       VM_DB.signal id
   | VM_suspend (id, _data) ->
       debug "VM.suspend %s" id ;
+      (* Do a fresh Query_migratable before committing to the suspend sequence.
+         The stale data/cant_suspend_reason in xenstore (written by the QMP event
+         thread on transient NVMe in-flight I/O) may have already been cleared by
+         the time we reach here; this authoritative check ensures we only fail if
+         the device is genuinely non-migratable at suspend time. *)
+      let module B = (val get_backend () : S) in
+      B.VM.assert_can_save (VM_DB.read_exn id) ;
       perform_atomics (atomics_of_operation op) t ;
       VM_DB.signal id
   | VM_restore_vifs id ->

--- a/ocaml/xenopsd/lib/xenops_server_simulator.ml
+++ b/ocaml/xenopsd/lib/xenops_server_simulator.ml
@@ -598,11 +598,15 @@ module VM = struct
 
   let wait_shutdown _ _vm _reason _timeout = true
 
+  let assert_can_save _vm = ()
+
   let save _ _cb vm flags data vgpu_data _pre_suspend_callback =
     with_lock m (save_nolock vm flags data vgpu_data)
 
   let restore _ _cb vm vbds vifs data vgpu_data extras =
     with_lock m (restore_nolock vm vbds vifs data vgpu_data extras)
+
+  let resume _ _vm = ()
 
   let s3suspend _ _vm = ()
 


### PR DESCRIPTION
  data-cant-suspend-reason is not a reliable basis to decide
  whether a VM can be suspended, in some corner case, vm suspend
  operation runs into error,

  State blocked by non-migratable device 0000:00:07.0/nvme