### PR TITLE
xe: Fix bash completion for 'xe vlan-create pif-uuid='

### DIFF
--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -585,7 +585,7 @@ _xe()
 
                     # Show corresponding name labels for each UUID
                     SHOW_DESCRIPTION=1
-                    local name_label_cmd="$xe ${class}-list params=name-label 2>/dev/null --minimal uuid="
+                    local name_label_cmd="$xe ${class}-list params=name-label,device 2>/dev/null --minimal uuid="
                     __xe_debug "triggering autocompletion for UUIDs, list command is '${class}-list'"
                     __xe_debug "name_label_cmd is '$name_label_cmd'"
 


### PR DESCRIPTION
Before:

    $ xe vlan-create pif-uuid=<TAB>
    3c1548f0-343f-b629-939a-e832512085f5  -
    98d4cc1f-d97f-2126-7005-7c721e43c29f  -
    93ba9954-b286-b984-9277-e62ec56f12c9  -

After:

    $ xe vlan-create pif-uuid=<TAB>
    3c1548f0-343f-b629-939a-e832512085f5  - eth0
    93ba9954-b286-b984-9277-e62ec56f12c9  - eth1
    93dbac2c-b3e4-292f-ac35-1352b5ba9a75  - eth0