### PR TITLE
CP-313264: introduce faster migration datapath using kernel TLS (kTLS) instead of stunnel

### DIFF
--- a/doc/content/design/migration-tls.md
+++ b/doc/content/design/migration-tls.md
@@ -1,0 +1,265 @@
+---
+title: Migration Stream Encryption with kernel TLS (kTLS)
+layout: default
+design_doc: true
+revision: 1
+status: proposed
+---
+# Migration Stream Encryption with kernel TLS (kTLS)
+
+VM-migrate sends the guest memory over a TLS connection so the data is
+encrypted on the wire. Today that TLS is provided by stunnel, an external
+process. This document describes an alternative that keeps the same TLS
+security but removes stunnel from the sender's data path, using the kernel's
+own TLS (kTLS), and so makes vm-migrate and host-evacuate faster.
+
+## Existing transport: stunnel
+
+stunnel is an external process that terminates TLS for the xenguest migration
+stream. As it is a separate process from xenguest, the dom0 kernel has to pipe
+the plaintext between the two, so every byte of guest RAM is copied through an
+extra userspace hop and encrypted in userspace. That wastes dom0 cpu and memory
+throughput, so the result is a slower vm-migrate, and therefore a slower
+host-evacuate for the user. The slowdown is worst exactly when dom0 cpu is the
+bottleneck.
+
+stunnel cannot be removed by linking it into xenguest, as it is not a library:
+it is a configuration wrapper around OpenSSL.
+
+## Solution: kTLS on the sender
+
+The data pipe between xenguest and stunnel disappears if the kernel does the
+bulk TLS encryption in place, on the same socket xenguest already writes to.
+Linux 6.6 supports this through kTLS: once the symmetric key is installed on a
+socket with `setsockopt(SOL_TLS, ...)`, the kernel encrypts/decrypts every
+subsequent `read`/`write` transparently, using AES-NI, producing the same
+byte stream stunnel produces today.
+
+Phase 1 changes only the sender host and already provides the speed-up (see
+Performance), while proving the kTLS sender interoperates with the unchanged
+stunnel receiver on the destination. Benefits:
+
+* significant speed-up: host-evacuate is around 1.5x faster for 10 parallel
+  VMs, for less dom0 cpu (see Performance).
+* xenguest is unmodified: no libssl in xenguest, so no extra xen-devel
+  upstreaming, maintenance or security reviews on xenguest/libxenguest.
+* same TLS security as stunnel: a small `ktls-helper` does the OpenSSL
+  handshake with the same key size, cipher, certificate and verification stunnel
+  uses, then asks the kernel to take over the bulk encryption.
+* backwards-compatible & conservative: stunnel stays the default; kTLS is an
+  option, introduced gradually until it is proven in the field.
+
+## Principles
+
+* P1. kernel data pipes between userspace processes add latency and cut data
+  throughput in dom0.
+* P2. keep the existing security guarantees.
+* P3. backwards-compatibility.
+* P4. guarded new features.
+
+## Use cases
+
+* U1. Admin configuration:
+    * U1.1. a new `migration_ktls` option selects the faster datapath for
+      vm-migrate and host-evacuate (P1, P2).
+    * U1.2. the option can be reverted to the original stunnel datapath (P3).
+* U2. Admin usage when the option is selected:
+    * U2.1. vm-migrate is faster, or at least the same (P1).
+    * U2.2. host-evacuate is faster, or at least the same (P1).
+    * U2.3. vm-migrate and host-evacuate still work between hosts configured
+      with different options (P3).
+* U3. Over time the option may graduate to become the default for vm-migrate
+  and host-evacuate (P4).
+
+## Requirements
+
+* R1. Admin configuration:
+    * R1.1.1. Host-level: `xe-enable-experimental-feature migration_ktls` sets
+      `/etc/xenserver/features.d/migration_ktls` to 1 on the host, enabling the
+      option there.
+    * R1.1.2. Pool-level: when every host has the entry, the matching
+      `restrict_migration_ktls` shown by `xe pool-list params=restrictions`
+      reads `false`.
+    * R1.1.3. Pool-level (future): a helper `xe pool-experimental-feature-set
+      name=migration_ktls` sets the entry on each host of the pool.
+* R2. Admin usage:
+    * R2.1. vm-migrate: when the option is enabled, xenopsd uses
+      `ktls-helper` instead of stunnel to set up kTLS transport for
+      xenguest (see Design).
+    * R2.2. host-evacuate: the vm-migrate operations it drives inherit R2.1.
+* R3. Future: once kTLS is the default, a XenAPI field
+  `pool.migration_transport` could expose `ktls` (default) or `stunnel`.
+
+Implementation note: R1.1.1 describes the intended activation. The current
+implementation does not yet read `features.d/migration_ktls`; it selects the
+transport per host from `xenopsd.conf` instead:
+
+```
+migration-tls = "ktls"      # use the helper
+migration-tls = "stunnel"   # explicit default
+migration-tls = ""          # currently defaults to "stunnel"
+```
+
+Wiring `xe-enable-experimental-feature migration_ktls` to this `xenopsd.conf`
+option (so the host flag drives R1.1.1/R1.1.2) is outstanding.
+
+## Design
+
+### Considered designs
+
+The goal is to remove the plaintext data pipe between stunnel and xenguest.
+
+| Design | Summary | Analysis |
+| --- | --- | --- |
+| A: TLS inside xenguest/libxenguest | link libssl into xenguest; xenguest does `SSL_connect`/`SSL_accept` and `SSL_read`/`SSL_write` directly. Needs an SNI dispatcher (eg. sniproxy) on the receiver to share port 443. | Removes the pipe, but embeds TLS in xenguest: lots of changes, lots of xen-devel upstreaming, and ongoing security-maintenance on xenguest/libxenguest. Too expensive to create and maintain. |
+| B: xenguest as a stunnel SNI backend | use stunnel's SNI dispatch to route migration traffic to xenguest. | Easy (stunnel config only), but the plaintext pipe between stunnel and the backend remains, so it defeats the goal. |
+| C: kTLS via a small TLS helper | `ktls-helper` does the OpenSSL handshake, asks OpenSSL to enable kTLS on the socket, and hands the kTLS socket fd to xenopsd over SCM_RIGHTS. xenguest then sees only plaintext; the kernel encrypts transparently. | xenguest is unmodified, stunnel leaves the sender data path, the helper reuses stunnel's OpenSSL config/keys/certificates, and kTLS can later be offloaded to hardware NICs. |
+
+Conclusion: design C (kTLS) seems superior, as it reaches the goal with fewer
+changes, is toolstack-only (no xen-devel upstream loop, no future xenguest
+security maintenance), is a small focused tool rather than a change to the
+highly-complex xenguest, leaves the stunnel option in place, and opens the way
+to kTLS hardware offload later.
+
+### kTLS sender
+
+Performance: the kernel encrypts the migration stream in the xenguest context,
+so dom0 no longer copies the whole guest RAM between xenguest and stunnel. The
+effect is largest where dom0 cpu, not the wire, is the bottleneck.
+
+Security: the helper uses OpenSSL exactly as stunnel does, so the bulk kTLS
+stream is byte-identical to stunnel's and is accepted by the unchanged
+destination stunnel.
+
+* same handshake: TLS 1.2, with the cipher list and ECDHE curve taken from the
+  pool TLS policy (`Stunnel.Openssl`, the same source the stunnel client reads),
+  renegotiation disabled, authenticated with `SSL_VERIFY_PEER`
+  against the destination's pool-internal certificate (CN = host uuid,
+  SNI = `pool`).
+* single source of truth: the helper's verification is derived from the same
+  configuration the stunnel fallback would use, so `--cert-bundle-file`/`--sni` come from it
+  and `--no-verify` is sent only when verification is disabled pool-wide. SNI is
+  always sent, so the destination serves its pool-internal certificate either
+  way.
+* the TLS 1.2 pin is necessary for kTLS, as a TLS 1.3 post-handshake
+  KeyUpdate cannot be carried by the kernel kTLS data path.
+* no new security code in xenguest: after the handshake OpenSSL installs the
+  symmetric key in the kernel, and everything xenguest writes as plaintext is
+  encrypted transparently.
+* the helper hands the socket over only after confirming the kernel actually
+  enabled kTLS in both directions (`BIO_get_ktls_send` and `BIO_get_ktls_recv`),
+  as the migration channel is bidirectional; otherwise it errors and the sender
+  falls back to stunnel.
+
+Backwards-compatibility: the new behaviour is hidden behind the per-host option,
+and a kTLS sender works with a stunnel receiver, so the worst case is exactly
+today's behaviour.
+
+### The helper
+
+`ktls-helper` does only what stunnel cannot, then gets out of the way:
+
+1. perform the TLS handshake with OpenSSL (same protocol/cipher/cert/verification
+   as stunnel).
+2. ask OpenSSL to enable kTLS on the socket.
+3. confirm the kernel took over send and receive (`BIO_get_ktls_send`/`_recv`);
+   if not, error so the sender falls back to stunnel.
+4. hand the now-encrypting socket to xenopsd over SCM_RIGHTS, then exit.
+
+The helper is not a proxy and is not in the data path: it is a short-lived "set
+up the encrypted socket, hand it over, get out of the way" step. xenopsd brokers
+the fd to xenguest just as it brokers the stunnel fd today, and xenguest writes
+the migration stream as plaintext while the kernel encrypts each `write` in
+place.
+
+### Why stunnel cannot remove the data pipe
+
+stunnel is a general-purpose TLS proxy, and a proxy must receive plaintext on
+one side to encrypt it on the other, so the xenguest -> stunnel plaintext hop is
+structural and cannot be removed while stunnel is in the path. stunnel has no
+pass-through mode and cannot hand its encrypted socket to another process, so its
+bulk encryption stays in userspace.
+
+An alternative considered but rejected was to make stunnel use kTLS and then pull
+its kernel-encrypting socket out of the stunnel process with `pidfd_getfd(2)`.
+This has lots of issues: it needs ptrace-level privilege over stunnel and racy
+fd-table scraping; there is no clean ownership handoff, as the TLS sequence
+number and any partial record are per-socket and two writers corrupt the stream;
+and nobody owns the TLS control path, so an inbound TLS 1.3 KeyUpdate stalls the
+receive side. The safe form of "hand a kTLS socket to the datapath" is precisely
+the dedicated helper above.
+
+## Performance
+
+Single host-evacuate, 10 VMs migrating in parallel, sender kTLS vs sender
+stunnel, same host pair. The hosts have Intel Xeon Gold 6430 cpus (128 pCPU,
+16 dom0 vCPUs) on a 25 GbE link, and each guest is Windows Server 2019 with
+64 GB RAM and 12 vCPUs. The improvement grows with guest load, as a busier
+guest has more memory to transmit and pushes dom0 cpu harder:
+
+| Guest load | stunnel | kTLS | Improvement |
+| --- | --- | --- | --- |
+| idle | 185s | 163s | 1.13x |
+| medium (windows apps) | 249s | 171s | 1.46x |
+| high (synthetic page thrasher) | 1341s | 835s | 1.60x |
+
+host-evacuate improvement is around 1.5x for 10 parallel VMs, for
+lower dom0 cpu (eg. on the medium load, mean dom0 cpu drops from ~0.73 to ~0.53
+of the 16 dom0 vCPUs). The improvement is smaller for idle guests, as dom0 is
+then not the bottleneck.
+
+## Implementation
+
+The sender path is in xenopsd. Outside the helper itself, the change is small:
+
+* `ocaml/ktls-helper/helper/` — the standalone C helper, with its
+  Makefile and README. It is built on its own (`make`) and deployed to
+  `/usr/libexec/xapi/ktls-helper`.
+* `ocaml/xenopsd/lib/migrate_connect.ml` — a drop-in replacement for
+  `Open_uri.with_open_uri` that spawns the helper when `migration-tls = "ktls"`
+  and falls back to `Open_uri` otherwise.
+* `ocaml/xenopsd/lib/xenops_server.ml` — the three migration fd call sites
+  (vm, mem, vgpu) in the `VM_migrate` branch go through `Migrate_connect`.
+* `ocaml/xenopsd/lib/xenopsd.ml`, `ocaml/xenopsd/xc/xc_resources.ml`,
+  `ocaml/xenopsd/xenopsd.conf` — register the `migration-tls` option and the
+  `xenopsd-tls-helper` resource, and document them.
+
+Fallback: the sender falls back to stunnel only when the kTLS path fails to
+produce the fd (helper spawn, TLS handshake, kTLS install or SCM_RIGHTS). It logs
+a single warn line and uses stunnel for that one connection, so the migration
+still proceeds. Once the fd is handed to the migration, any later exception is a
+migration-layer failure and propagates unchanged, as silently retrying it over a
+fresh stunnel socket would re-enter the in-progress receive on the destination
+and corrupt its state.
+
+## Upgrade
+
+The kTLS sender produces the same TLS stream as stunnel and the receiver is
+unchanged, so a kTLS-enabled host migrates to a stunnel host with no
+coordination. xapi only permits migration from older to newer toolstacks, so a
+newer kTLS sender is never required by an older receiver. The option is off by
+default, so an upgrade changes nothing until an admin enables it.
+
+## Applicability
+
+Phase 1 covers the sender side of the guest-memory migration stream (the vm,
+mem and vgpu fds in `VM_migrate`). It leaves the receiver and the other TLS
+users unchanged: SMAPIv1 storage migration uses `sparse_dd` and SMAPIv3 uses
+stunnel, both untouched, as are RRD and other stunnel traffic. Phase 2 (the
+kTLS receiver) would extend the same treatment to the destination.
+
+## Outlook
+
+* Phase 2: a kTLS receiver, so the destination also drops stunnel from the data
+  path. It needs an SNI dispatcher (eg. sniproxy) to share port 443 between the
+  receiver and the existing stunnel endpoint.
+* kTLS hardware-offload NICs (`CONFIG_TLS_DEVICE=y` in kernel) could move the bulk
+  encryption off the cpu. This depends on the NIC and the network topology: the
+  offload applies where the migration socket terminates in a TLS-capable NIC (for
+  example a raw or bonded NIC), but not where the traffic is bridged (kernel or Open
+  vSwitch). The gain grows with line rate: at 100 GbE and above, software AES-GCM
+  (even with AES-NI/AVX2 or VAES/AVX-512) becomes the bottleneck on a single core.
+* `pool.migration_transport` (R3) once kTLS becomes the default.
+* mutual TLS (client-certificate auth) and destination-hostname pinning exceed
+  the stunnel migration client and can be done with the Phase 2 receiver work.
+

