### PR TITLE
Implement SXM with snapshots for SMAPIv3

### DIFF
--- a/ocaml/xapi-idl/storage/storage_interface.ml
+++ b/ocaml/xapi-idl/storage/storage_interface.ml
@@ -978,6 +978,23 @@ module StorageAPI (R : RPC) = struct
       declare "VDI.set_content_id" []
         (dbg_p @-> sr_p @-> vdi_p @-> content_id_p @-> returning unit_p err)
 
+    (** [set_snapshot_metadata sr vdi snapshot_of snapshot_time is_a_snapshot] tells
+        the storage backend that [vdi] is a snapshot of [snapshot_of] taken at
+        [snapshot_time]. *)
+    let set_snapshot_metadata =
+      let snapshot_of_p = Param.mk ~name:"snapshot_of" Vdi.t in
+      let snapshot_time_p = Param.mk ~name:"snapshot_time" Types.string in
+      let is_a_snapshot_p = Param.mk ~name:"is_a_snapshot" Types.bool in
+      declare "VDI.set_snapshot_metadata" []
+        (dbg_p
+        @-> sr_p
+        @-> vdi_p
+        @-> snapshot_of_p
+        @-> snapshot_time_p
+        @-> is_a_snapshot_p
+        @-> returning unit_p err
+        )
+
     (** [compose task sr parent child] layers the updates from [child] onto [parent],
         modifying [child] *)
     let compose =
@@ -1628,6 +1645,16 @@ module type Server_impl = sig
       -> content_id:content_id
       -> unit
 
+    val set_snapshot_metadata :
+         context
+      -> dbg:debug_info
+      -> sr:sr
+      -> vdi:vdi
+      -> snapshot_of:vdi
+      -> snapshot_time:string
+      -> is_a_snapshot:bool
+      -> unit
+
     val compose :
       context -> dbg:debug_info -> sr:sr -> vdi1:vdi -> vdi2:vdi -> unit
 
