### PR TITLE
Remove image format from deprecated receive start

### DIFF
--- a/ocaml/xapi-idl/storage/storage_interface.ml
+++ b/ocaml/xapi-idl/storage/storage_interface.ml
@@ -1176,7 +1176,6 @@ module StorageAPI (R : RPC) = struct
           @-> sr_p
           @-> VDI.vdi_info_p
           @-> id_p
-          @-> image_format_p
           @-> similar_p
           @-> returning result err
           )
@@ -1194,7 +1193,6 @@ module StorageAPI (R : RPC) = struct
           @-> sr_p
           @-> VDI.vdi_info_p
           @-> id_p
-          @-> image_format_p
           @-> similar_p
           @-> vm_p
           @-> returning result err
@@ -1358,7 +1356,6 @@ module type MIRROR = sig
     -> sr:sr
     -> vdi_info:vdi_info
     -> id:Mirror.id
-    -> image_format:string
     -> similar:Mirror.similars
     -> Mirror.mirror_receive_result
 
@@ -1368,7 +1365,6 @@ module type MIRROR = sig
     -> sr:sr
     -> vdi_info:vdi_info
     -> id:Mirror.id
-    -> image_format:string
     -> similar:Mirror.similars
     -> vm:vm
     -> Mirror.mirror_receive_result
@@ -1901,14 +1897,11 @@ module Server (Impl : Server_impl) () = struct
           ~mirror_vm ~mirror_id ~local_vdi ~copy_vm ~live_vm ~url ~remote_mirror
           ~dest_sr ~verify_dest
     ) ;
