### PR TITLE
auto-mark new VMs for Secure Boot certificate update on boot

### DIFF
--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -159,6 +159,8 @@ let prototyped_of_field = function
       Some "23.18.0"
   | "VM", "actions__after_softreboot" ->
       Some "23.1.0"
+  | "pool", "auto_update_vm_secureboot_certificates" ->
+      Some "26.15.0-next"
   | "pool", "vm_console_idle_timeout" ->
       Some "26.1.0"
   | "pool", "limit_console_sessions" ->

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -160,7 +160,7 @@ let prototyped_of_field = function
   | "VM", "actions__after_softreboot" ->
       Some "23.1.0"
   | "pool", "auto_update_vm_secureboot_certificates" ->
-      Some "26.15.0-next"
+      Some "26.16.0-next"
   | "pool", "vm_console_idle_timeout" ->
       Some "26.1.0"
   | "pool", "limit_console_sessions" ->

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -2429,6 +2429,15 @@ let t =
              means never timeout. This setting applies only to VM consoles; \
              for host consoles, use the separate parameter \
              'host.console_idle_timeout'."
+        ; field ~writer_roles:_R_POOL_OP ~qualifier:RW ~lifecycle:[] ~ty:Bool
+            ~default_value:(Some (VBool false))
+            "auto_update_vm_secureboot_certificates"
+            "When true, at VM.create time the pool automatically marks a newly \
+             created VM whose Secure Boot certificates are due to expire by \
+             setting VM.secureboot_certificates_state to update_on_boot (the \
+             same effect as VM.update_secureboot_certificates_on_boot), so the \
+             certificates are updated on the VM's next boot. Only applies to \
+             VM.create."
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "981fd4b2f96e75ee70540759ebd0f37d"
+let last_known_schema_hash = "838743e71bc9a29271d2edb339c5eaeb"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -315,7 +315,8 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ?(update_sync_day = 0L) ?(update_sync_enabled = false)
     ?(recommendations = []) ?(license_server = [])
     ?(ha_reboot_vm_on_internal_shutdown = true)
-    ?(limit_console_sessions = false) ?(vm_console_idle_timeout = 0L) () =
+    ?(limit_console_sessions = false) ?(vm_console_idle_timeout = 0L)
+    ?(auto_update_vm_secureboot_certificates = false) () =
   let pool_ref = Ref.make () in
   Db.Pool.create ~__context ~ref:pool_ref ~uuid:(make_uuid ()) ~name_label
     ~name_description ~master ~default_SR ~suspend_image_SR ~crash_dump_SR
@@ -337,7 +338,7 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~ext_auth_cache_expiry:300L ~update_sync_frequency ~update_sync_day
     ~update_sync_enabled ~recommendations ~license_server
     ~ha_reboot_vm_on_internal_shutdown ~limit_console_sessions
-    ~vm_console_idle_timeout ;
+    ~vm_console_idle_timeout ~auto_update_vm_secureboot_certificates ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1516,6 +1516,16 @@ let pool_record rpc session_id pool =
       ; make_field ~name:"update-sync-enabled"
           ~get:(fun () -> (x ()).API.pool_update_sync_enabled |> string_of_bool)
           ()
+      ; make_field ~name:"auto-update-vm-secureboot-certificates"
+          ~get:(fun () ->
+            (x ()).API.pool_auto_update_vm_secureboot_certificates
+            |> string_of_bool
+          )
+          ~set:(fun x ->
+            Client.Pool.set_auto_update_vm_secureboot_certificates ~rpc
+              ~session_id ~self:pool ~value:(bool_of_string x)
+          )
+          ()
       ; make_field ~name:"recommendations"
           ~get:(fun () -> get_from_map (x ()).API.pool_recommendations)
           ~get_map:(fun () -> (x ()).API.pool_recommendations)

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -55,6 +55,7 @@ let create_pool_record ~__context =
       ~ext_auth_cache_size:50L ~ext_auth_cache_expiry:300L ~recommendations:[]
       ~license_server:[] ~ha_reboot_vm_on_internal_shutdown:true
       ~limit_console_sessions:false ~vm_console_idle_timeout:0L