@@ -1838,6 +1865,11 @@ module Server (Impl : Server_impl) () = struct
     S.VDI.get_by_name (fun dbg sr name -> Impl.VDI.get_by_name () ~dbg ~sr ~name) ;
     S.VDI.set_content_id (fun dbg sr vdi content_id ->
         Impl.VDI.set_content_id () ~dbg ~sr ~vdi ~content_id
+    ) ;
+    S.VDI.set_snapshot_metadata
+      (fun dbg sr vdi snapshot_of snapshot_time is_a_snapshot ->
+        Impl.VDI.set_snapshot_metadata () ~dbg ~sr ~vdi ~snapshot_of
+          ~snapshot_time ~is_a_snapshot
     ) ;
     S.VDI.compose (fun dbg sr vdi1 vdi2 ->
         Impl.VDI.compose () ~dbg ~sr ~vdi1 ~vdi2

--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
+++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
@@ -155,6 +155,10 @@ module VDI = struct
   let set_content_id ctx ~dbg ~sr ~vdi ~content_id =
     Storage_interface.unimplemented __FUNCTION__
 
+  let set_snapshot_metadata ctx ~dbg ~sr ~vdi ~snapshot_of ~snapshot_time
+      ~is_a_snapshot =
+    Storage_interface.unimplemented __FUNCTION__
+
   let compose ctx ~dbg ~sr ~vdi1 ~vdi2 =
     Storage_interface.unimplemented __FUNCTION__
 

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1465,6 +1465,14 @@ module VDIImpl (M : META) = struct
     >>>= (fun sr ->
     clone ~dbg ~sr
       ~vdi:(Storage_interface.Vdi.string_of vdi_info.Storage_interface.vdi)
+    >>>= update_keys ~dbg ~sr ~key:_vdi_type_key
+           ~value:
+             ( match vdi_info.Storage_interface.ty with
+             | "" ->
+                 None
+             | s ->
+                 Some s
+             )
     >>>= fun response -> return (vdi_of_volume response)
     )
     |> wrap

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1814,6 +1814,20 @@ end
 module DATAImpl (M : META) = struct
   module VDI = VDIImpl (M)
 
+  (* per-(sr,vdi) cache to avoid Volume.stat RPC on every mirror poll.
+     No mutex: this module runs single-threaded under Lwt. *)
+  let vdi_stat_cache = Base.Hashtbl.create ~size:16 (module Base.String)
+
+  let stat_resolve_clone_on_boot ~dbg ~sr ~vdi =
+    VDI.stat ~dbg ~sr ~vdi >>>= fun response ->
+    match
+      List.assoc_opt _clone_on_boot_key response.Xapi_storage.Control.keys
+    with
+    | None ->
+        return response
+    | Some temporary ->
+        VDI.stat ~dbg ~sr ~vdi:temporary
+
   let stat dbg sr vdi' _vm key =
     let open Storage_interface in
     let convert_key = function
@@ -1823,16 +1837,16 @@ module DATAImpl (M : META) = struct
           Data_client.MirrorV1 k
     in
 
+    let sr_str = Sr.string_of sr in
     let vdi = Vdi.string_of vdi' in
+    let cache_key = sr_str ^ "/" ^ vdi in
+
     Attached_SRs.find sr >>>= fun sr ->
-    VDI.stat ~dbg ~sr ~vdi >>>= fun response ->
-    ( match
-        List.assoc_opt _clone_on_boot_key response.Xapi_storage.Control.keys
-      with
+    ( match Base.Hashtbl.find vdi_stat_cache cache_key with
+      | Some cached_response ->
+          return cached_response
       | None ->
-          return response
-      | Some temporary ->
-          VDI.stat ~dbg ~sr ~vdi:temporary
+          stat_resolve_clone_on_boot ~dbg ~sr ~vdi
       )
     >>>= fun response ->
     choose_datapath response >>>= fun (rpc, _datapath, _uri) ->
@@ -1840,6 +1854,7 @@ module DATAImpl (M : META) = struct
     return_data_rpc (fun () -> Data_client.stat (rpc ~dbg) dbg key)
     >>>= function
     | {failed; complete; progress} ->
+        if complete || failed then Base.Hashtbl.remove vdi_stat_cache cache_key ;
         return Mirror.{failed; complete; progress}
 
   let stat_impl dbg sr vdi vm key = wrap @@ stat dbg sr vdi vm key
@@ -1848,19 +1863,14 @@ module DATAImpl (M : META) = struct
     let* () =
       info (fun m -> m "image_format (%s) is not currently used" image_format)
     in
+    let sr_str = Storage_interface.Sr.string_of sr in
     let vdi = Storage_interface.Vdi.string_of vdi' in
     let domain = Storage_interface.Vm.string_of vm' in
+    let cache_key = sr_str ^ "/" ^ vdi in
+
     Attached_SRs.find sr >>>= fun sr ->
-    VDI.stat ~dbg ~sr ~vdi >>>= fun response ->
-    ( match
-        List.assoc_opt _clone_on_boot_key response.Xapi_storage.Control.keys
-      with
-      | None ->
-          return response
-      | Some temporary ->
-          VDI.stat ~dbg ~sr ~vdi:temporary
-      )
-    >>>= fun response ->
+    stat_resolve_clone_on_boot ~dbg ~sr ~vdi >>>= fun response ->
+    Base.Hashtbl.set vdi_stat_cache ~key:cache_key ~data:response ;
     choose_datapath response >>>= fun (rpc, _datapath, uri) ->
     return_data_rpc (fun () ->
         Data_client.mirror (rpc ~dbg) dbg uri domain remote

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1347,6 +1347,20 @@ module VDIImpl (M : META) = struct
         Volume_client.unset (volume_rpc ~dbg ?missing) dbg sr vdi key
     )
 
+  (* Non-transactional, like other multi-key setters here; the XAPI DB
+     updated by SR.update_snapshot_info_dest is authoritative and wins on
+     SR.scan. *)
+  let set_snapshot_metadata ~dbg ~sr ~vdi ~snapshot_of ~snapshot_time
+      ~is_a_snapshot =
+    let vdi_str = Storage_interface.Vdi.string_of vdi in
+    let snapshot_of_str = Storage_interface.Vdi.string_of snapshot_of in
+    set ~dbg ~sr ~vdi:vdi_str ~key:_snapshot_of_key ~value:snapshot_of_str
+    >>>= fun () ->
+    set ~dbg ~sr ~vdi:vdi_str ~key:_snapshot_time_key ~value:snapshot_time
+    >>>= fun () ->
+    set ~dbg ~sr ~vdi:vdi_str ~key:_is_a_snapshot_key
+      ~value:(string_of_bool is_a_snapshot)
+
   let stat ~dbg ~sr ~vdi =
     (* TODO add default value to sharable? *)
     return_volume_rpc (fun () ->
@@ -1736,6 +1750,17 @@ module VDIImpl (M : META) = struct
     let* () = set ~dbg ~sr ~vdi ~key:_vdi_content_id_key ~value:content_id in
     return ()
 
+  let vdi_set_snapshot_metadata_impl dbg sr vdi snapshot_of snapshot_time
+      is_a_snapshot =
+    wrap
+    @@
+    let* sr = Attached_SRs.find sr in
+    let* () =
+      set_snapshot_metadata ~dbg ~sr ~vdi ~snapshot_of ~snapshot_time
+        ~is_a_snapshot
+    in
+    return ()
+
   let vdi_add_to_sm_config_impl dbg sr vdi key value =
     wrap
     @@
@@ -1958,6 +1983,7 @@ let bind ~volume_script_dir =
   S.VDI.data_destroy VDI.vdi_data_destroy_impl ;
   S.VDI.compose VDI.vdi_compose_impl ;
   S.VDI.set_content_id VDI.vdi_set_content_id_impl ;
+  S.VDI.set_snapshot_metadata VDI.vdi_set_snapshot_metadata_impl ;
   S.VDI.add_to_sm_config VDI.vdi_add_to_sm_config_impl ;
   S.VDI.remove_from_sm_config VDI.vdi_remove_from_sm_config_impl ;
   S.VDI.similar_content VDI.similar_content_impl ;

--- a/ocaml/xapi/storage_migrate_helper.ml
+++ b/ocaml/xapi/storage_migrate_helper.ml
@@ -314,6 +314,34 @@ module State = struct
           (Sr.of_string sr, Vdi.of_string (String.concat "/" rest))
     | _ ->
         failwith "Bad id"
+
+  (** A single (source → destination) snapshot pairing recorded during SMAPIv3
+      live migration. Used after mirroring to update VBD references and restore
+      snapshot metadata on the destination. *)
+  type snapshot_relation = {
+      src_vdi: Storage_interface.Vdi.t
+    ; dest_vdi: Storage_interface.Vdi.t
+    ; snapshot_time: Clock.Date.t
+  }
+
+  type snapshot_mappings_table = (string, snapshot_relation list) Hashtbl.t
+
+  let snapshot_mappings : snapshot_mappings_table = Hashtbl.create 10
+
+  let set_snapshot_mappings mirror_id relations =
+    Xapi_stdext_threads.Threadext.Mutex.execute mutex (fun () ->
+        Hashtbl.replace snapshot_mappings mirror_id relations
+    )
+
+  let get_snapshot_mappings mirror_id =
+    Xapi_stdext_threads.Threadext.Mutex.execute mutex (fun () ->
+        Hashtbl.find_opt snapshot_mappings mirror_id |> Option.value ~default:[]
+    )
+
+  let remove_snapshot_mappings mirror_id =
+    Xapi_stdext_threads.Threadext.Mutex.execute mutex (fun () ->
+        Hashtbl.remove snapshot_mappings mirror_id
+    )
 end
 
 let vdi_info = function

--- a/ocaml/xapi/storage_migrate_helper.ml
+++ b/ocaml/xapi/storage_migrate_helper.ml
@@ -345,6 +345,76 @@ end))
 
 module type SMAPIv2 = module type of Local
 
+(* Forget an orphan VDI row on the SXM destination pool. Uses the XenAPI
+   session embedded in the SXM url so the lookup runs against the dest
+   pool's DB — required for cross-pool SXM where the source pool has no
+   row for the dest SR. Empty url means a legacy intra-pool path that
+   already cleaned the row via SMAPIv1 vdi_delete; no-op then. *)
+let forget_orphan_dest_vdi ~url ~verify_dest ~sr ~vdi =
+  if url = "" then
+    SXM.debug "%s: no url, skipping dest forget" __FUNCTION__
+  else
+    SXM.log_and_ignore_exn (fun () ->
+        let parsed = Http.Url.of_string url in
+        let session_id_opt =
+          List.assoc_opt "session_id" (Http.Url.get_query_params parsed)
+          |> Option.map Ref.of_string
+        in
+        let host_opt =
+          match fst parsed with
+          | Http.Url.Http {host; _} ->
+              Some host
+          | _ ->
+              None
+        in
+        match (session_id_opt, host_opt) with
+        | Some session_id, Some host ->
+            Server_helpers.exec_with_new_task "SXM forget orphan dest VDI"
+              (fun __context ->
+                let verify_cert =
+                  if verify_dest then
+                    Stunnel_client.pool ()
+                  else
+                    None
+                in
+                let uuid = Vdi.string_of vdi in
+                let lookup host =
+                  let rpc =
+                    Helpers.make_remote_rpc ~verify_cert ~__context host
+                  in
+                  (Client.Client.VDI.get_by_uuid ~rpc ~session_id ~uuid, rpc)
+                in
+                let resolve () =
+                  try Some (lookup host) with
+                  | Api_errors.Server_error (code, master_ip :: _)
+                    when code = Api_errors.host_is_slave -> (
+                    try Some (lookup master_ip) with _ -> None
+                  )
+                  | _ ->
+                      None
+                in
+                match resolve () with
+                | None ->
+                    ()
+                | Some (vdi_ref, rpc) ->
+                    let rec_ =
+                      Client.Client.VDI.get_record ~rpc ~session_id
+                        ~self:vdi_ref
+                    in
+                    if rec_.API.vDI_is_a_snapshot then (
+                      SXM.info "%s forgetting orphan VDI %s on dest sr %s"
+                        __FUNCTION__ uuid (Sr.string_of sr) ;
+                      Client.Client.VDI.forget ~rpc ~session_id ~vdi:vdi_ref
+                    ) else
+                      SXM.warn
+                        "%s skipping non-snapshot row at vdi %s on dest sr %s"
+                        __FUNCTION__ uuid (Sr.string_of sr)
+            )
+        | _ ->
+            SXM.warn "%s url missing session_id or host, skipping forget"
+              __FUNCTION__
+    )
+
 let get_remote_backend url verify_dest =
   let remote_url = Storage_utils.connection_args_of_uri ~verify_dest url in
   let module Remote = StorageAPI (Idl.Exn.GenClient (struct

--- a/ocaml/xapi/storage_migrate_helper.mli
+++ b/ocaml/xapi/storage_migrate_helper.mli
@@ -265,6 +265,12 @@ module Local : SMAPIv2
 
 val get_remote_backend : string -> bool -> (module SMAPIv2)
 
+val forget_orphan_dest_vdi :
+  url:string -> verify_dest:bool -> sr:sr -> vdi:vdi -> unit
+(** Forget an orphan VDI row on the SXM destination pool using the XenAPI
+    session embedded in the SXM url. Best-effort; cross-pool safe; empty
+    [url] is a no-op for legacy intra-pool paths. *)
+
 val find_vdi :
   dbg:string -> sr:sr -> vdi:vdi -> (module SMAPIv2) -> vdi_info * vdi_info list
 

--- a/ocaml/xapi/storage_migrate_helper.mli
+++ b/ocaml/xapi/storage_migrate_helper.mli
@@ -236,6 +236,20 @@ module State : sig
   val copy_id_of : Storage_interface.sr * Storage_interface.vdi -> string
 
   val of_copy_id : string -> Storage_interface.sr * Storage_interface.vdi
+
+  (** A single source→destination snapshot pairing recorded during SMAPIv3
+      live migration. *)
+  type snapshot_relation = {
+      src_vdi: Storage_interface.Vdi.t
+    ; dest_vdi: Storage_interface.Vdi.t
+    ; snapshot_time: Clock.Date.t
+  }
+
+  val set_snapshot_mappings : string -> snapshot_relation list -> unit
+
+  val get_snapshot_mappings : string -> snapshot_relation list
+
+  val remove_snapshot_mappings : string -> unit
 end
 
 val vdi_info :

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -365,8 +365,16 @@ module Mux = struct
           Db.VDI.set_snapshot_of ~__context ~self:vdi ~value:snapshot_of
       )
 
+    (* Push snapshot metadata to the backend so a later SR.scan does not
+       re-overwrite XAPI DB fields with stale volume keys. *)
+    let update_backend_snapshot_metadata ~dbg sr snapshot leaf snapshot_time =
+      let module C = StorageAPI (Idl.Exn.GenClient (struct
+        let rpc = of_sr sr
+      end)) in
+      C.VDI.set_snapshot_metadata dbg sr snapshot leaf snapshot_time true
+
     let update_snapshot_info_dest () ~dbg ~sr ~vdi ~src_vdi ~snapshot_pairs =
-      with_dbg ~name:"SR.update_snapshot_info_dest" ~dbg @@ fun _di ->
+      with_dbg ~name:"SR.update_snapshot_info_dest" ~dbg @@ fun di ->
       info
         "SR.update_snapshot_info_dest dbg:%s sr:%s vdi:%s ~src_vdi:%s \
          snapshot_pairs:%s"
@@ -409,6 +417,11 @@ module Mux = struct
               in
               assert_content_ids_match ~vdi_info1:local_snapshot_info
                 ~vdi_info2:src_snapshot_info ;
+              D.log_and_ignore_exn (fun () ->
+                  update_backend_snapshot_metadata
+                    ~dbg:(Debug_info.to_string di) sr local_snapshot vdi
+                    src_snapshot_info.snapshot_time
+              ) ;
               set_snapshot_time __context ~dbg ~sr ~vdi:local_snapshot
                 ~snapshot_time:src_snapshot_info.snapshot_time ;
               set_snapshot_of __context ~dbg ~sr ~vdi:local_snapshot
@@ -705,6 +718,17 @@ module Mux = struct
         let rpc = of_sr sr
       end)) in
       C.VDI.set_content_id (Debug_info.to_string di) sr vdi content_id