--- a/ocaml/ktls-helper/README.md
+++ b/ocaml/ktls-helper/README.md
@@ -1,0 +1,53 @@
+# ktls-helper
+
+Sender-side kTLS helper for VM live migration. It replaces the per-migration
+stunnel client subprocess on the sender: it performs the TLS handshake in
+userspace, installs the symmetric keys into the kernel via kTLS, and hands the
+kTLS-enabled socket fd back to xenopsd via `SCM_RIGHTS`.
+
+Once xenopsd holds the fd, every subsequent `read()`/`write()` is
+decrypted/encrypted by the kernel on the calling thread — no stunnel pipe, no
+extra context switches, no extra copies.
+
+## Enabling
+
+Set the following in `/etc/xenopsd.conf` (or `/etc/xenopsd.conf.d/migration.conf`)
+and restart xenopsd:
+
+```
+migration-tls = ktls
+```
+
+If the option is absent or set to `stunnel` (the default), xenopsd uses the
+existing stunnel-based path. If the helper fails for any reason (binary missing,
+TLS handshake error, kTLS install rejected by the kernel), xenopsd logs a `warn`
+and transparently retries that single connection over stunnel, so the migration
+still succeeds over TLS.
+
+## Invocation contract
+
+```
+ktls-helper \
+    --host <dest-host> \
+    --port <dest-port> \
+    --send-fd <N> \
+    --ciphers <openssl-cipher-list> \
+    --curves <openssl-curve> \
+    [--cert-bundle-file <pem> | --no-verify] \
+    [--sni <name>]
+```
+
+- `--send-fd N` is the integer fd of a Unix-domain socket inherited from
+  xenopsd. After a successful handshake the helper confirms kTLS is installed in
+  both directions, then writes a single byte plus the kTLS-enabled socket fd
+  onto `N` via `SCM_RIGHTS` and exits 0 (the byte is a required carrier for the
+  `SCM_RIGHTS` fd; its value is ignored). On any failure it writes a single line
+  to stderr and exits 1.
+- `--cert-bundle-file` is the PEM trust bundle used to verify the destination
+  (a CA bundle or a pinned peer certificate). `--no-verify` skips verification
+  when pool certificate verification is disabled.
+- `--ciphers` and `--curves` are the OpenSSL cipher list and ECDHE curve the
+  helper must negotiate. They are mandatory and passed by xenopsd from the same
+  `Stunnel.Openssl` TLS policy the stunnel client uses, so the helper carries no
+  cipher policy of its own. The helper refuses to run if either is missing or
+  empty rather than fall back to OpenSSL's broad defaults.

