### PR TITLE
CA-428532: Ensure db flush is executed in shutdown_agent

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -2049,7 +2049,7 @@ let external_auth_set_ldaps =
     ~lifecycle:
       [
         ( Published
-        , "26.15.0-next"
+        , "26.16.0"
         , "This call enables or disables LDAPS for external authentication on \
            the host"
         )
@@ -2060,21 +2060,21 @@ let external_auth_set_ldaps =
           param_type= Ref _host
         ; param_name= "host"
         ; param_doc= "The host whose LDAPS configuration should be set"
-        ; param_release= numbered_release "26.15.0-next"
+        ; param_release= numbered_release "26.16.0"
         ; param_default= None
         }
       ; {
           param_type= Bool
         ; param_name= "ldaps"
         ; param_doc= "Whether to enable or disable LDAPS"
-        ; param_release= numbered_release "26.15.0-next"
+        ; param_release= numbered_release "26.16.0"
         ; param_default= None
         }
       ; {
           param_type= Bool
         ; param_name= "force"
         ; param_doc= "Force the operation even if already in the desired state"
-        ; param_release= numbered_release "26.15.0-next"
+        ; param_release= numbered_release "26.16.0"
         ; param_default= Some (VBool false)
         }
       ]

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -252,7 +252,7 @@ let prototyped_of_message = function
   | "VTPM", "create" ->
       Some "22.26.0"
   | "VDI", "revert" ->
-      Some "26.15.0-next"
+      Some "26.16.0"
   | "host", "set_servertime" ->
       Some "26.0.0"
   | "host", "get_ntp_synchronized" ->
@@ -312,7 +312,7 @@ let prototyped_of_message = function
   | "pool", "exchange_trusted_certificates_on_join" ->
       Some "26.13.0"
   | "pool", "sync_trusted_certificates_from" ->
-      Some "26.15.0-next"
+      Some "26.16.0"
   | "pool", "uninstall_trusted_certificate" ->
       Some "26.13.0"
   | "pool", "install_trusted_certificate" ->

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -665,7 +665,7 @@ let external_auth_set_ldaps =
     ~lifecycle:
       [
         ( Published
-        , "26.15.0-next"
+        , "26.16.0"
         , "This call enables or disables LDAPS for external authentication on \
            all hosts in the pool"
         )
@@ -676,21 +676,21 @@ let external_auth_set_ldaps =
           param_type= Ref _pool
         ; param_name= "pool"
         ; param_doc= "The pool whose LDAPS configuration should be set"
-        ; param_release= numbered_release "26.15.0-next"
+        ; param_release= numbered_release "26.16.0"
         ; param_default= None
         }
       ; {
           param_type= Bool
         ; param_name= "ldaps"
         ; param_doc= "Whether to enable or disable LDAPS"
-        ; param_release= numbered_release "26.15.0-next"
+        ; param_release= numbered_release "26.16.0"
         ; param_default= None
         }
       ; {
           param_type= Bool
         ; param_name= "force"
         ; param_doc= "Force the operation even if already in the desired state"
-        ; param_release= numbered_release "26.15.0-next"
+        ; param_release= numbered_release "26.16.0"
         ; param_default= Some (VBool false)
         }
       ]

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -811,8 +811,13 @@ let restart_agent ~__context ~host:_ =
 let shutdown_agent ~__context =
   debug "Host.shutdown_agent: Host agent will shutdown in 1s!!!!" ;
   let host_uuid = Helpers.get_localhost_uuid () in
-  Xapi_hooks.xapi_pre_shutdown ~__context ~host_uuid
-    ~reason:Xapi_hooks.reason__clean_shutdown ;
+  ( try
+      Xapi_hooks.xapi_pre_shutdown ~__context ~host_uuid
+        ~reason:Xapi_hooks.reason__clean_shutdown
+    with exn ->
+      warn "%s: xapi_pre_shutdown hook failed: %s" __FUNCTION__
+        (Printexc.to_string exn)
+  ) ;
   Xapi_fuse.light_fuse_and_dont_restart ~fuse_length:1. ()
 
 let disable ~__context ~host ~auto_enable =


### PR DESCRIPTION
In `shutdown_agent`, the `xapi_pre_shutdown` may raise exception, then the `light_fuse_and_dont_restart` is skipped. A DB data loss is found because db flush in that function is not executed.