+
+    let set_snapshot_metadata () ~dbg ~sr ~vdi ~snapshot_of ~snapshot_time
+        ~is_a_snapshot =
+      with_dbg ~name:"VDI.set_snapshot_metadata" ~dbg @@ fun di ->
+      info "VDI.set_snapshot_metadata dbg:%s sr:%s vdi:%s snapshot_of:%s" dbg
+        (s_of_sr sr) (s_of_vdi vdi) (s_of_vdi snapshot_of) ;
+      let module C = StorageAPI (Idl.Exn.GenClient (struct
+        let rpc = of_sr sr
+      end)) in
+      C.VDI.set_snapshot_metadata (Debug_info.to_string di) sr vdi snapshot_of
+        snapshot_time is_a_snapshot
 
     let similar_content () ~dbg ~sr ~vdi =
       with_dbg ~name:"VDI.similar_content" ~dbg @@ fun di ->

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -887,6 +887,11 @@ module SMAPIv1 : Server_impl = struct
             ~value:content_id
       )
 
+    let set_snapshot_metadata _context ~dbg:_ ~sr:_ ~vdi:_ ~snapshot_of:_
+        ~snapshot_time:_ ~is_a_snapshot:_ =
+      (* SMAPIv1 doesn't need this - snapshot metadata is managed by xapi database only *)
+      ()
+
     let similar_content _context ~dbg ~sr ~vdi =
       with_dbg ~name:"VDI.similar_content" ~dbg @@ fun di ->
       info "VDI.similar_content dbg:%s sr:%s vdi:%s" di.log (s_of_sr sr)

--- a/ocaml/xapi/storage_smapiv1_migrate.ml
+++ b/ocaml/xapi/storage_smapiv1_migrate.ml
@@ -634,7 +634,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
         mirror_cleanup ~dbg ~sr ~snapshot
 
   let receive_start_common ~dbg ~sr ~vdi_info ~id ~image_format ~similar ~vm
-      (module SMAPI : SMAPIv2) =
+      ~url ~verify_dest (module SMAPI : SMAPIv2) =
     let on_fail : (unit -> unit) list ref = ref [] in
     let vdis = SMAPI.SR.scan dbg sr in
     (* We drop cbt_metadata VDIs that do not have any actual data *)
@@ -734,8 +734,8 @@ module MIRROR : SMAPIv2_MIRROR = struct
               ; parent_vdi= parent.vdi
               ; remote_vdi= vdi_info.vdi
               ; mirror_vm= vm
-              ; url= ""
-              ; verify_dest= false
+              ; url
+              ; verify_dest
               }
         ) ;
       let nearest_content_id = Option.map (fun x -> x.content_id) nearest in
@@ -763,7 +763,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
       (string_of_vdi_info vdi_info)
       id image_format ;
     receive_start_common ~dbg ~sr ~vdi_info ~id ~image_format ~similar
-      ~vm:(Vm.of_string "0")
+      ~vm:(Vm.of_string "0") ~url:"" ~verify_dest:false
       (module Local)
 
   let receive_start2 _ctx ~dbg ~sr ~vdi_info ~id ~image_format ~similar ~vm =
@@ -772,6 +772,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
       (string_of_vdi_info vdi_info)
       id image_format ;
     receive_start_common ~dbg ~sr ~vdi_info ~id ~image_format ~similar ~vm
+      ~url:"" ~verify_dest:false
       (module Local)
 
   let receive_start3 _ctx ~dbg ~sr ~vdi_info ~mirror_id ~image_format ~similar
@@ -786,7 +787,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
       Storage_migrate_helper.get_remote_backend url verify_dest
     in
     receive_start_common ~dbg ~sr ~vdi_info ~id:mirror_id ~image_format ~similar
-      ~vm
+      ~vm ~url ~verify_dest
       (module Remote)
 
   let receive_finalize _ctx ~dbg ~id =
@@ -808,10 +809,17 @@ module MIRROR : SMAPIv2_MIRROR = struct
           (Vdi.string_of r.leaf_vdi) ;
         SMAPI.DP.destroy2 dbg r.leaf_dp r.sr r.leaf_vdi r.mirror_vm false ;
         SMAPI.VDI.compose dbg r.sr r.parent_vdi r.leaf_vdi ;
-        (* On SMAPIv3, compose would have removed the now invalid dummy vdi, so
-           there is no need to destroy it anymore, while this is necessary on SMAPIv1 SRs. *)
+        (* Destroy the dummy backend volume on the dest SR. On SMAPIv1
+           this also drops the dest XAPI DB row; on SMAPIv3 only the
+           backend volume is removed. *)
         D.log_and_ignore_exn (fun () -> SMAPI.VDI.destroy dbg r.sr r.dummy_vdi
         ) ;
+        (* Forget the dest XAPI DB row that survives on SMAPIv3. The forget
+           runs against the dest pool via the XenAPI session embedded in the
+           SXM url, so it works both intra-pool and cross-pool. No-op on
+           SMAPIv1 where the row was already dropped above. *)
+        Storage_migrate_helper.forget_orphan_dest_vdi ~url:r.url
+          ~verify_dest:r.verify_dest ~sr:r.sr ~vdi:r.dummy_vdi ;
         SMAPI.VDI.remove_from_sm_config dbg r.sr r.leaf_vdi "base_mirror"
       )
       recv_state ;
@@ -932,7 +940,11 @@ module MIRROR : SMAPIv2_MIRROR = struct
         D.log_and_ignore_exn (fun () -> Remote.DP.destroy dbg r.leaf_dp false) ;
         List.iter
           (fun v ->
-            D.log_and_ignore_exn (fun () -> Remote.VDI.destroy dbg r.sr v)
+            D.log_and_ignore_exn (fun () -> Remote.VDI.destroy dbg r.sr v) ;
+            (* The cancel path runs before compose, so the dest XAPI DB row
+               for each VDI may also linger on SMAPIv3. Forget on dest pool. *)
+            Storage_migrate_helper.forget_orphan_dest_vdi ~url ~verify_dest
+              ~sr:r.sr ~vdi:v
           )
           [r.dummy_vdi; r.leaf_vdi; r.parent_vdi]
       )

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -880,6 +880,15 @@ functor
         let dbg = Debug_info.to_string di in
         Impl.VDI.set_content_id context ~dbg ~sr ~vdi ~content_id
 
+      let set_snapshot_metadata context ~dbg ~sr ~vdi ~snapshot_of
+          ~snapshot_time ~is_a_snapshot =
+        with_dbg ~name:"VDI.set_snapshot_metadata" ~dbg @@ fun di ->
+        info "VDI.set_snapshot_metadata dbg:%s sr:%s vdi:%s snapshot_of:%s"
+          di.log (s_of_sr sr) (s_of_vdi vdi) (s_of_vdi snapshot_of) ;
+        let dbg = Debug_info.to_string di in
+        Impl.VDI.set_snapshot_metadata context ~dbg ~sr ~vdi ~snapshot_of
+          ~snapshot_time ~is_a_snapshot
+
       let similar_content context ~dbg ~sr ~vdi =
         with_dbg ~name:"VDI.similar_content" ~dbg @@ fun di ->
         info "VDI.similar_content dbg:%s sr:%s vdi:%s" di.log (s_of_sr sr)

--- a/ocaml/xapi/storage_smapiv3_migrate.ml
+++ b/ocaml/xapi/storage_smapiv3_migrate.ml
@@ -545,6 +545,71 @@ let rec dfs_process_node ~ctx ~working_vdi ~working_dp ~nbd_uri ~counter ~total
   in
   this_relation :: (inactive_relations @ active_relations)
 
