### PR TITLE
xapi: evacuate non-HA-protected VMs when no host failures are tolerated

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -761,6 +761,14 @@ let _ =
     ~doc:"The host failed to disable external authentication." () ;
   error Api_errors.host_evacuate_in_progress ["host"]
     ~doc:"This host is being evacuated." () ;
+  error Api_errors.host_evacuate_vm_not_ha_protected ["vm"]
+    ~doc:
+      "The host cannot be evacuated because HA is enabled on the pool and a VM \
+       running on it is not HA-protected (its ha_restart_priority is not set \
+       to 'restart'). Set the VM's ha_restart_priority to 'restart', shut down \
+       or suspend the VM, or disable HA on the pool before evacuating the \
+       host."
+    () ;
 
   (* Pool errors *)
   error Api_errors.pool_joining_host_cannot_contain_shared_SRs []

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1007,6 +1007,9 @@ let cannot_evacuate_host = add_error "CANNOT_EVACUATE_HOST"
 
 let host_evacuate_in_progress = add_error "HOST_EVACUATE_IN_PROGRESS"
 
+let host_evacuate_vm_not_ha_protected =
+  add_error "HOST_EVACUATE_VM_NOT_HA_PROTECTED"
+
 let system_status_retrieval_failed = add_error "SYSTEM_STATUS_RETRIEVAL_FAILED"
 
 let system_status_must_use_tar_on_oem =

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -352,7 +352,9 @@ let compute_evacuation_plan_no_wlb ~__context ~host ?(ignore_ha = false) () =
     List.iter
       (fun (vm, _) ->
         Hashtbl.replace plans vm
-          (Error (Api_errors.host_not_enough_free_memory, [Ref.string_of vm]))
+          (Error
+             (Api_errors.host_evacuate_vm_not_ha_protected, [Ref.string_of vm])
+          )
       )
       unprotected_vms ;
     let migratable_vms, _ =

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -334,12 +334,28 @@ let compute_evacuation_plan_no_wlb ~__context ~host ?(ignore_ha = false) () =
       all_user_vms ;
     plans
   ) else
-    (* If HA is enabled we require that non-protected VMs are suspended. This gives us the property that
-       			   the result obtained by executing the evacuation plan and disabling the host looks the same (from the HA
-       			   planner's PoV) to the result obtained following a host failure and VM restart. *)
+    (* When HA reserves capacity for failover (ha_host_failures_to_tolerate > 0)
+       we exclude non-protected VMs from the evacuation: the HA planner only
+       accounts for protected VMs, so executing the evacuation plan and
+       disabling the host looks the same (from the HA planner's PoV) as a host
+       failure followed by VM restart. Placing non-protected VMs on the
+       remaining hosts would consume memory the planner does not reserve and
+       could break the failover plan, which is why VM.start / VM.migrate of
+       such VMs are blocked with HA_OPERATION_WOULD_BREAK_FAILOVER_PLAN when a
+       plan is reserved.
+
+       When ha_host_failures_to_tolerate is 0, ha_plan_exists_for is 0: there is
+       no reserved plan to break (protected VMs are still restarted, but only on
+       a best-effort basis). That best-effort restart can already be degraded by
+       an ordinary VM.start, which is not blocked at ftt = 0, so we likewise let
+       evacuation migrate every user VM. *)
     let pool = Helpers.get_pool ~__context in
+    let ha_reserves_capacity =
+      Db.Pool.get_ha_enabled ~__context ~self:pool
+      && Db.Pool.get_ha_host_failures_to_tolerate ~__context ~self:pool > 0L
+    in
     let protected_vms, unprotected_vms =
-      if Db.Pool.get_ha_enabled ~__context ~self:pool && not ignore_ha then
+      if ha_reserves_capacity && not ignore_ha then
         List.partition
           (fun (_, record) ->
             Helpers.vm_should_always_run record.API.vM_ha_always_run


### PR DESCRIPTION
> Draft for discussion. Stacked on #7145 and currently shows both commits;
> the first commit belongs to #7145. I would like maintainer input on the HA
> semantics before this is considered for merge.

## Why

Even with the clearer error from #7145, evacuating a host under HA still fails
outright as soon as a non-HA-protected VM is resident on it. That is a real
obstacle for small pools: with two hosts, `ha_host_failures_to_tolerate` is
necessarily 0, yet administrators routinely need to put a host into maintenance.
Today that fails even though the destination has plenty of free memory.

Excluding non-protected VMs from the evacuation plan only makes sense when HA is
actually reserving capacity for failover. The reason they are excluded is that
the HA planner accounts only for protected VMs, and placing extra VMs on the
remaining hosts could break the failover plan. When `ha_host_failures_to_tolerate`
is 0, no capacity is reserved for failover at all, so there is no plan to break:
migrating non-protected VMs is then exactly as safe as in a pool without HA.

## How

Only partition VMs into protected and unprotected when HA reserves capacity
(`ha_enabled && ha_host_failures_to_tolerate > 0`). Otherwise treat all user VMs
as migratable and let the existing memory binpack place them, exactly as in a
pool without HA. When capacity is reserved, behaviour is unchanged and
unprotected VMs are still reported with `HOST_EVACUATE_VM_NOT_HA_PROTECTED`
(from #7145).

Only `ocaml/xapi/xapi_host.ml` is touched (in `compute_evacuation_plan_no_wlb`).

## Open questions (why this is a draft)

* Is `ha_host_failures_to_tolerate = 0` the right condition, or should it key off
  `ha_overcommitted` / `ha_plan_exists_for` instead?
* The original comment said the post-evacuation state should look to the HA
  planner the same as a host failure followed by VM restart. With ftt = 0 there
  is no failover reservation, but is there any other place that relies on
  non-protected VMs being excluded from the evacuation plan?
* Would you prefer this behind a feature flag in `xapi_globs.ml` (defaulted off)
  for wider testing first, as suggested in CONTRIBUTING?

## Testing

Built and tested on CI (build and test, unit tests, format, CodeChecker and
ShellCheck all green on a fork branch). No automated test is added yet for the
`compute_evacuation_plan_no_wlb` paths; the existing `test_ha_vm_failover.ml`
covers the binpack layer but not this function. Happy to add coverage once the
approach is agreed.

Depends on #7145.