+      ~auto_update_vm_secureboot_certificates:false
 
 let set_master_ip ~__context =
   let ip =

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -690,6 +690,31 @@ let create ~__context ~name_label ~name_description ~power_state ~user_version
     ~pending_guidances:[] ~recommended_guidances:[]
     ~pending_guidances_recommended:[] ~pending_guidances_full:[]
     ~secureboot_certificates_state:`ok ;
+  (* CP-313373: when the pool has opted in to automatic Secure Boot certificate
+     updates, inspect the NVRAM supplied at creation time (e.g. by MCS) and, if
+     its certificates are due to expire, schedule an update on the VM's next
+     boot. check_secureboot_certificates_state returns `ok cheaply when the
+     NVRAM contains no EFI variables (e.g. BIOS VMs), so no external check is
+     run in that case. There may be no pool in unit-test mock databases, in
+     which case there is no opt-in setting to honour and the check is skipped. *)
+  ( match Db.Pool.get_all ~__context with
+  | [] ->
+      ()
+  | pool :: _ -> (
+      if
+        Db.Pool.get_auto_update_vm_secureboot_certificates ~__context ~self:pool
+      then
+        match
+          Xapi_vm_helpers.check_secureboot_certificates_state ~__context
+            ~self:vm_ref
+        with
+        | `update_available ->
+            Db.VM.set_secureboot_certificates_state ~__context ~self:vm_ref
+              ~value:`update_on_boot
+        | `ok ->
+            ()
+    )
+  ) ;
   Xapi_vm_lifecycle.update_allowed_operations ~__context ~self:vm_ref ;
   update_memory_overhead ~__context ~vm:vm_ref ;
   update_vm_virtual_hardware_platform_version ~__context ~vm:vm_ref ;

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -690,30 +690,33 @@ let create ~__context ~name_label ~name_description ~power_state ~user_version
     ~pending_guidances:[] ~recommended_guidances:[]
     ~pending_guidances_recommended:[] ~pending_guidances_full:[]
     ~secureboot_certificates_state:`ok ;
-  (* CP-313373: when the pool has opted in to automatic Secure Boot certificate
-     updates, inspect the NVRAM supplied at creation time (e.g. by MCS) and, if
-     its certificates are due to expire, schedule an update on the VM's next
-     boot. check_secureboot_certificates_state returns `ok cheaply when the
-     NVRAM contains no EFI variables (e.g. BIOS VMs), so no external check is
-     run in that case. There may be no pool in unit-test mock databases, in
-     which case there is no opt-in setting to honour and the check is skipped. *)
+  (* Inspect the NVRAM supplied at creation time and record whether its Secure
+     Boot certificates are due to expire. If the pool has opted in to automatic
+     Secure Boot certificate updates and an update is available, schedule it on
+     the VM's next boot; otherwise simply record the current state so it is
+     visible to the user.
+     check_secureboot_certificates_state returns `ok cheaply when the NVRAM
+     contains no EFI variables (e.g. BIOS VMs), so no external check is run in
+     that case. There may be no pool in unit-test mock databases, in which case
+     there is no opt-in setting to honour and the check is skipped. *)
   ( match Db.Pool.get_all ~__context with
   | [] ->
       ()
-  | pool :: _ -> (
-      if
+  | pool :: _ ->
+      let auto_update =
         Db.Pool.get_auto_update_vm_secureboot_certificates ~__context ~self:pool
-      then
+      in
+      let value : API.vm_secureboot_certificates_state =
         match
           Xapi_vm_helpers.check_secureboot_certificates_state ~__context
             ~self:vm_ref
         with
-        | `update_available ->
-            Db.VM.set_secureboot_certificates_state ~__context ~self:vm_ref
-              ~value:`update_on_boot
-        | `ok ->
-            ()
-    )
+        | `update_available when auto_update ->
+            `update_on_boot
+        | (`ok | `update_available) as state ->
+            (state :> API.vm_secureboot_certificates_state)
+      in
+      Db.VM.set_secureboot_certificates_state ~__context ~self:vm_ref ~value
   ) ;
   Xapi_vm_lifecycle.update_allowed_operations ~__context ~self:vm_ref ;
   update_memory_overhead ~__context ~vm:vm_ref ;


### PR DESCRIPTION
Microsoft's 2011 Secure Boot certificates expire between June and October 2026. XenServer already has a remediation workflow (the per-VM field `VM.secureboot_certificates_state` plus `VM.update_secureboot_certificates_on_boot`) that lets an admin mark a VM so its Secure Boot certificates are replaced on the next (re)boot. CVAD MCS (Citrix Machine Creation Services) stores a copy of the VM NVRAM per catalog and supplies it on VM.create; catalogs built from 2011-only VMs therefore keep creating 2011-only VMs, which can fail to boot once the disk relies on 2023 certs. This feature lets a pool opt in to having xapi auto-mark such freshly created VMs so the certs are updated on first boot.

Tested:
1. Mock varstore-nvram-certcheck to always return `update_required`.
2. Use `VM.create` to trigger the logic:
```
Test A (flag=true):  state = update_on_boot  (expect update_on_boot)
Test B (flag=false): state = ok  (expect ok)
```