--- a/ocaml/ktls-helper/helper/Makefile
+++ b/ocaml/ktls-helper/helper/Makefile
@@ -1,0 +1,21 @@
+# Standalone convenience Makefile for the ktls-helper.
+
+CC      ?= gcc
+CFLAGS  ?= -O2 -Wall -Wextra -Werror -std=gnu99
+LDFLAGS ?=
+LDLIBS  ?= -lssl -lcrypto
+
+BIN     := ktls-helper
+
+all: $(BIN)
+
+$(BIN): ktls-helper.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LDLIBS)
+
+install: $(BIN)
+	install -D -m 0755 $(BIN) $(DESTDIR)/usr/libexec/xapi/$(BIN)
+
+clean:
+	rm -f $(BIN)
+
+.PHONY: all install clean

--- a/ocaml/ktls-helper/helper/ktls-helper.c
+++ b/ocaml/ktls-helper/helper/ktls-helper.c
@@ -257,6 +257,15 @@ int main(int argc, char **argv) {
         die("kTLS RX not installed (kernel lacks TLS_RX for the negotiated "
             "cipher); negotiated cipher = %s", SSL_get_cipher_name(ssl));
 
+    /* Report the negotiated TLS version and cipher of the kTLS socket before
+       handoff. xenopsd forwards the helper's stdout and stderr to syslog (key
+       "ktls-helper"). Flush explicitly, as stdout to forkexecd is buffered;
+       otherwise the line is lost if the helper is killed on the xenopsd
+       timeout after the fd is sent. */
+    printf("kTLS active: %s %s\n", SSL_get_version(ssl),
+           SSL_get_cipher_name(ssl));
+    fflush(stdout);
+
     if (send_fd(send_fd_num, fd) < 0)
         die("sendmsg(SCM_RIGHTS) on fd %d: %s", send_fd_num, strerror(errno));
 

--- a/ocaml/ktls-helper/helper/ktls-helper.c
+++ b/ocaml/ktls-helper/helper/ktls-helper.c
@@ -1,0 +1,275 @@
+/*
+ * ktls-helper — sender-side kTLS helper for VM live migration.
+ *
+ * Steps:
+ *   1. open a TCP socket to the destination host:port
+ *   2. TLS handshake using the pool CA bundle (matching the stunnel migration
+ *      client)
+ *   3. ask OpenSSL to install kTLS (SSL_OP_ENABLE_KTLS) and confirm the kernel
+ *      installed kTLS for BOTH directions (TX and RX) — the migration channel
+ *      is bidirectional
+ *   4. hand the kTLS-enabled socket fd back to xenopsd via SCM_RIGHTS on a
+ *      unix-socket fd inherited from the parent
+ *   5. exit; xenopsd then read()s/write()s plaintext and the kernel
+ *      decrypts/encrypts on the fly
+ *
+ * Build: see the Makefile. Installed at /usr/libexec/xapi/ktls-helper.
+ *
+ * Invocation:
+ *   ktls-helper --host <h> --port <p> --send-fd <N>
+ *               --ciphers <list> --curves <name>
+ *               [--cert-bundle-file <pem> | --no-verify] [--sni <name>]
+ *
+ * Exit codes:
+ *   0  success (kTLS active in both directions, fd handed off)
+ *   1  any failure (TLS handshake, kTLS install, SCM_RIGHTS send, ...)
+ *      stderr carries a single human-readable line for xenopsd to log.
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <getopt.h>
+#include <limits.h>
+#include <netdb.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+
+static void die(const char *fmt, ...) __attribute__((noreturn, format(printf, 1, 2)));
+
+static void die(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    fputs("ktls-helper: ", stderr);
+    vfprintf(stderr, fmt, ap);
+    fputc('\n', stderr);
+    va_end(ap);
+    exit(1);
+}
+
+static const char *ossl_err(void) {
+    unsigned long e = ERR_peek_last_error();
+    return e ? ERR_reason_error_string(e) : "(no OpenSSL error)";
+}
+
+static int send_fd(int sock, int fd) {
+    char dummy = 'x';
+    struct iovec io = { .iov_base = &dummy, .iov_len = 1 };
+    union {
+        struct cmsghdr cm;
+        char buf[CMSG_SPACE(sizeof(int))];
+    } u;
+    memset(&u, 0, sizeof(u));
+    struct msghdr msg = {0};
+    msg.msg_iov = &io;
+    msg.msg_iovlen = 1;
+    msg.msg_control = u.buf;
+    msg.msg_controllen = sizeof(u.buf);
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type = SCM_RIGHTS;
+    cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+    memcpy(CMSG_DATA(cmsg), &fd, sizeof(int));
+    ssize_t n;
+    do {
+        n = sendmsg(sock, &msg, 0);
+    } while (n < 0 && errno == EINTR);
+    return (int) n;
+}
+
+static int tcp_connect(const char *host, const char *port) {
+    struct addrinfo hints = {0};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    struct addrinfo *res = NULL;
+    int rc = getaddrinfo(host, port, &hints, &res);
+    if (rc != 0)
+        die("getaddrinfo(%s, %s): %s", host, port, gai_strerror(rc));
+    int fd = -1;
+    int last_errno = 0;
+    for (struct addrinfo *ai = res; ai; ai = ai->ai_next) {
+        fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+        if (fd < 0) { last_errno = errno; continue; }
+        if (connect(fd, ai->ai_addr, ai->ai_addrlen) == 0) break;
+        last_errno = errno;
+        close(fd);
+        fd = -1;
+    }
+    freeaddrinfo(res);
+    if (fd < 0)
+        die("connect %s:%s: %s", host, port, strerror(last_errno));
+    int one = 1;
+    (void) setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+    (void) setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &one, sizeof(one));
+    return fd;
+}
+
+int main(int argc, char **argv) {
+    const char *host = NULL;
+    const char *port = NULL;
+    const char *bundle = NULL;
+    const char *ciphers = NULL;
+    const char *curves = NULL;
+    const char *sni = NULL;
+    int send_fd_num = -1;
+    int no_verify = 0;
+
+    static struct option long_opts[] = {
+        {"host",                required_argument, 0, 'h'},
+        {"port",                required_argument, 0, 'p'},
+        {"cert-bundle-file",    required_argument, 0, 'c'},
+        {"ciphers",             required_argument, 0, 'C'},
+        {"curves",              required_argument, 0, 'g'},
+        {"sni",                 required_argument, 0, 's'},
+        {"send-fd",             required_argument, 0, 'f'},
+        {"no-verify",           no_argument,       0, 'n'},
+        {0, 0, 0, 0}
+    };
+    int idx;
+    int c;
+    while ((c = getopt_long(argc, argv, "", long_opts, &idx)) != -1) {
+        switch (c) {
+            case 'h': host = optarg; break;
+            case 'p': port = optarg; break;
+            case 'c': bundle = optarg; break;
+            case 'C': ciphers = optarg; break;
+            case 'g': curves = optarg; break;
+            case 's': sni = optarg; break;
+            case 'n': no_verify = 1; break;
+            case 'f': {
+                /* --send-fd is a Forkhelpers placeholder rewritten to an
+                   integer fd before exec; validate it strictly anyway. */
+                char *end = NULL;
+                errno = 0;
+                long v = strtol(optarg, &end, 10);
+                if (optarg[0] == '\0' || *end != '\0' || errno != 0
+                    || v < 0 || v > INT_MAX)
+                    die("invalid --send-fd value: %s", optarg);
+                send_fd_num = (int) v;
+                break;
+            }
+            default:
+                die("usage: %s --host H --port P --send-fd N "
+                    "--ciphers LIST --curves NAME "
+                    "[--cert-bundle-file PEM | --no-verify] [--sni NAME]", argv[0]);
+        }
+    }
+    if (!host || !port || send_fd_num < 0)
+        die("missing required argument; need --host --port --send-fd");
+    /* --ciphers/--curves are mandatory and must be non-empty. The cipher list
+       and ECDHE curve come from xapi's TLS policy (Stunnel.Openssl) via argv, so
+       the helper keeps no cipher policy of its own. Fail here rather than
+       skip the SSL_CTX_set_cipher_list/set1_groups_list calls below: skipping
+       would leave OpenSSL's broad defaults active, negotiating weaker crypto
+       than the stunnel client this helper replaces. */
+    if (!ciphers || !ciphers[0] || !curves || !curves[0])
+        die("--ciphers and --curves are required and must be non-empty");
+    if (!no_verify && !bundle)
+        die("--cert-bundle-file is required unless --no-verify is given");
+
+    int fd = tcp_connect(host, port);
+
+    const SSL_METHOD *method = TLS_client_method();
+    SSL_CTX *ctx = SSL_CTX_new(method);
+    if (!ctx)
+        die("SSL_CTX_new: %s", ossl_err());
+
+    /* Pin TLSv1.2. This pin is necessary for kTLS, not merely stunnel parity:
+       it prevents TLS1.3 post-handshake KeyUpdate, which the kernel kTLS data
+       path cannot process once OpenSSL has handed off the socket. */
+    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+    SSL_CTX_set_max_proto_version(ctx, TLS1_2_VERSION);
+    /* The cipher list and ECDHE curve arrive via --ciphers/--curves, sourced
+       from xapi's Stunnel.Openssl TLS policy (the same values the stunnel client
+       this helper replaces negotiates), so there is no second copy to drift. */
+    if (SSL_CTX_set_cipher_list(ctx, ciphers) != 1)
+        die("SSL_CTX_set_cipher_list(%s): %s", ciphers, ossl_err());
+    if (SSL_CTX_set1_groups_list(ctx, curves) != 1)
+        die("SSL_CTX_set1_groups_list(%s): %s", curves, ossl_err());
+
+    /* Request kTLS BEFORE the handshake; also forbid renegotiation (defence in
+       depth — the AES-GCM TLS1.2 suites do not renegotiate, and the kernel
+       could not process a post-handoff renegotiation anyway). If kTLS install
+       fails along the way the handshake still succeeds but the BIO_get_ktls_*
+       checks below return 0. */
+    SSL_CTX_set_options(ctx, SSL_OP_ENABLE_KTLS | SSL_OP_NO_RENEGOTIATION);
+
+    if (no_verify) {
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+    } else {
+        if (SSL_CTX_load_verify_locations(ctx, bundle, NULL) != 1)
+            die("failed to load --cert-bundle-file %s (expected a PEM bundle): "
+                "%s", bundle, ossl_err());
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+    }
+
+    SSL *ssl = SSL_new(ctx);
+    if (!ssl)
+        die("SSL_new: %s", ossl_err());
+
+    /* BIO_NOCLOSE: SSL_free must not close the underlying fd, since we are
+       handing it to xenopsd. */
+    BIO *bio = BIO_new_socket(fd, BIO_NOCLOSE);
+    if (!bio)
+        die("BIO_new_socket: %s", ossl_err());
+    SSL_set_bio(ssl, bio, bio);
+
+    if (sni && SSL_set_tlsext_host_name(ssl, sni) != 1)
+        die("SSL_set_tlsext_host_name(%s): %s", sni, ossl_err());
+
+    ERR_clear_error();
+    if (SSL_connect(ssl) != 1)
+        die("SSL_connect: %s", ossl_err());
+
+    /* SSL_VERIFY_PEER (set above) already makes SSL_connect fail on a bad
+       certificate, so in normal operation this re-check never fires. It is a
+       defence-in-depth guard against a future change that drops or weakens
+       that flag; if it ever did fire it reports the specific failure reason. */
+    if (!no_verify) {
+        long vr = SSL_get_verify_result(ssl);
+        if (vr != X509_V_OK)
+            die("certificate verification failed: %s",
+                X509_verify_cert_error_string(vr));
+    }
+
+    /* No-plaintext invariant: confirm the kernel installed kTLS in BOTH
+       directions BEFORE handing the fd to xenopsd. The migration channel is
+       bidirectional (the sender both writes the memory image and reads
+       handshake replies on this fd), so TX-only kTLS is not sufficient. These
+       gates MUST stay strictly after SSL_connect and strictly before send_fd
+       below — a refactor must not reorder them, or plaintext could be sent. */
+    if (!BIO_get_ktls_send(SSL_get_wbio(ssl)))
+        die("kTLS TX not installed (tls.ko missing or cipher rejected by "
+            "kernel); negotiated cipher = %s", SSL_get_cipher_name(ssl));
+    if (!BIO_get_ktls_recv(SSL_get_rbio(ssl)))
+        die("kTLS RX not installed (kernel lacks TLS_RX for the negotiated "
+            "cipher); negotiated cipher = %s", SSL_get_cipher_name(ssl));
+
+    if (send_fd(send_fd_num, fd) < 0)
+        die("sendmsg(SCM_RIGHTS) on fd %d: %s", send_fd_num, strerror(errno));
+
+    /* Do NOT SSL_shutdown — it would send close_notify down the socket that
+       xenopsd is about to use. SSL_free is safe (BIO_NOCLOSE). The kTLS state
+       lives in the kernel socket, so userspace teardown here is purely local;
+       end-of-stream integrity is enforced by the migration layer. */
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+
+    /* Closing our fd is fine: the kernel keeps the socket alive while xenopsd
+       holds the duplicated fd received via SCM_RIGHTS. */
+    close(fd);
+    close(send_fd_num);
+    return 0;
+}

