### PR TITLE
Drop redundant secureboot_certificates_state recompute

### DIFF
--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -2436,8 +2436,12 @@ let t =
              created VM whose Secure Boot certificates are due to expire by \
              setting VM.secureboot_certificates_state to update_on_boot (the \
              same effect as VM.update_secureboot_certificates_on_boot), so the \
-             certificates are updated on the VM's next boot. Only applies to \
-             VM.create."
+             certificates are updated on the VM's next boot. This applies to \
+             VMs created by VM.create, including those created by operations \
+             that internally call it: the HTTP(s) PUT /import and \
+             /import_metadata calls and disaster recovery (VM.recover and \
+             VM_appliance.recover); it does not apply to VM.clone or VM.copy, \
+             which inherit the source VM's state."
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "838743e71bc9a29271d2edb339c5eaeb"
+let last_known_schema_hash = "811f0a66a5f69db0fcb2e0378a27d81c"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -619,12 +619,6 @@ module VM : HandlerTools = struct
         else
           {vm_record with API.vM_has_vendor_device= false}
       in
-      (* Always default secureboot_certificates_state to ok in the record
-         passed to create_from_record -- the actual state will be recomputed
-         below against the importing pool's certificates. *)
-      let vm_record =
-        {vm_record with API.vM_secureboot_certificates_state= `ok}
-      in
       let vm_record =
         {
           vm_record with
@@ -781,19 +775,6 @@ module VM : HandlerTools = struct
       ) ;
       Db.VM.set_bios_strings ~__context ~self:vm
         ~value:vm_record.API.vM_bios_strings ;
-      (* Always recompute secureboot_certificates_state against the
-         importing pool's certificates, since the exporting pool's state
-         is not meaningful here. *)
-      ( if not vm_record.API.vM_is_default_template then
-          let state =
-            ( Xapi_vm_helpers.check_secureboot_certificates_state ~__context
-                ~self:vm
-              :> API.vm_secureboot_certificates_state
-              )
-          in
-          Db.VM.set_secureboot_certificates_state ~__context ~self:vm
-            ~value:state
-      ) ;
       debug "Created VM: %s (was %s)" (Ref.string_of vm) x.id ;
       (* Although someone could sneak in here and attempt to power on the VM, it
          				 doesn't really matter since no VBDs have been created yet.


### PR DESCRIPTION
Every VM import operation (VM.import, VM.import_metadata, DR recover,
cross-pool migrate) creates the VM through create_from_record, which drives
VM.create -> Xapi_vm.create. That already computes
secureboot_certificates_state against the importing pool.