+(** SXM v3 (SMAPIv3) pre-flight: the destination reconstructs the base chain
+    from the VM-snapshot tree, so refuse snapshot shapes that tree cannot
+    express - hidden VDI.snapshots and orphan snapshot VDIs. *)
+let assert_migratable ~__context ~vm_uuid ~active_vdis ~snapshot_vdis =
+  let uuid self = Db.VDI.get_uuid ~__context ~self in
+  let sr_of vdi = Db.VDI.get_SR ~__context ~self:vdi in
+  let is_v3_vdi vdi =
+    Storage_mux_reg.smapi_version_of_sr
+      (Storage_interface.Sr.of_string
+         (Db.SR.get_uuid ~__context ~self:(sr_of vdi))
+      )
+    = SMAPIv3
+  in
+  let active_disks = List.sort_uniq compare active_vdis in
+  let vm_snapshot_disks = snapshot_vdis in
+  let abort what items render =
+    if items <> [] then
+      raise
+        (Api_errors.Server_error
+           ( Api_errors.operation_not_allowed
+           , [
+               Printf.sprintf "Cannot migrate VM %s: %s [%s]" vm_uuid what
+                 (String.concat "; " (List.map render items))
+             ]
+           )
+        )
+  in
+  (* hidden: VDI.snapshots of an active disk not backing any VM snapshot *)
+  let hidden =
+    List.concat_map
+      (fun active ->
+        Db.VDI.get_snapshots ~__context ~self:active
+        |> List.filter (fun s ->
+            (not (List.mem s vm_snapshot_disks)) && is_v3_vdi s
+        )
+        |> List.map (fun s -> (s, active))
+      )
+      active_disks
+  in
+  abort
+    "it has VDI-level snapshots on SMAPIv3 SRs that are not part of any VM \
+     snapshot and must be deleted before migrating:"
+    hidden (fun (s, active) ->
+      Printf.sprintf "%s (snapshot of active disk %s)" (uuid s) (uuid active)
+  ) ;
+  (* orphans: a VM-snapshot disk whose active disk was deleted has no live
+     leaf to anchor it on at the destination, so refuse unconditionally *)
+  let orphaned s =
+    let snapshot_of = Db.VDI.get_snapshot_of ~__context ~self:s in
+    not
+      (Db.is_valid_ref __context snapshot_of
+      && List.mem snapshot_of active_disks
+      )
+  in
+  let orphans =
+    List.filter (fun s -> is_v3_vdi s && orphaned s) snapshot_vdis
+  in
+  abort
+    "it has orphan snapshot VDIs on SMAPIv3 SRs whose active disk was deleted; \
+     delete these snapshots before migrating:"
+    orphans (fun s ->
+      Printf.sprintf "%s (SR %s)" (uuid s)
+        (Db.SR.get_uuid ~__context ~self:(sr_of s))
+  )
+
 module MIRROR : SMAPIv2_MIRROR = struct
   type context = unit
 

--- a/ocaml/xapi/storage_smapiv3_migrate.ml
+++ b/ocaml/xapi/storage_smapiv3_migrate.ml
@@ -14,6 +14,7 @@
 
 module D = Debug.Make (struct let name = __MODULE__ end)
 
+module Date = Clock.Date
 module Unixext = Xapi_stdext_unix.Unixext
 module State = Storage_migrate_helper.State
 module SXM = Storage_migrate_helper.SXM
@@ -30,11 +31,16 @@ let s_of_vdi = Storage_interface.Vdi.string_of
 
 let s_of_vm = Storage_interface.Vm.string_of
 
+(** Path of the unix-domain socket on which the local NBD proxy thread listens
+    for connections from QEMU on behalf of [mirror_vm]. The same path is used
+    by the proxy server (export side) and by the URI passed to the destination
+    (import side), so derive both from this single helper. *)
+let nbd_proxy_path_of_vm vm =
+  Printf.sprintf "/var/run/nbdproxy/export/%s" (Vm.string_of vm)
+
 let export_nbd_proxy ~remote_url ~mirror_vm ~sr ~vdi ~dp ~verify_dest =
   D.debug "%s spawning exporting nbd proxy" __FUNCTION__ ;
-  let path =
-    Printf.sprintf "/var/run/nbdproxy/export/%s" (Vm.string_of mirror_vm)
-  in
+  let path = nbd_proxy_path_of_vm mirror_vm in
   let proxy_srv = Fecomms.open_unix_domain_sock_server path in
   try
     let uri =
@@ -73,48 +79,477 @@ let export_nbd_proxy ~remote_url ~mirror_vm ~sr ~vdi ~dp ~verify_dest =
     Unix.close proxy_srv ;
     raise e
 
-let mirror_wait ~dbg ~sr ~vdi ~vm ~mirror_id mirror_key =
-  let rec mirror_wait_rec key =
+let mirror_poll_interval = 0.5
+
+(** Poll the mirror until complete; on failure raise Migration_mirror_failure
+    and, when [mirror_id] is given, mark Send_state.failed and post an update. *)
+let wait_for_mirror ~dbg ~sr ~vdi ~vm ?mirror_id ~error_msg mirror_key =
+  let on_failure () =
+    match mirror_id with
+    | Some mid ->
+        State.find_active_local_mirror mid
+        |> Option.iter (fun (s : State.Send_state.t) -> s.failed <- true) ;
+        Updates.add (Dynamic.Mirror mid) updates
+    | None ->
+        ()
+  in
+  let rec poll key =
     let {failed; complete; progress} : Mirror.status =
       Local.DATA.stat dbg sr vdi vm key
     in
