### PR TITLE
xenctrl-ext: link stubs explicitly agains libxenctrl

### DIFF
--- a/ocaml/libs/xenctrl-ext/dune
+++ b/ocaml/libs/xenctrl-ext/dune
@@ -6,5 +6,6 @@
   (language c)
   (names xenctrlext_stubs)
  )
+ (c_library_flags (-lxenctrl))
 )
 


### PR DESCRIPTION
The xenctrlext_stubs use libxenctrl symbols (e.g. xc_cpumap_alloc) but did not declare it as a link dependency. So, the produced dllxenctrl_ext_stubs.so had no NEEDED entry for libxenctrl.

When I try to run `dune utop` on my Debian Trixie the loading fails with:
  Fatal error: cannot load shared library dllxenctrl_ext_stubs
  Reason: .../ocaml/libs/xenctrl-ext/dllxenctrl_ext_stubs.so:
          undefined symbol: xc_cpumap_alloc

This patch adds -lxenctrl to c_library_flags so the stubs declare the dependency themselves.