--- a/ocaml/libs/stunnel/stunnel.ml
+++ b/ocaml/libs/stunnel/stunnel.ml
@@ -173,6 +173,17 @@ let debug_conf_of_env () : string =
   |> String.lowercase_ascii
   |> fun x -> List.mem x ["yes"; "true"; "1"] |> debug_conf_of_bool
 
+module Openssl = struct
+  (* The OpenSSL-rendered cipher list and ECDHE curve the stunnel client
+     negotiates, re-exported from the single source of truth in Tls_policy so
+     callers that must match it (the ktls-helper, which replaces the
+     per-migration stunnel client) share one definition instead of keeping a
+     second copy that can drift. *)
+  let default_ciphers = Tls_policy.Openssl.default_ciphers
+
+  let default_curve = Tls_policy.Openssl.default_curve
+end
+
 let config_file ?(accept = None) config host port =
   ( match config with
   | None ->

--- a/ocaml/libs/stunnel/stunnel.mli
+++ b/ocaml/libs/stunnel/stunnel.mli
@@ -64,6 +64,16 @@ val world : verification_config
 
 val external_host : string -> verification_config
 
+module Openssl : sig
+  val default_ciphers : string
+  (** OpenSSL cipher list the stunnel client negotiates; the single source of
+      truth the ktls-helper mirrors. *)
+
+  val default_curve : string
+  (** OpenSSL ECDHE curve the stunnel client pins; the single source of truth
+      the ktls-helper mirrors. *)
+end
+
 val with_connect :
      ?unique_id:int
   -> ?use_fork_exec_helper:bool

--- a/ocaml/xenopsd/lib/migrate_connect.ml
+++ b/ocaml/xenopsd/lib/migrate_connect.ml
@@ -140,7 +140,12 @@ let connect_via_ktls_helper ~host ~port ~verify_cert =
   let args = helper_args ~host ~port ~fd_uuid ~verify_cert in
   D.debug "spawning %s for %s:%d" !helper_path host port ;
   let pid =
-    try Forkhelpers.safe_close_and_exec None None None configs !helper_path args
+    (* Route the helper's stdout+stderr to syslog under "ktls-helper" so its
+       "kTLS active" line and any error line are visible. *)
+    try
+      Forkhelpers.safe_close_and_exec None None None configs
+        ~syslog_stdout:(Forkhelpers.Syslog_WithKey "ktls-helper")
+        ~redirect_stderr_to_stdout:true !helper_path args
     with e -> close_ignore sock_helper ; close_ignore sock_xenopsd ; raise e
   in
   (* The helper now holds its own copy of sock_helper; we don't need ours. *)

--- a/ocaml/xenopsd/lib/migrate_connect.ml
+++ b/ocaml/xenopsd/lib/migrate_connect.ml
@@ -1,0 +1,238 @@
+(*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(* TLS transport for the VM-migration data connections in [Xenops_server].
+
+   When [migration-tls = "ktls"] is set in xenopsd.conf and the migration URI
+   uses https, this module spawns the external [ktls-helper] binary to
+   perform the TLS handshake and install a kTLS-enabled socket in the kernel,
+   then receives the resulting socket fd via SCM_RIGHTS and passes it to the
+   caller. The fd behaves like an ordinary TCP socket for [read]/[write]: the
+   kernel encrypts outgoing data and decrypts incoming data transparently.
+
+   On any failure to PRODUCE the kTLS fd (helper missing, handshake error,
+   kTLS install rejected by the kernel, SCM_RIGHTS message lost, ...) this
+   module logs a single [warn] and transparently falls back to the existing
+   [Open_uri.with_open_uri] (stunnel) path, so the migration still succeeds
+   over TLS. Failures raised AFTER the fd has been handed to the caller are
+   migration-layer failures and propagate unchanged. *)
+
+module D = Debug.Make (struct let name = "migrate_connect" end)
+
+(* Transport selected by the xenopsd.conf [migration-tls] option. Empty or
+   unknown values mean the default stunnel path (the historical behaviour). *)
+module Migration_tls = struct
+  type t = Stunnel | Ktls
+
+  let to_string = function Stunnel -> "stunnel" | Ktls -> "ktls"
+
+  (* Parse a conf value, defaulting unknown/empty to [Stunnel] with a warning.
+     Config parsing must never crash xenopsd, so this does not raise (mirrors
+     the [Xenops_server.compressor] convention). *)
+  let of_string s =
+    match String.lowercase_ascii (String.trim s) with
+    | "" | "stunnel" ->
+        Stunnel
+    | "ktls" ->
+        Ktls
+    | other ->
+        D.warn "unknown migration-tls value %S; using stunnel" other ;
+        Stunnel
+end
+
+let migration_tls = ref Migration_tls.Stunnel
+
+let ktls_enabled () = !migration_tls = Migration_tls.Ktls
+
+(* Path to the helper binary. Registered as an Xcp_service resource
+   ("xenopsd-tls-helper") so it is access-checked at startup and overridable in
+   xenopsd.conf; this ref holds the resolved path. *)
+let helper_path = ref "/usr/libexec/xapi/ktls-helper"
+
+(* Maximum time to wait for the helper to finish handshaking and hand back the
+   fd before abandoning the kTLS path and falling back to stunnel. *)
+let helper_timeout = ref 30.0
+
+(* Default port for an https URI with no explicit port. NB: [Constants.https_port]
+   would couple xenopsd's library to xapi-consts; that coupling was reverted for
+   a build issue, so the value is kept local here. *)
+let default_https_port = 443
+
+(* Close [fd] ignoring errors, via the canonical stdext helper. *)
+let close_ignore fd =
+  Xapi_stdext_pervasives.Pervasiveext.ignore_exn (fun () -> Unix.close fd)
+
+let protect ~finally protected =
+  Xapi_stdext_pervasives.Pervasiveext.finally protected finally
+
+(* [let@ () = protect ~finally:cleanup in body] runs [body] then always runs
+   [cleanup], reading top to bottom instead of nesting [body] inside a thunk. *)
+let ( let@ ) f x = f x
+
+let recv_one_fd sock =
+  (* The 16-byte buffer holds enough space for the throwaway 1-byte SCM_RIGHTS
+     control payload the helper sends alongside the fd. *)
+  let buf = Bytes.make 16 '\000' in
+  let _len, _, fd = Fd_send_recv.recv_fd sock buf 0 (Bytes.length buf) [] in
+  fd
+
+(* Build the helper argv from the resolved verification policy and the options.
+   [verify_cert] is the same [Stunnel.verification_config option] the stunnel
+   fallback would use, so the kTLS path honours the pool's certificate-
+   verification on/off switch (single source of truth). *)
+let helper_args ~host ~port ~fd_uuid ~verify_cert =
+  (* SNI selects which certificate the destination serves (the pool-internal
+     cert), independently of whether we verify it, so it is always sent — the
+     migration profile uses "pool", matching the stunnel client. *)
+  let sni_name =
+    Option.bind verify_cert (fun cfg -> cfg.Stunnel.sni)
+    |> Option.value ~default:"pool"
+  in
+  let verify_args =
+    match verify_cert with
+    | None ->
+        (* No CA to verify against: certificate verification is disabled
+           pool-wide (/var/xapi/verify-certificates absent or emergency-disabled)
+           or this is a cross-pool migration. This is the same [verify_cert] the
+           stunnel fallback receives, so the kTLS path mirrors stunnel exactly
+           and is never more permissive. *)
+        ["--no-verify"]
+    | Some cfg ->
+        ["--cert-bundle-file"; cfg.Stunnel.cert_bundle_path]
+  in
+  (* Pass the cipher list and ECDHE curve the helper must negotiate, sourced
+     from the same [Stunnel.Openssl] values the stunnel client uses, so the two
+     paths stay in lock-step and the helper carries no cipher policy of its own. *)
+  let cipher_args =
+    [
+      "--ciphers"
+    ; Stunnel.Openssl.default_ciphers
+    ; "--curves"
+    ; Stunnel.Openssl.default_curve
+    ]
+  in
+  ["--host"; host; "--port"; string_of_int port; "--sni"; sni_name]
+  @ verify_args
+  @ cipher_args
+  @ ["--send-fd"; fd_uuid]
+
+(* Spawn the helper and return the kTLS-enabled fd it sends back via SCM_RIGHTS.
+   Raises on any failure; the caller decides whether to fall back. *)
+let connect_via_ktls_helper ~host ~port ~verify_cert =
+  if not (Sys.file_exists !helper_path) then
+    failwith (Printf.sprintf "kTLS helper not found at %s" !helper_path) ;
+  let sock_xenopsd, sock_helper =
+    Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0
+  in
+  let fd_uuid = Uuidx.(to_string (make ())) in
+  let configs = [(fd_uuid, sock_helper)] in
+  let args = helper_args ~host ~port ~fd_uuid ~verify_cert in
+  D.debug "spawning %s for %s:%d" !helper_path host port ;
+  let pid =
+    try Forkhelpers.safe_close_and_exec None None None configs !helper_path args
+    with e -> close_ignore sock_helper ; close_ignore sock_xenopsd ; raise e
+  in
+  (* The helper now holds its own copy of sock_helper; we don't need ours. *)
+  close_ignore sock_helper ;
+  (* [sock_xenopsd] is closed on every path by the [protect] cleanup below; the
+     helper is always reaped via [waitpid] (killed first if it times out) so it
+     cannot leak. *)
+  let@ () = protect ~finally:(fun () -> close_ignore sock_xenopsd) in
+  let received_fd =
+    try
+      if
+        not
+          (Xapi_stdext_threads.Threadext.wait_timed_read sock_xenopsd
+             !helper_timeout
+          )
+      then (
+        (* Kill the helper so we don't leak it. *)
+        ( try Unix.kill (Forkhelpers.getpid pid) Sys.sigkill with _ -> ()
+        ) ;
+        failwith
+          (Printf.sprintf "helper did not respond within %.0fs" !helper_timeout)
+      ) ;
+      recv_one_fd sock_xenopsd
+    with e ->
+      (try ignore (Forkhelpers.waitpid pid) with _ -> ()) ;
+      raise e
+  in
+  (* Reap the helper and check its exit status. Close the fd we would return on
+     ANY failure to confirm a clean exit (a raising waitpid, or a non-zero or
+     other status); on a clean exit it is handed to the caller, so it must NOT
+     be closed here. *)
+  ( try
+      match snd (Forkhelpers.waitpid pid) with
+      | Unix.WEXITED 0 ->
+          ()
+      | status ->
+          let reason =
+            match status with
+            | Unix.WEXITED n ->
+                Printf.sprintf "exited with status %d" n
+            | Unix.WSIGNALED n ->
+                Printf.sprintf "killed by signal %d" n
+            | Unix.WSTOPPED n ->
+                Printf.sprintf "stopped by signal %d" n
+          in
+          failwith (Printf.sprintf "ktls-helper %s" reason)
+    with e -> close_ignore received_fd ; raise e
+  ) ;
+  D.debug "received kTLS fd from helper for %s:%d" host port ;
+  received_fd
+
+(** Drop-in replacement for [Open_uri.with_open_uri] on the migration paths.
+
+    - When [migration-tls = "ktls"] and the URI is https, spawn the helper,
+      receive the kTLS-enabled fd via SCM_RIGHTS, and pass it to [f]. On any
+      failure to produce the fd, log a [warn] and fall back to
+      [Open_uri.with_open_uri].
+    - Otherwise behave exactly as [Open_uri.with_open_uri]. *)
+let with_open_uri ?verify_cert uri f =
+  let fallback () = Open_uri.with_open_uri ?verify_cert uri f in
+  let is_https = Uri.scheme uri = Some "https" in
+  if not (is_https && ktls_enabled ()) then
+    fallback ()
+  else
+    match Uri.host uri with
+    | None ->
+        fallback ()
+    | Some host -> (
+        let port = Option.value ~default:default_https_port (Uri.port uri) in
+        (* [Open_uri]'s [?verify_cert] is itself a [verification_config option],
+           so this binding is an option-of-option; flatten it for the helper
+           (the [fallback] above re-passes the original via [?verify_cert]). *)
+        let verify_cert = Option.join verify_cert in
+        (* Only fall back to stunnel when the kTLS path fails to PRODUCE the fd
+           (helper spawn / handshake / kTLS install / SCM_RIGHTS). Once [f fd]
+           is invoked the kTLS fd has been committed; any exception raised by
+           [f] is a migration-layer failure and MUST propagate unchanged, since
+           silently retrying [f] over a fresh stunnel socket would re-enter the
+           in-progress migration on the destination and corrupt its state. *)
+        let fd_or_none =
+          try Some (connect_via_ktls_helper ~host ~port ~verify_cert)
+          with e ->
+            D.warn
+              "migration-tls=ktls connect failed for %s:%d (%s); falling back \
+               to stunnel for this connection"
+              host port (Printexc.to_string e) ;
+            None
+        in
+        match fd_or_none with
+        | None ->
+            fallback ()
+        | Some fd ->
+            let@ () = protect ~finally:(fun () -> close_ignore fd) in
+            f fd
+      )

--- a/ocaml/xenopsd/lib/migrate_connect.mli
+++ b/ocaml/xenopsd/lib/migrate_connect.mli
@@ -1,0 +1,45 @@
+(*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** TLS transport for the VM-migration data connections. See the module
+    implementation for the full description of the kTLS helper flow and the
+    transparent stunnel fallback. *)
+
+module Migration_tls : sig
+  type t = Stunnel | Ktls
+
+  val to_string : t -> string
+
+  val of_string : string -> t
+  (** Parse a [xenopsd.conf] [migration-tls] value; empty or unknown values
+      default to [Stunnel] and never raise. *)
+end
+
+val migration_tls : Migration_tls.t ref
+(** The transport selected by the [migration-tls] option in xenopsd.conf. *)
+
+val helper_path : string ref
+(** Path to the migration TLS helper binary, registered as an Xcp_service
+    resource and overridable in xenopsd.conf. *)
+
+val with_open_uri :
+     ?verify_cert:Stunnel.verification_config option
+  -> Uri.t
+  -> (Unix.file_descr -> 'a)
+  -> 'a
+(** Drop-in replacement for [Open_uri.with_open_uri] on the migration paths.
+    With [migration-tls = "ktls"] and an https URI, spawn the helper, receive
+    the kTLS-enabled fd via SCM_RIGHTS, and pass it to [f]; on any failure to
+    produce the fd, log a warning and fall back to [Open_uri.with_open_uri].
+    Otherwise behaves exactly as [Open_uri.with_open_uri]. *)

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -2437,7 +2437,7 @@ and perform_exn ?result (op : operation) (t : Xenops_task.task_handle) : unit =
       info "VM %s has memory_limit = %Ld" id state.Vm.memory_limit ;
       let url = make_url "/migrate/vm/" new_dest_id in
       let https = Uri.scheme url = Some "https" in
-      Open_uri.with_open_uri ~verify_cert url (fun vm_fd ->
+      Migrate_connect.with_open_uri ~verify_cert url (fun vm_fd ->
           let module Handshake = Xenops_migrate.Handshake in
           let do_request fd extra_cookies url =
             if not https then Sockopt.set_sock_keepalives fd ;
@@ -2518,7 +2518,7 @@ and perform_exn ?result (op : operation) (t : Xenops_task.task_handle) : unit =
           in
           let save ?vgpu_fd () =
             let url = make_url "/migrate/mem/" new_dest_id in
-            Open_uri.with_open_uri ~verify_cert url (fun mem_fd ->
+            Migrate_connect.with_open_uri ~verify_cert url (fun mem_fd ->
                 (* vm_fd: signaling channel, mem_fd: memory stream *)
                 do_request mem_fd [] url ;
                 Handshake.recv_success mem_fd ;
@@ -2557,7 +2557,7 @@ and perform_exn ?result (op : operation) (t : Xenops_task.task_handle) : unit =
                 make_url "/migrate/vgpu/"
                   (VGPU_DB.string_of_id (new_dest_id, dev_id))
               in
-              Open_uri.with_open_uri ~verify_cert url (fun vgpu_fd ->
+              Migrate_connect.with_open_uri ~verify_cert url (fun vgpu_fd ->
                   if not https then Sockopt.set_sock_keepalives vgpu_fd ;
                   do_request vgpu_fd [(cookie_vgpu_migration, "")] url ;
                   Handshake.recv_success vgpu_fd ;

--- a/ocaml/xenopsd/lib/xenopsd.ml
+++ b/ocaml/xenopsd/lib/xenopsd.ml
@@ -340,6 +340,20 @@ let options =
     , (fun () -> !Xenops_server.migration_compressor)
     , "Compression method; one of 'stream' (default), 'xenguest'"
     )
+  ; ( "migration-tls"
+    , Arg.String
+        (fun s ->
+          Migrate_connect.migration_tls :=
+            Migrate_connect.Migration_tls.of_string s
+        )
+    , (fun () ->
+        Migrate_connect.Migration_tls.to_string !Migrate_connect.migration_tls
+      )
+    , "TLS transport for VM migration: 'stunnel' (default) uses the stunnel \
+       client subprocess; 'ktls' uses the ktls-helper to install kTLS on the \
+       migration socket. On any failure the 'ktls' path logs a warning and \
+       falls back to stunnel."
+    )
   ]
 
 let path () = Filename.concat !sockets_path "xenopsd"

--- a/ocaml/xenopsd/xc/xc_resources.ml
+++ b/ocaml/xenopsd/xc/xc_resources.ml
@@ -91,6 +91,11 @@ let nonessentials =
     , igmp_query_injector_script
     , "path to the igmp query injector script"
     )
+  ; ( X_OK
+    , "xenopsd-tls-helper"
+    , Migrate_connect.helper_path
+    , "path to the ktls-helper binary used when migration-tls=ktls"
+    )
   ]
   @ Resources.hvm_guests
   @ Resources.pv_guests

--- a/ocaml/xenopsd/xenopsd.conf
+++ b/ocaml/xenopsd/xenopsd.conf
@@ -126,3 +126,18 @@ disable-logging-for=http tracing tracing_export
 # Compression method used when migration compression is enabled - either stream or xenguest.
 # migration-compressor = "stream"
 
+# TLS transport for VM live migration.
+#   "stunnel" — default; spawn one stunnel client subprocess per migration
+#   "ktls"    — spawn the ktls-helper instead. The helper performs the
+#               TLS handshake, installs the symmetric keys into the kernel via
+#               kTLS, and hands the kTLS-enabled socket fd back to xenopsd over
+#               SCM_RIGHTS. Subsequent reads/writes are decrypted/encrypted by
+#               the kernel — no stunnel pipe on the data path.
+# If the 'ktls' helper fails for any reason xenopsd logs a warning and
+# transparently falls back to the stunnel path for that one connection,
+# so the migration still succeeds.
+# migration-tls = "stunnel"
+
+# Path to the ktls-helper binary (used only when migration-tls=ktls).
+# xenopsd-tls-helper = "/usr/libexec/xapi/ktls-helper"
+


### PR DESCRIPTION
stunnel is an external process that provides secure TLS transport for the xenguest VM-migrate stream. It's a separate process from xenguest, and the dom0 kernel pipes the data between these processes, wasting cpu and memory throughput. The result is a slower VM-migrate experience, and consequently a slower host-evacuate experience for the user.

This change removes this inefficient data pipe between stunnel and xenguest, with a new option to replace stunnel's TLS with kernel TLS (kTLS). When this ktls option is enabled, the kernel transparently uses TLS to securely transport the data produced by xenguest, without the need to modify xenguest and without the need to use stunnel.

Measurements indicate significant improvements:
* host-evacuate time: ~1.50x faster (stunnel/kTLS), depending on the load of the guests (higher load the better, as there is more guest data pages being transmitted, see details in the design page [migration-tls.md](https://github.com/xapi-project/xen-api/compare/master...mg12:xen-api:cp-313264-migration-ktls?expand=1#diff-7eead193dafea33095d3e70b27d0d0ee495a5950d004e4b7561780b6aebf5ebd)).
* dom0 cpu usage: ~20% less (see details in the design page [migration-tls.md](https://github.com/xapi-project/xen-api/compare/master...mg12:xen-api:cp-313264-migration-ktls?expand=1#diff-7eead193dafea33095d3e70b27d0d0ee495a5950d004e4b7561780b6aebf5ebd)).

Activation uses a new xenopsd.conf flag, so the existing stunnel datapath remains the default.


Tested with:
* performance tests
* ring3 BVT