-    if complete then (
-      Option.fold ~none:()
-        ~some:(fun p -> D.info "%s progress is %f" __FUNCTION__ p)
-        progress ;
-      D.info "%s qemu mirror %s completed" mirror_id __FUNCTION__
-    ) else if failed then (
+    if complete then
       Option.iter
-        (fun (snd_state : State.Send_state.t) -> snd_state.failed <- true)
-        (State.find_active_local_mirror mirror_id) ;
-      D.info "%s qemu mirror %s failed" mirror_id __FUNCTION__ ;
-      State.find_active_local_mirror mirror_id
-      |> Option.iter (fun (s : State.Send_state.t) -> s.failed <- true) ;
-      Updates.add (Dynamic.Mirror mirror_id) updates ;
+        (fun p -> D.debug "%s mirror completed, progress: %.2f" __FUNCTION__ p)
+        progress
+    else if failed then (
+      on_failure () ;
       raise
-        (Storage_interface.Storage_error
-           (Migration_mirror_failure "Mirror failed during syncing")
-        )
+        (Storage_interface.Storage_error (Migration_mirror_failure error_msg))
     ) else (
-      Option.fold ~none:()
-        ~some:(fun p -> D.info "%s progress is %f" __FUNCTION__ p)
+      Option.iter
+        (fun p -> D.debug "%s mirror progress: %.2f" __FUNCTION__ p)
         progress ;
-      mirror_wait_rec key
+      Unix.sleepf mirror_poll_interval ;
+      poll key
     )
   in
-
   match mirror_key with
   | Storage_interface.Mirror.CopyV1 _ ->
       ()
   | Storage_interface.Mirror.MirrorV1 _ ->
-      D.debug "%s waiting for mirroring to be done" __FUNCTION__ ;
-      mirror_wait_rec mirror_key
+      D.debug "%s waiting for mirror to complete" __FUNCTION__ ;
+      poll mirror_key
+
+(** Deactivate and detach a snapshot VDI. Uses [Fun.protect] so [detach]
+    runs even if [deactivate] raises -- otherwise the datapath leaks until
+    reboot (xapi has no datapath GC). *)
+let detach_snapshot_vdi ~dbg ~dp ~sr ~snapshot_vdi ~copy_vm =
+  D.debug "%s detaching snapshot VDI %s" __FUNCTION__ (s_of_vdi snapshot_vdi) ;
+  Fun.protect
+    ~finally:(fun () -> Local.VDI.detach dbg dp sr snapshot_vdi copy_vm)
+    (fun () -> Local.VDI.deactivate dbg dp sr snapshot_vdi copy_vm)
+
+let create_destination_snapshot ~dbg ~dest_sr ~dest_url ~verify_dest
+    ~dest_vdi_info ~src_content_id =
+  let (module Remote) =
+    Storage_migrate_helper.get_remote_backend dest_url verify_dest
+  in
+  D.debug "%s creating snapshot of destination VDI %s" __FUNCTION__
+    (s_of_vdi dest_vdi_info.vdi) ;
+  let dest_snapshot =
+    Remote.VDI.snapshot dbg dest_sr {dest_vdi_info with sm_config= []}
+  in
+  D.debug "%s propagating src content_id %s onto dest snapshot %s" __FUNCTION__
+    src_content_id
+    (s_of_vdi dest_snapshot.vdi) ;
+  Remote.VDI.set_content_id dbg dest_sr dest_snapshot.vdi src_content_id ;
+  {dest_snapshot with content_id= src_content_id}
+
+let mirror_snapshot_into_existing_dest ~dbg ~sr ~snapshot_vdi_uuid ~dest_sr
+    ~dest_url ~verify_dest ~copy_vm ~image_format ~dest_vdi_info ~nbd_uri =
+  SXM.info "%s mirroring snapshot %s into VDI %s" __FUNCTION__ snapshot_vdi_uuid
+    (s_of_vdi dest_vdi_info.vdi) ;
+
+  let snapshot_vdi = Vdi.of_string snapshot_vdi_uuid in
+  let dp = Uuidx.(to_string (make ())) in
+
+  try
+    (* Capture src snapshot content_id BEFORE attaching, so we can
+       propagate it onto the dest snapshot to satisfy
+       assert_content_ids_match in update_snapshot_info_dest. *)
+    let src_content_id =
+      try (Local.VDI.stat dbg sr snapshot_vdi).content_id
+      with e ->
+        D.warn "%s failed to stat src snapshot %s for content_id: %s"
+          __FUNCTION__ snapshot_vdi_uuid (Printexc.to_string e) ;
+        ""
+    in
+    D.debug "%s captured src snapshot %s content_id=%s" __FUNCTION__
+      snapshot_vdi_uuid src_content_id ;
+
+    ignore (Local.VDI.attach3 dbg dp sr snapshot_vdi copy_vm false) ;
+    Local.VDI.activate_readonly dbg dp sr snapshot_vdi copy_vm ;
+
+    D.debug "%s starting QEMU mirror from snapshot %s" __FUNCTION__
+      snapshot_vdi_uuid ;
+    let mirror_key =
+      Local.DATA.mirror dbg sr snapshot_vdi image_format copy_vm nbd_uri
+    in
+
+    wait_for_mirror ~dbg ~sr ~vdi:snapshot_vdi ~vm:copy_vm
+      ~error_msg:(Printf.sprintf "Snapshot %s mirror failed" snapshot_vdi_uuid)
+      mirror_key ;
+
+    detach_snapshot_vdi ~dbg ~dp ~sr ~snapshot_vdi ~copy_vm ;
+
+    let dest_snapshot =
+      create_destination_snapshot ~dbg ~dest_sr ~dest_url ~verify_dest
+        ~dest_vdi_info ~src_content_id
+    in
+    D.debug "%s destination snapshot created: %s" __FUNCTION__
+      (s_of_vdi dest_snapshot.vdi) ;
+
+    dest_snapshot
+  with e ->
+    D.error "%s snapshot mirror failed: %s" __FUNCTION__ (Printexc.to_string e) ;
+    D.log_and_ignore_exn (fun () ->
+        detach_snapshot_vdi ~dbg ~dp ~sr ~snapshot_vdi ~copy_vm
+    ) ;
+    raise e
+
+let nbd_export_of_attach_info backend =
+  match Storage_interface.nbd_export_of_attach_info backend with
+  | Some export ->
+      export
+  | None ->
+      raise
+        (Storage_error
+           (Migration_preparation_failure "No NBD export found in attach info")
+        )
+
+(** A node in the VM snapshot tree, projected onto a single disk position
+    (identified by VDI lineage — see [find_lineage_vdi_on_snapshot_vm]).
+    Branching at a node means the source VM was reverted to that snapshot
+    before further snapshots were taken; among the children exactly one
+    lies on the active path (the chain leading to the live VM) and the rest
+    are reverted-and-orphaned branches that still need to be reproduced on
+    the destination so the snapshot tree topology survives migration. *)
+type snapshot_tree_node = {
+    vdi_uuid: string
+  ; snapshot_time: Date.t
+  ; on_active_path: bool
+  ; children: snapshot_tree_node list
+}
+
+let find_active_vm_for_vdi ~__context ~vdi_ref =
+  Db.VDI.get_VBDs ~__context ~self:vdi_ref
+  |> List.find_map (fun vbd ->
+      let vm = Db.VBD.get_VM ~__context ~self:vbd in
+      if Db.VM.get_is_a_snapshot ~__context ~self:vm then
+        None
+      else
+        Some vm
+  )
+
+(** For a snapshot VM, find the disk VDI that belongs to [lineage] (the set
+    of snapshot VDI refs of the disk being migrated). *)
+let find_lineage_vdi_on_snapshot_vm ~__context ~lineage ~snapshot_vm =
+  Db.VM.get_VBDs ~__context ~self:snapshot_vm
+  |> List.find_map (fun vbd ->
+      if Db.VBD.get_type ~__context ~self:vbd <> `Disk then
+        None
+      else
+        let vdi = Db.VBD.get_VDI ~__context ~self:vbd in
+        if not (List.mem vdi lineage) then
+          None
+        else
+          let uuid = Db.VDI.get_uuid ~__context ~self:vdi in
+          let time = Db.VDI.get_snapshot_time ~__context ~self:vdi in
+          Some (uuid, time)
+  )
+
+let sort_snapshots_by_time ~__context snaps =
+  List.sort
+    (fun a b ->
+      Date.compare
+        (Db.VM.get_snapshot_time ~__context ~self:a)
+        (Db.VM.get_snapshot_time ~__context ~self:b)
+    )
+    snaps
+
+(** Walk the [parent] chain upward from [vm] to collect the set of
+    snapshot VMs on the active path (the chronological line from the
+    oldest root snapshot down to [vm]). The result is a set membership
+    predicate, returned as a [Ref.t -> bool]. *)
+let build_active_path_predicate ~__context ~vm =
+  let rec collect snap acc =
+    if snap = Ref.null then
+      acc
+    else
+      collect (Db.VM.get_parent ~__context ~self:snap) (snap :: acc)
+  in
+  let path = collect (Db.VM.get_parent ~__context ~self:vm) [] in
+  fun snap -> List.mem snap path
+
+(** Build the snapshot subtree rooted at [snapshot_vm], projected onto a
+    single disk identified by [lineage] (the disk's snapshot VDI set). A
+    node whose snapshot VM has no VDI in [lineage] is skipped: its
+    descendants (if any match) are promoted to take its place, so we never
+    lose snapshots that exist for the disk just because an intermediate
+    snapshot VM did not include it. *)
+let rec build_subtree_for_lineage ~__context ~lineage ~on_active_path
+    snapshot_vm =
+  let recur_children () =
+    Db.VM.get_children ~__context ~self:snapshot_vm
+    |> List.filter (fun c -> Db.VM.get_is_a_snapshot ~__context ~self:c)
+    |> sort_snapshots_by_time ~__context
+    |> List.concat_map
+         (build_subtree_for_lineage ~__context ~lineage ~on_active_path)
+  in
+  match find_lineage_vdi_on_snapshot_vm ~__context ~lineage ~snapshot_vm with
+  | Some (vdi_uuid, snapshot_time) ->
+      [
+        {
+          vdi_uuid
+        ; snapshot_time
+        ; on_active_path= on_active_path snapshot_vm
+        ; children= recur_children ()
+        }
+      ]
+  | None ->
+      (* Promote descendants: a snapshot VM without this disk is a
+         transparent intermediate — its disk-bearing descendants must
+         still appear in the tree at the parent's level. *)
+      recur_children ()
+
+(** Build the forest of snapshot-tree nodes for the disk identified by
+    [lineage], walking the snapshot VMs of [vm] from the roots of the VM
+    snapshot tree (those with no [parent]) and projecting each onto
+    [lineage]. [on_active_path] decides which snapshot VMs lie on the chain
+    leading to the live VM. *)
+let build_forest_for_lineage ~__context ~vm ~lineage ~on_active_path =
+  Db.VM.get_snapshots ~__context ~self:vm
+  |> List.filter (fun s -> Db.VM.get_parent ~__context ~self:s = Ref.null)
+  |> sort_snapshots_by_time ~__context
+  |> List.concat_map
+       (build_subtree_for_lineage ~__context ~lineage ~on_active_path)
+
+let rec count_tree_nodes trees =
+  List.fold_left
+    (fun acc node -> acc + 1 + count_tree_nodes node.children)
+    0 trees
+
+(** Retrieve the snapshot tree for the active disk [vdi] being migrated.
+    The tree is built by:
+      1. locating the live VM that has [vdi] attached,
+      2. taking the disk's lineage = [VDI.snapshots] of [vdi] (the correct,
+         revert- and slot-reuse-safe snapshot-to-disk identity),
+      3. walking the live VM's snapshot tree and projecting each snapshot VM
+         onto the lineage.
+    Returns root nodes sorted by [snapshot_time] (oldest first). *)
+let get_snapshot_tree ~dbg ~vdi =
+  D.debug "%s retrieving snapshot tree for VDI %s" __FUNCTION__ (s_of_vdi vdi) ;
+  try
+    Server_helpers.exec_with_new_task "get_snapshot_tree"
+      ~subtask_of:(Ref.of_string dbg) (fun __context ->
+        let vdi_uuid = s_of_vdi vdi in
+        let vdi_ref = Db.VDI.get_by_uuid ~__context ~uuid:vdi_uuid in
+        match find_active_vm_for_vdi ~__context ~vdi_ref with
+        | None ->
+            D.warn "%s no active VM found for VDI %s" __FUNCTION__ vdi_uuid ;
+            []
+        | Some vm ->
+            let lineage = Db.VDI.get_snapshots ~__context ~self:vdi_ref in
+            if lineage = [] then (
+              D.debug "%s no snapshots for VDI %s" __FUNCTION__ vdi_uuid ;
+              []
+            ) else
+              let on_active_path = build_active_path_predicate ~__context ~vm in
+              let roots =
+                build_forest_for_lineage ~__context ~vm ~lineage ~on_active_path
+              in
+              D.debug "%s VDI %s lineage of %d, %d root(s), %d node(s)"
+                __FUNCTION__ vdi_uuid (List.length lineage) (List.length roots)
+                (count_tree_nodes roots) ;
+              roots
+    )
+  with e ->
+    D.error "%s failed to retrieve snapshot tree: %s" __FUNCTION__
+      (Printexc.to_string e) ;
+    raise
+      (Storage_error
+         (Migration_preparation_failure
+            (Printf.sprintf "Failed to build snapshot tree for VDI %s: %s"
+               (s_of_vdi vdi) (Printexc.to_string e)
+            )
+         )
+      )
+
+let start_nbd_proxy_thread ~url ~mirror_vm ~dest_sr ~mirror_vdi ~mirror_datapath
+    ~verify_dest =
+  Thread.create
+    (fun () ->
+      export_nbd_proxy ~remote_url:url ~mirror_vm ~sr:dest_sr
+        ~vdi:mirror_vdi.vdi ~dp:mirror_datapath ~verify_dest
+    )
+    ()
+
+(** Invariant context shared across all nodes in a snapshot tree traversal.
+    Extracted to avoid threading 8+ parameters through every recursive call.
+    [on_fail] accumulates undo thunks (most recently registered first) that
+    [send_start] runs in reverse if any node's mirror fails, so a partial
+    DFS does not leak per-node destination snapshot VDIs. *)
+type mirror_ctx = {
+    dbg: string
+  ; sr: Sr.t
+  ; dest_sr: Sr.t
+  ; url: string
+  ; verify_dest: bool
+  ; mirror_vm: Vm.t
+  ; copy_vm: Vm.t
+  ; nbd_proxy_path: string
+  ; image_format: string
+  ; on_fail: (unit -> unit) list ref
+}
+
+let nbd_uri_of_export ~nbd_proxy_path export =
+  Uri.make ~scheme:"nbd+unix" ~host:"" ~path:export
+    ~query:[("socket", [nbd_proxy_path])]
+    ()
+  |> Uri.to_string
+
+let prepare_branch_vdi ~ctx ~dest_snapshot =
+  let (module Remote) =
+    Storage_migrate_helper.get_remote_backend ctx.url ctx.verify_dest
+  in
+  let bv = Remote.VDI.clone ctx.dbg ctx.dest_sr dest_snapshot in
+  let bdp = Uuidx.(to_string (make ())) in
+  D.debug "%s branch VDI %s cloned from snapshot %s" __FUNCTION__
+    (s_of_vdi bv.vdi)
+    (s_of_vdi dest_snapshot.vdi) ;
+  let cleanup () =
+    D.debug "%s cleaning up branch VDI %s" __FUNCTION__ (s_of_vdi bv.vdi) ;
+    D.log_and_ignore_exn (fun () ->
+        Remote.VDI.deactivate ctx.dbg bdp ctx.dest_sr bv.vdi ctx.mirror_vm
+    ) ;
+    D.log_and_ignore_exn (fun () ->
+        Remote.VDI.detach ctx.dbg bdp ctx.dest_sr bv.vdi ctx.mirror_vm
+    ) ;
+    D.log_and_ignore_exn (fun () ->
+        Remote.VDI.destroy ctx.dbg ctx.dest_sr bv.vdi
+    )
+  in
+  (* Clean up the clone if any of attach/activate/nbd setup raises: the
+     caller only arms [cleanup] via Fun.protect after we return, so a
+     failure here would otherwise leak the branch VDI. *)
+  let nbd_uri =
+    try
+      let backend =
+        Remote.VDI.attach3 ctx.dbg bdp ctx.dest_sr bv.vdi ctx.mirror_vm true
+      in
+      (* This clone is the mirror TARGET for the revert subtree, so it must
+         be activated WRITABLE -- a readonly datapath makes qemu-dp reject
+         the mirror target with "Could not open image: Permission denied". *)
+      Remote.VDI.activate3 ctx.dbg bdp ctx.dest_sr bv.vdi ctx.mirror_vm ;
+      nbd_uri_of_export ~nbd_proxy_path:ctx.nbd_proxy_path
+        (nbd_export_of_attach_info backend)
+    with e ->
+      D.error "%s failed to prepare branch VDI %s: %s" __FUNCTION__
+        (s_of_vdi bv.vdi) (Printexc.to_string e) ;
+      cleanup () ;
+      raise e
+  in
+  (bv, bdp, nbd_uri, cleanup)
+
+(** Mirror a single snapshot-tree node into the supplied [working_vdi],
+    take a destination snapshot to anchor the mirrored data, and return
+    the destination snapshot info plus the [snapshot_relation] entry.
+
+    This is the unit of work executed at every node, regardless of
+    whether the node sits on the active path or on a reverted branch --
+    the only thing that changes between those cases is which VDI is
+    passed as [working_vdi]. *)
+let mirror_node_into ~ctx ~working_vdi ~working_dp ~nbd_uri ~counter ~total node
+    =
+  incr counter ;
+  SXM.info "%s [%d/%d] mirroring snapshot %s into VDI %s" __FUNCTION__ !counter
+    total node.vdi_uuid (s_of_vdi working_vdi.vdi) ;
+  (* Give the NBD proxy thread time to start listening before issuing
+     the mirror RPC. A proper fix would use a Mutex+Condition for
+     readiness signalling -- tracked as a follow-up. *)
+  let _ : Thread.t =
+    start_nbd_proxy_thread ~url:ctx.url ~mirror_vm:ctx.mirror_vm
+      ~dest_sr:ctx.dest_sr ~mirror_vdi:working_vdi ~mirror_datapath:working_dp
+      ~verify_dest:ctx.verify_dest
+  in
+  Unix.sleepf mirror_poll_interval ;
+  let dest_snapshot =
+    mirror_snapshot_into_existing_dest ~dbg:ctx.dbg ~sr:ctx.sr
+      ~snapshot_vdi_uuid:node.vdi_uuid ~dest_sr:ctx.dest_sr ~dest_url:ctx.url
+      ~verify_dest:ctx.verify_dest ~copy_vm:ctx.copy_vm
+      ~image_format:ctx.image_format ~dest_vdi_info:working_vdi ~nbd_uri
+  in
+  let (module Remote) =
+    Storage_migrate_helper.get_remote_backend ctx.url ctx.verify_dest
+  in
+  ctx.on_fail :=
+    (fun () -> Remote.VDI.destroy ctx.dbg ctx.dest_sr dest_snapshot.vdi)
+    :: !(ctx.on_fail) ;
+  let relation =
+    State.
+      {
+        src_vdi= Vdi.of_string node.vdi_uuid
+      ; dest_vdi= dest_snapshot.vdi
+      ; snapshot_time= node.snapshot_time
+      }
+  in
+  (dest_snapshot, relation)
+
+(** DFS through the snapshot tree.
+
+    Invariants:
+    - [working_vdi] is the destination VDI currently impersonating the
+      source disk's leaf as we walk down a chain. On the root of the
+      whole tree this is the [mirror_vdi] created by [receive_start3];
+      whenever we descend into a non-active sibling we clone the parent
+      snapshot to obtain a fresh [working_vdi] for that subtree.
+    - At a branching node (multiple children) we process the
+      reverted/inactive subtrees first, each with its own cloned
+      [working_vdi] which is destroyed as soon as the subtree finishes.
+      The single active-path child is processed last and inherits the
+      same [working_vdi], so when recursion bottoms out on the deepest
+      active node the [working_vdi] is still the original [mirror_vdi]
+      and is correctly positioned for live-leaf mirroring.
+    - Inactive-first ordering also keeps resource usage low: a cloned
+      branch's attach handle, NBD socket and qemu mirror job are torn
+      down before the next branch starts. *)
+let rec dfs_process_node ~ctx ~working_vdi ~working_dp ~nbd_uri ~counter ~total
+    node =
+  let dest_snapshot, this_relation =
+    mirror_node_into ~ctx ~working_vdi ~working_dp ~nbd_uri ~counter ~total node
+  in
+  let inactive_children, active_children =
+    List.partition (fun c -> not c.on_active_path) node.children
+  in
+  if List.length active_children > 1 then
+    D.warn "%s node %s has %d active-path children, expected <= 1" __FUNCTION__
+      node.vdi_uuid
+      (List.length active_children) ;
+  (* Process reverted/inactive subtrees first: each is rooted on a
+     fresh clone of [dest_snapshot] and its working VDI is destroyed
+     after the subtree finishes. *)
+  let inactive_relations =
+    List.concat_map
+      (fun child ->
+        let branch_vdi, branch_dp, branch_nbd_uri, cleanup =
+          prepare_branch_vdi ~ctx ~dest_snapshot
+        in
+        Fun.protect ~finally:cleanup (fun () ->
+            dfs_process_node ~ctx ~working_vdi:branch_vdi ~working_dp:branch_dp
+              ~nbd_uri:branch_nbd_uri ~counter ~total child
+        )
+      )
+      inactive_children
+  in
+  (* Then process the active continuation, reusing [working_vdi]
+     unchanged so the storage-layer chain keeps advancing on the same
+     leaf. There should be at most one active child; we recurse on all
+     of them defensively in case of upstream data inconsistency. *)
+  let active_relations =
+    List.concat_map
+      (fun child ->
+        dfs_process_node ~ctx ~working_vdi ~working_dp ~nbd_uri ~counter ~total
+          child
+      )
+      active_children
+  in
+  this_relation :: (inactive_relations @ active_relations)
 
 module MIRROR : SMAPIv2_MIRROR = struct
   type context = unit
 
   let send_start _ctx ~dbg ~task_id:_ ~dp ~sr ~vdi ~image_format ~mirror_vm
-      ~mirror_id ~local_vdi:_ ~copy_vm:_ ~live_vm ~url ~remote_mirror ~dest_sr
+      ~mirror_id ~local_vdi:_ ~copy_vm ~live_vm ~url ~remote_mirror ~dest_sr
       ~verify_dest =
     D.debug
       "%s dbg: %s dp: %s sr: %s vdi:%s image_format:%s mirror_vm:%s mirror_id: \
@@ -127,9 +562,12 @@ module MIRROR : SMAPIv2_MIRROR = struct
        activating the VDI again on dom 0 when it is already activated on the live_vm.
        This means that if the VM shutsdown while SXM is in progress the
        mirroring for SMAPIv3 will fail.*)
-    let nbd_proxy_path =
-      Printf.sprintf "/var/run/nbdproxy/export/%s" (Vm.string_of mirror_vm)
-    in
+    let snapshot_tree = get_snapshot_tree ~dbg ~vdi in
+    let has_snapshots = snapshot_tree <> [] in
+    if has_snapshots then
+      SXM.info "%s found snapshot tree with %d node(s) to mirror" __FUNCTION__
+        (count_tree_nodes snapshot_tree) ;
+
     match remote_mirror with
     | Mirror.Vhd_mirror _ ->
         raise
@@ -139,56 +577,95 @@ module MIRROR : SMAPIv2_MIRROR = struct
              )
           )
     | Mirror.SMAPIv3_mirror {nbd_export; mirror_datapath; mirror_vdi} -> (
-      try
-        let nbd_uri =
-          Uri.make ~scheme:"nbd+unix" ~host:"" ~path:nbd_export
-            ~query:[("socket", [nbd_proxy_path])]
-            ()
-          |> Uri.to_string
+        let nbd_proxy_path = nbd_proxy_path_of_vm mirror_vm in
+        let nbd_uri = nbd_uri_of_export ~nbd_proxy_path nbd_export in
+        let ctx =
+          {
+            dbg
+          ; sr
+          ; dest_sr
+          ; url
+          ; verify_dest
+          ; mirror_vm
+          ; copy_vm
+          ; nbd_proxy_path
+          ; image_format
+          ; on_fail= ref []
+          }
         in
-        let _ : Thread.t =
-          Thread.create
-            (fun () ->
-              export_nbd_proxy ~remote_url:url ~mirror_vm ~sr:dest_sr
-                ~vdi:mirror_vdi.vdi ~dp:mirror_datapath ~verify_dest
-            )
-            ()
-        in
+        let run_on_fail () = List.iter D.log_and_ignore_exn !(ctx.on_fail) in
+        try
+          (* The dest leaf VDI is created and activated WRITABLE by
+             receive_start3 and stays writable for the whole send: every
+             snapshot is mirrored into it (cloning at revert branches) and
+             the live leaf mirror lands into it too. It must NOT be
+             re-activated readonly here -- the snapshot mirror writes into
+             this leaf, so a readonly datapath makes qemu-dp reject the
+             mirror target with "Could not open image: Permission denied". *)
+          let snapshot_relations =
+            if has_snapshots then (
+              let total = count_tree_nodes snapshot_tree in
+              let counter = ref 0 in
+              let relations =
+                List.concat_map
+                  (fun root ->
+                    dfs_process_node ~ctx ~working_vdi:mirror_vdi
+                      ~working_dp:mirror_datapath ~nbd_uri ~counter ~total root
+                  )
+                  snapshot_tree
+              in
+              SXM.info "%s %d snapshot(s) mirrored successfully" __FUNCTION__
+                (List.length relations) ;
+              relations
+            ) else
+              []
+          in
+          D.debug "%s starting NBD proxy for leaf mirror" __FUNCTION__ ;
+          let _ : Thread.t =
+            start_nbd_proxy_thread ~url ~mirror_vm ~dest_sr ~mirror_vdi
+              ~mirror_datapath ~verify_dest
+          in
+          D.info "%s nbd_proxy_path: %s nbd_url %s" __FUNCTION__ nbd_proxy_path
+            nbd_uri ;
+          let mk = Local.DATA.mirror dbg sr vdi image_format live_vm nbd_uri in
 
-        D.info "%s nbd_proxy_path: %s nbd_url %s" __FUNCTION__ nbd_proxy_path
-          nbd_uri ;
-        let mk = Local.DATA.mirror dbg sr vdi image_format live_vm nbd_uri in
-
-        D.debug "%s Updating active local mirrors: id=%s" __FUNCTION__ mirror_id ;
-        let alm =
-          State.Send_state.
-            {
-              url
-            ; dest_sr
-            ; remote_info=
-                Some
-                  {dp= mirror_datapath; vdi= mirror_vdi.vdi; url; verify_dest}
-            ; local_dp= dp
-            ; tapdev= None
-            ; failed= false
-            ; watchdog= None
-            ; vdi
-            ; live_vm
-            ; mirror_key= Some mk
-            }
-        in
-        State.add mirror_id (State.Send_op alm) ;
-        D.debug "%s Updated mirror_id %s in the active local mirror"
-          __FUNCTION__ mirror_id ;
-        mirror_wait ~dbg ~sr ~vdi ~vm:live_vm ~mirror_id mk
-      with e ->
-        D.error "%s caught exception during mirror: %s" __FUNCTION__
-          (Printexc.to_string e) ;
-        raise
-          (Storage_interface.Storage_error
-             (Migration_mirror_failure (Printexc.to_string e))
-          )
-    )
+          D.debug "%s Updating active local mirrors: id=%s" __FUNCTION__
+            mirror_id ;
+          let alm =
+            State.Send_state.
+              {
+                url
+              ; dest_sr
+              ; remote_info=
+                  Some
+                    {dp= mirror_datapath; vdi= mirror_vdi.vdi; url; verify_dest}
+              ; local_dp= dp
+              ; tapdev= None
+              ; failed= false
+              ; watchdog= None
+              ; vdi
+              ; live_vm
+              ; mirror_key= Some mk
+              }
+          in
+          State.add mirror_id (State.Send_op alm) ;
+          D.debug "%s Updated mirror_id %s in the active local mirror"
+            __FUNCTION__ mirror_id ;
+          wait_for_mirror ~dbg ~sr ~vdi ~vm:live_vm ~mirror_id
+            ~error_msg:"Leaf VDI mirror failed during syncing" mk ;
+          State.set_snapshot_mappings mirror_id snapshot_relations
+        with
+        | Storage_interface.Storage_error _ as e ->
+            run_on_fail () ; raise e
+        | e ->
+            run_on_fail () ;
+            D.error "%s caught exception during mirror: %s" __FUNCTION__
+              (Printexc.to_string e) ;
+            raise
+              (Storage_interface.Storage_error
+                 (Migration_mirror_failure (Printexc.to_string e))
+              )
+      )
 
   let receive_start _ctx ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~image_format:_
       ~similar:_ =
@@ -222,16 +699,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
       D.info "Created leaf VDI for mirror receive: %s" (string_of_vdi_info leaf) ;
       on_fail := (fun () -> Remote.VDI.destroy dbg sr leaf.vdi) :: !on_fail ;
       let backend = Remote.VDI.attach3 dbg leaf_dp sr leaf.vdi vm true in
-      let nbd_export =
-        match nbd_export_of_attach_info backend with
-        | None ->
-            raise
-              (Storage_error
-                 (Migration_preparation_failure "Cannot parse nbd uri")
-              )
-        | Some export ->
-            export
-      in
+      let nbd_export = nbd_export_of_attach_info backend in
       D.debug "%s activating dp %s sr: %s vdi: %s vm: %s" __FUNCTION__ leaf_dp
         (s_of_sr sr) (s_of_vdi leaf.vdi) (s_of_vm vm) ;
       Remote.VDI.activate3 dbg leaf_dp sr leaf.vdi vm ;
@@ -240,7 +708,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
       in
       let remote_mirror = Mirror.SMAPIv3_mirror qcow2_res in
       D.debug
-        "%s updating receiving state lcoally to id: %s vm: %s vdi_info: %s"
+        "%s updating receiving state locally to id: %s vm: %s vdi_info: %s"
         __FUNCTION__ mirror_id (s_of_vm vm)
         (string_of_vdi_info vdi_info) ;
       State.add mirror_id

--- a/ocaml/xapi/storage_smapiv3_migrate.mli
+++ b/ocaml/xapi/storage_smapiv3_migrate.mli
@@ -15,3 +15,14 @@
 module type SMAPIv2_MIRROR = Storage_interface.MIRROR
 
 module MIRROR : SMAPIv2_MIRROR
+
+val assert_migratable :
+     __context:Context.t
+  -> vm_uuid:string
+  -> active_vdis:[`VDI] API.Ref.t list
+  -> snapshot_vdis:[`VDI] API.Ref.t list
+  -> unit
+(** SXM v3 (SMAPIv3) pre-flight check: reject snapshot shapes the destination's
+    VM-snapshot-tree reconstruction cannot express (hidden VDI.snapshots and
+    orphan snapshot VDIs on SMAPIv3 SRs). Raises
+    [Api_errors.operation_not_allowed] when such VDIs are present. *)

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1189,9 +1189,9 @@ let vdi_copy_fun __context dbg vdi_map remote is_intra_pool remote_vdis so_far
       (Storage_interface.Vdi.string_of remote_vdi) ;
     (mirror_id, remote_vdi)
   in
-  let post_mirror mirror_id mirror_record =
+  let post_mirror mirror_id mirror_records =
     try
-      let result = continuation mirror_record in
+      let result = continuation mirror_records in
       ( match mirror_id with
       | Some mid ->
           ignore (Storage_access.unregister_mirror mid)
@@ -1200,7 +1200,21 @@ let vdi_copy_fun __context dbg vdi_map remote is_intra_pool remote_vdis so_far
       ) ;
       if mirror && not (Xapi_fist.storage_motion_keep_vdi () || copy) then
         Helpers.call_api_functions ~__context (fun rpc session_id ->
-            XenAPI.VDI.destroy ~rpc ~session_id ~self:vconf.vdi
+            XenAPI.VDI.destroy ~rpc ~session_id ~self:vconf.vdi ;
+            List.iter
+              (fun mr ->
+                if mr.mr_local_vdi_reference <> vconf.vdi then
+                  Helpers.log_exn_continue
+                    (Printf.sprintf "destroy source snapshot VDI %s"
+                       (Ref.string_of mr.mr_local_vdi_reference)
+                    )
+                    (fun () ->
+                      XenAPI.VDI.destroy ~rpc ~session_id
+                        ~self:mr.mr_local_vdi_reference
+                    )
+                    ()
+              )
+              mirror_records
         ) ;
       result
     with e ->
@@ -1223,6 +1237,43 @@ let vdi_copy_fun __context dbg vdi_map remote is_intra_pool remote_vdis so_far
       else
         raise e
   in
+  let get_snapshot_relations mirror_id =
+    match mirror_id with
+    | Some mid ->
+        let relations =
+          Storage_migrate_helper.State.get_snapshot_mappings mid
+        in
+        if relations <> [] then
+          debug "retrieved %d snapshot relation(s) for mirror %s"
+            (List.length relations) mid ;
+        relations
+    | None ->
+        []
+  in
+  let create_snapshot_mirror_record
+      (r : Storage_migrate_helper.State.snapshot_relation) =
+    let src_uuid = Storage_interface.Vdi.string_of r.src_vdi in
+    let dest_uuid = Storage_interface.Vdi.string_of r.dest_vdi in
+    let src_ref = Db.VDI.get_by_uuid ~__context ~uuid:src_uuid in
+    let dest_ref =
+      XenAPI.VDI.get_by_uuid ~rpc:remote.rpc ~session_id:remote.session
+        ~uuid:dest_uuid
+    in
+    {
+      mr_dp= None
+    ; mr_mirrored= false
+    ; mr_local_sr= vconf.sr
+    ; mr_local_vdi= r.src_vdi
+    ; mr_remote_sr= dest_sr
+    ; mr_remote_vdi= r.dest_vdi
+    ; mr_local_xenops_locator=
+        Xapi_xenops.xenops_vdi_locator_of vconf.sr r.src_vdi
+    ; mr_remote_xenops_locator=
+        Xapi_xenops.xenops_vdi_locator_of dest_sr r.dest_vdi
+    ; mr_local_vdi_reference= src_ref
+    ; mr_remote_vdi_reference= dest_ref
+    }
+  in
   if mirror then
     with_new_dp (fun new_dp ->
         let mirror_id, remote_vdi = mirror_to_remote new_dp in
@@ -1230,7 +1281,18 @@ let vdi_copy_fun __context dbg vdi_map remote is_intra_pool remote_vdis so_far
             let mirror_record =
               get_mirror_record ~new_dp remote_vdi remote_vdi_ref
             in
-            post_mirror mirror_id mirror_record
+            let snapshot_relations = get_snapshot_relations mirror_id in
+            let snapshot_mirror_records =
+              List.map create_snapshot_mirror_record snapshot_relations
+            in
+            let all_mirror_records = mirror_record :: snapshot_mirror_records in
+            Fun.protect
+              ~finally:(fun () ->
+                Option.iter
+                  Storage_migrate_helper.State.remove_snapshot_mappings
+                  mirror_id
+              )
+              (fun () -> post_mirror mirror_id all_mirror_records)
         )
     )
   else
@@ -1240,7 +1302,7 @@ let vdi_copy_fun __context dbg vdi_map remote is_intra_pool remote_vdis so_far
            ~uuid:vdi_uuid
         )
     in
-    continuation mirror_record
+    continuation [mirror_record]
 
 let wait_for_fist __context fistpoint name =
   if fistpoint () then (
@@ -1255,14 +1317,15 @@ let wait_for_fist __context fistpoint name =
     )
   )
 
-(* Helper function to apply a 'with_x' function to a list *)
+(* Helper function to apply a 'with_x' function to a list. The continuation
+   receives a list per item; results are concatenated so [fn] sees a flat list. *)
 let rec with_many withfn many fn =
   let rec inner l acc =
     match l with
     | [] ->
         fn acc
     | x :: xs ->
-        withfn x (fun y -> inner xs (y :: acc))
+        withfn x (fun ys -> inner xs (ys @ acc))
   in
   inner many []
 
@@ -1398,6 +1461,9 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vdi_format_map ~vif_map
   let snapshots_vdis =
     List.filter_map (vdi_filter __context false) snapshots_vbds
   in
+  Storage_smapiv3_migrate.assert_migratable ~__context ~vm_uuid
+    ~active_vdis:(List.map (fun v -> v.vdi) vms_vdis)
+    ~snapshot_vdis:(List.map (fun v -> v.vdi) snapshots_vdis) ;
   let suspends_vdis =
     List.fold_left
       (fun acc vm_or_snapshot ->
@@ -1450,10 +1516,16 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vdi_format_map ~vif_map
     else
       host_suspend_SR
   in
-  (* Resolve placement of unspecified VDIs here - unspecified VDIs that
-            are 'snapshot_of' a specified VDI go to the same place. suspend VDIs
-            that are unspecified go to the suspend_sr_ref defined above *)
-  let extra_vdis = suspends_vdis @ snapshots_vdis in
+  (* Resolve placement of unspecified VDIs here. Unspecified VDIs that
+     are 'snapshot_of' a specified VDI go to the same place. Suspend VDIs
+     that are unspecified go to the suspend_sr_ref defined above.
+     SMAPIv3 snapshots are excluded because they are mirrored during send_start. *)
+  let copyable_snapshots =
+    List.filter
+      (fun vconf -> Storage_mux_reg.smapi_version_of_sr vconf.sr <> SMAPIv3)
+      snapshots_vdis
+  in
+  let extra_vdis = suspends_vdis @ copyable_snapshots in
   let extra_vdi_map =
     List.map
       (fun vconf ->


### PR DESCRIPTION
The new SXM v3 storage-layer engine drives the migration from the source side. For each disk being migrated, it discovers the snapshot tree from the source VM, then DFS-walks the tree and mirrors each node over an NBD proxy onto the destination. Inactive (reverted) branches are mirrored onto cloned working VDIs so they don't affect the active leaf, while the active path keeps advancing on the same destination leaf — so when the walk bottoms out, the destination leaf is correctly positioned for the live-leaf mirror that follows. The source→destination snapshot pairings are recorded so the toolstack can reconstruct the snapshot relationships on the destination once the mirror completes.

The result: a VM with snapshots on a SMAPIv3 SR can now be live-migrated cleanly, with its full snapshot tree (including reverted branches) reproduced on the destination.

Design refer: https://github.com/xapi-project/xen-api/blob/feature/sxm-v3/doc/content/xapi/storage/sxm/sxm-v3-with-snapshot.md

- Migrate with SMAPIv3 → SMAPIv1 and SMAPIv1 → SMAPIv3 round-trip with multiple snapshots + mid-way revert verified
- Stress test with a complex snapshot tree (multiple reverted branches plus an active leaf); full tree reproduced on the destination, no source-side leaks