### PR TITLE
xapi: report a clear error when host evacuation is blocked by unprotected VMs

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -761,6 +761,14 @@ let _ =
     ~doc:"The host failed to disable external authentication." () ;
   error Api_errors.host_evacuate_in_progress ["host"]
     ~doc:"This host is being evacuated." () ;
+  error Api_errors.host_evacuate_vm_not_ha_protected ["vm"]
+    ~doc:
+      "The host cannot be evacuated because HA is enabled on the pool and a VM \
+       running on it is not HA-protected (its ha_restart_priority is not set \
+       to 'restart'). Set the VM's ha_restart_priority to 'restart', shut down \
+       or suspend the VM, or disable HA on the pool before evacuating the \
+       host."
+    () ;
 
   (* Pool errors *)
   error Api_errors.pool_joining_host_cannot_contain_shared_SRs []

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1007,6 +1007,9 @@ let cannot_evacuate_host = add_error "CANNOT_EVACUATE_HOST"
 
 let host_evacuate_in_progress = add_error "HOST_EVACUATE_IN_PROGRESS"
 
+let host_evacuate_vm_not_ha_protected =
+  add_error "HOST_EVACUATE_VM_NOT_HA_PROTECTED"
+
 let system_status_retrieval_failed = add_error "SYSTEM_STATUS_RETRIEVAL_FAILED"
 
 let system_status_must_use_tar_on_oem =

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -352,7 +352,9 @@ let compute_evacuation_plan_no_wlb ~__context ~host ?(ignore_ha = false) () =
     List.iter
       (fun (vm, _) ->
         Hashtbl.replace plans vm
-          (Error (Api_errors.host_not_enough_free_memory, [Ref.string_of vm]))
+          (Error
+             (Api_errors.host_evacuate_vm_not_ha_protected, [Ref.string_of vm])
+          )
       )
       unprotected_vms ;
     let migratable_vms, _ =


### PR DESCRIPTION
## Why

When HA is enabled on a pool, `host.evacuate` refuses to plan the evacuation of
any VM that is not HA-protected, that is, whose `ha_restart_priority` is not
`restart`. This is by design: the HA planner only accounts for protected VMs, so
unprotected ones are left out of the plan.

The problem is the error reported in that situation. `compute_evacuation_plan_no_wlb`
marked every unprotected VM with `HOST_NOT_ENOUGH_FREE_MEMORY`, and `host.evacuate`
then raised it. That error is misleading in two ways:

* It blames free memory, so operators investigate RAM on the destination hosts
  (which is usually plentiful) instead of the real cause.
* It is raised with a single parameter (the VM reference), while
  `HOST_NOT_ENOUGH_FREE_MEMORY` is documented as taking `[needed; available]`.
  Clients such as Xen Orchestra therefore render the available memory as
  `<unknown>`.

This has confused users for years. See #4323 and the forum reports linked from
it: evacuation fails with `HOST_NOT_ENOUGH_FREE_MEMORY` even when the destination
has tens of GB free, purely because a resident VM is not HA-protected.

## How

Introduce a dedicated error, `HOST_EVACUATE_VM_NOT_HA_PROTECTED`, carrying the VM
reference, and raise it instead for unprotected VMs. The message states the real
cause and the ways to resolve it (set the VM's `ha_restart_priority` to
`restart`, shut down or suspend the VM, or disable HA before evacuating the
host).

Behaviour is otherwise unchanged: the evacuation still fails for these VMs, it is
just reported correctly.

Files touched:

* `ocaml/xapi-consts/api_errors.ml`: declare the error.
* `ocaml/idl/datamodel_errors.ml`: register it with a description.
* `ocaml/xapi/xapi_host.ml`: raise it for unprotected VMs in the evacuation plan.

## Testing

Built and tested on CI (build and test, unit tests, format, CodeChecker and
ShellCheck all green on a fork branch). The change is a pure diagnostic
improvement with no change to which VMs can be evacuated, so no new automated
test is included.

Closes #4323