-    S.DATA.MIRROR.receive_start (fun dbg sr vdi_info id image_format similar ->
-        Impl.DATA.MIRROR.receive_start () ~dbg ~sr ~vdi_info ~id ~image_format
-          ~similar
+    S.DATA.MIRROR.receive_start (fun dbg sr vdi_info id similar ->
+        Impl.DATA.MIRROR.receive_start () ~dbg ~sr ~vdi_info ~id ~similar
     ) ;
-    S.DATA.MIRROR.receive_start2
-      (fun dbg sr vdi_info id image_format similar vm ->
-        Impl.DATA.MIRROR.receive_start2 () ~dbg ~sr ~vdi_info ~id ~image_format
-          ~similar ~vm
+    S.DATA.MIRROR.receive_start2 (fun dbg sr vdi_info id similar vm ->
+        Impl.DATA.MIRROR.receive_start2 () ~dbg ~sr ~vdi_info ~id ~similar ~vm
     ) ;
     S.DATA.MIRROR.receive_start3
       (fun dbg sr vdi_info mirror_id image_format similar vm url verify_dest ->

--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
+++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
@@ -206,10 +206,10 @@ module DATA = struct
         ~verify_dest =
       Storage_interface.unimplemented __FUNCTION__
 
-    let receive_start ctx ~dbg ~sr ~vdi_info ~id ~image_format ~similar =
+    let receive_start ctx ~dbg ~sr ~vdi_info ~id ~similar =
       Storage_interface.unimplemented __FUNCTION__
 
-    let receive_start2 ctx ~dbg ~sr ~vdi_info ~id ~image_format ~similar ~vm =
+    let receive_start2 ctx ~dbg ~sr ~vdi_info ~id ~similar ~vm =
       Storage_interface.unimplemented __FUNCTION__
 
     let receive_start3 ctx ~dbg ~sr ~vdi_info ~mirror_id ~image_format ~similar

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -874,35 +874,31 @@ module Mux = struct
         Storage_interface.unimplemented
           __FUNCTION__ (* see storage_smapi{v1,v3}_migrate.ml *)
 
-      let receive_start () ~dbg ~sr ~vdi_info ~id ~image_format ~similar =
+      let receive_start () ~dbg ~sr ~vdi_info ~id ~similar =
         with_dbg ~name:"DATA.MIRROR.receive_start" ~dbg @@ fun _di ->
-        info
-          "%s dbg: %s sr: %s vdi_info: %s mirror_id: %s image_format: %s \
-           similar: %s"
+        info "%s dbg: %s sr: %s vdi_info: %s mirror_id: %s similar: %s"
           __FUNCTION__ dbg (s_of_sr sr)
           (string_of_vdi_info vdi_info)
-          id image_format
+          id
           (String.concat ";" similar) ;
         (* This goes straight to storage_smapiv1_migrate for backwards compatability
            reasons, new code should not call receive_start any more *)
         Storage_smapiv1_migrate.MIRROR.receive_start () ~dbg ~sr ~vdi_info ~id
-          ~image_format ~similar
+          ~similar
 
-      let receive_start2 () ~dbg ~sr ~vdi_info ~id ~image_format ~similar ~vm =
+      let receive_start2 () ~dbg ~sr ~vdi_info ~id ~similar ~vm =
         with_dbg ~name:"DATA.MIRROR.receive_start2" ~dbg @@ fun _di ->
-        info
-          "%s dbg: %s sr: %s vdi_info: %s mirror_id: %s image_format: %s \
-           similar: %s vm: %s"
+        info "%s dbg: %s sr: %s vdi_info: %s mirror_id: %s similar: %s vm: %s"
           __FUNCTION__ dbg (s_of_sr sr)
           (string_of_vdi_info vdi_info)
-          id image_format
+          id
           (String.concat ";" similar)
           (s_of_vm vm) ;
         info "%s dbg:%s" __FUNCTION__ dbg ;
         (* This goes straight to storage_smapiv1_migrate for backwards compatability
            reasons, new code should not call receive_start any more *)
         Storage_smapiv1_migrate.MIRROR.receive_start2 () ~dbg ~sr ~vdi_info ~id
-          ~image_format ~similar ~vm
+          ~similar ~vm
 
       (** see storage_smapiv{1,3}_migrate.receive_start3 *)
       let receive_start3 () ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -1168,12 +1168,11 @@ module SMAPIv1 : Server_impl = struct
           ~remote_mirror:_ ~dest_sr:_ ~verify_dest:_ =
         assert false
 
-      let receive_start _context ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~image_format:_
-          ~similar:_ =
+      let receive_start _context ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~similar:_ =
         assert false
 
-      let receive_start2 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~image_format:_
-          ~similar:_ ~vm:_ =
+      let receive_start2 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~similar:_
+          ~vm:_ =
         assert false
 
       let receive_start3 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_

--- a/ocaml/xapi/storage_smapiv1_migrate.ml
+++ b/ocaml/xapi/storage_smapiv1_migrate.ml
@@ -757,21 +757,19 @@ module MIRROR : SMAPIv2_MIRROR = struct
         !on_fail ;
       raise e
 
-  let receive_start _ctx ~dbg ~sr ~vdi_info ~id ~image_format ~similar =
-    D.debug "%s dbg: %s sr: %s vdi: %s id: %s image_format: %s" __FUNCTION__ dbg
-      (s_of_sr sr)
+  let receive_start _ctx ~dbg ~sr ~vdi_info ~id ~similar =
+    D.debug "%s dbg: %s sr: %s vdi: %s id: %s" __FUNCTION__ dbg (s_of_sr sr)
       (string_of_vdi_info vdi_info)
-      id image_format ;
-    receive_start_common ~dbg ~sr ~vdi_info ~id ~image_format ~similar
+      id ;
+    receive_start_common ~dbg ~sr ~vdi_info ~id ~image_format:"" ~similar
       ~vm:(Vm.of_string "0")
       (module Local)
 
-  let receive_start2 _ctx ~dbg ~sr ~vdi_info ~id ~image_format ~similar ~vm =
-    D.debug "%s dbg: %s sr: %s vdi: %s id: %s image_format: %s" __FUNCTION__ dbg
-      (s_of_sr sr)
+  let receive_start2 _ctx ~dbg ~sr ~vdi_info ~id ~similar ~vm =
+    D.debug "%s dbg: %s sr: %s vdi: %s id: %s" __FUNCTION__ dbg (s_of_sr sr)
       (string_of_vdi_info vdi_info)
-      id image_format ;
-    receive_start_common ~dbg ~sr ~vdi_info ~id ~image_format ~similar ~vm
+      id ;
+    receive_start_common ~dbg ~sr ~vdi_info ~id ~image_format:"" ~similar ~vm
       (module Local)
 
   let receive_start3 _ctx ~dbg ~sr ~vdi_info ~mirror_id ~image_format ~similar

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -1218,26 +1218,20 @@ functor
             ~remote_mirror:_ ~dest_sr:_ ~verify_dest:_ =
           Storage_interface.unimplemented __FUNCTION__
 
-        let receive_start context ~dbg ~sr ~vdi_info ~id ~image_format ~similar
-            =
-          info
-            "DATA.MIRROR.receive_start dbg:%s sr:%s id:%s image_format:%s \
-             similar:[%s]"
-            dbg (s_of_sr sr) id image_format
+        let receive_start context ~dbg ~sr ~vdi_info ~id ~similar =
+          info "DATA.MIRROR.receive_start dbg:%s sr:%s id:%s similar:[%s]" dbg
+            (s_of_sr sr) id
             (String.concat "," similar) ;
-          Impl.DATA.MIRROR.receive_start context ~dbg ~sr ~vdi_info ~id
-            ~image_format ~similar
+          Impl.DATA.MIRROR.receive_start context ~dbg ~sr ~vdi_info ~id ~similar
 
-        let receive_start2 context ~dbg ~sr ~vdi_info ~id ~image_format ~similar
-            ~vm =
+        let receive_start2 context ~dbg ~sr ~vdi_info ~id ~similar ~vm =
           info
-            "DATA.MIRROR.receive_start2 dbg:%s sr:%s id:%s image_format:%s \
-             similar:[%s] vm:%s"
-            dbg (s_of_sr sr) id image_format
+            "DATA.MIRROR.receive_start2 dbg:%s sr:%s id:%s similar:[%s] vm:%s"
+            dbg (s_of_sr sr) id
             (String.concat "," similar)
             (s_of_vm vm) ;
           Impl.DATA.MIRROR.receive_start2 context ~dbg ~sr ~vdi_info ~id
-            ~image_format ~similar ~vm
+            ~similar ~vm
 
         let receive_start3 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_
             ~image_format:_ ~similar:_ ~vm:_ =

--- a/ocaml/xapi/storage_smapiv3_migrate.ml
+++ b/ocaml/xapi/storage_smapiv3_migrate.ml
@@ -190,12 +190,10 @@ module MIRROR : SMAPIv2_MIRROR = struct
           )
     )
 
-  let receive_start _ctx ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~image_format:_
-      ~similar:_ =
+  let receive_start _ctx ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~similar:_ =
     Storage_interface.unimplemented __FUNCTION__
 
-  let receive_start2 _ctx ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~image_format:_
-      ~similar:_ ~vm:_ =
+  let receive_start2 _ctx ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~similar:_ ~vm:_ =
     Storage_interface.unimplemented __FUNCTION__
 
   let receive_start3 _ctx ~dbg ~sr ~vdi_info ~mirror_id ~image_format ~similar:_


### PR DESCRIPTION
The field image_format added to receive_start and receive_start2 breaks migration from old XAPI to new XAPI.

Both are sending RPC to the destination, which runs them locally. If the destination has the field but not the source it breaks compatibility. On the other hand, receive_start3 runs on the source. It is the VDI.create that is sent remotely to the destination.

This patch removes the new field. That means that you will not be able to choose the format of the destination when migrating from old version of XAPI to new version of XAPI. As receive_start and receive_start2 are deprecated the situation will become more and more rare.


(cherry picked from commit 71a2576b7aed6d9caf6b940ad5c13b142dab4eeb)