### PR TITLE
Rate limiting final changes before PR to master

### DIFF
--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -759,5 +759,19 @@ let client_of_req_and_fd req fd =
         None
   )
 
+(* An IPv4 connection may arrive as an IPv4-mapped IPv6 address
+   (e.g. ::ffff:1.2.3.4) depending on how the listening socket is bound.
+   [Ipaddr.to_string] preserves the IPv6 form, which then fails to
+   match string comparisons against the plain IPv4 form of the same
+   address. Callers that use the string for exact matching (e.g. the
+   per-caller rate-limit table) should route the value through this
+   helper first. *)
+let canonical_ip_string ip =
+  match Ipaddr.to_v4 ip with
+  | Some v4 ->
+      Ipaddr.V4.to_string v4
+  | None ->
+      Ipaddr.to_string ip
+
 let string_of_client (protocol, ip) =
-  Printf.sprintf "%s %s" (string_of_protocol protocol) (Ipaddr.to_string ip)
+  Printf.sprintf "%s %s" (string_of_protocol protocol) (canonical_ip_string ip)

--- a/ocaml/libs/http-lib/http_svr.mli
+++ b/ocaml/libs/http-lib/http_svr.mli
@@ -136,4 +136,11 @@ val https_client_of_req : Http.Request.t -> Ipaddr.t option
 
 val client_of_req_and_fd : Http.Request.t -> Unix.file_descr -> client option
 
+val canonical_ip_string : Ipaddr.t -> string
+(** [canonical_ip_string ip] returns [ip] as a string, normalising an
+    IPv4-mapped IPv6 address (e.g. ::ffff:1.2.3.4) to its plain IPv4
+    form. Use before comparing a request's source IP against caller
+    records so that IPv4 patterns match connections that surface as
+    IPv4-mapped IPv6. *)
+
 val string_of_client : client -> string

--- a/ocaml/libs/rate-limit/test/test_token_bucket.ml
+++ b/ocaml/libs/rate-limit/test/test_token_bucket.ml
@@ -253,6 +253,102 @@ let test_edge_cases () =
   Alcotest.(check bool)
     "Consuming very small amount should succeed" true success_small
 
+let test_oversized_consume_goes_negative () =
+  let initial_time = Mtime.Span.of_uint64_ns 0L in
+  let tb =
+    Token_bucket.create_with_timestamp initial_time ~burst_size:5.0
+      ~fill_rate:1.0
+  in
+  let success =
+    Token_bucket.consume_with_timestamp (fun () -> initial_time) tb 10.0
+  in
+  Alcotest.(check bool)
+    "Oversized consume from a full bucket should succeed" true success ;
+  Alcotest.(check (float 0.0))
+    "Bucket should be negative by (amount - burst_size)" (-5.0)
+    (Token_bucket.peek_with_timestamp initial_time tb)
+
+let test_second_oversized_consume_waits_for_burst () =
+  let initial_time = Mtime.Span.of_uint64_ns 0L in
+  let tb =
+    Token_bucket.create_with_timestamp initial_time ~burst_size:5.0
+      ~fill_rate:1.0
+  in
+  let _ =
+    Token_bucket.consume_with_timestamp (fun () -> initial_time) tb 10.0
+  in
+
+  (* After 5s: -5 + 5*1 = 0 tokens; bucket must still be at burst_size (5)
+     before a second oversized request can run. *)
+  let five_s = Mtime.Span.of_uint64_ns 5_000_000_000L in
+  Alcotest.(check (float 0.0))
+    "5s later, tokens have climbed to zero" 0.0
+    (Token_bucket.peek_with_timestamp five_s tb) ;
+  Alcotest.(check (float 0.0))
+    "Delay until second oversized request is (burst - current) / fill_rate" 5.0
+    (Token_bucket.get_delay_until_available_timestamp five_s tb 6.0) ;
+  let fail_now =
+    Token_bucket.consume_with_timestamp (fun () -> five_s) tb 6.0
+  in
+  Alcotest.(check bool)
+    "Oversized consume before bucket reaches burst_size should fail" false
+    fail_now ;
+
+  (* At 10s: -5 + 10*1 = 5 tokens (capped at burst_size), consume 6 succeeds
+     and leaves the bucket at -1. *)
+  let ten_s = Mtime.Span.of_uint64_ns 10_000_000_000L in
+  let success = Token_bucket.consume_with_timestamp (fun () -> ten_s) tb 6.0 in
+  Alcotest.(check bool)
+    "Second oversized consume succeeds once bucket refills to burst_size" true
+    success ;
+  Alcotest.(check (float 0.0))
+    "Bucket sits at burst_size - amount after second oversized consume" (-1.0)
+    (Token_bucket.peek_with_timestamp ten_s tb)
+
+(* Regression guard for the hang: previously, [delay_then_consume] on an
+   amount greater than [burst_size] looped forever because [consume] can
+   never see enough tokens (refill caps at [burst_size]) and
+   [get_delay_until_available] kept returning the same non-zero delay. Each
+   case here drains the bucket first so the operation must go through the
+   refill path, then runs it in a worker thread and asserts it completes
+   within a generous bound. A regression would leave the flag unset and
+   fail the alcotest check rather than deadlock the whole suite. *)
+let test_delay_then_consume_always_terminates () =
+  let cases =
+    [
+      (* label, burst_size, fill_rate, amount, bound_s *)
+      ("standard request from drained bucket", 5.0, 100.0, 3.0, 1.0)
+    ; ("amount equal to burst_size", 5.0, 100.0, 5.0, 1.0)
+    ; ("oversized request, tight bucket", 0.5, 200.0, 10.0, 1.0)
+    ; ("oversized request, small bucket", 1.0, 100.0, 5.0, 1.0)
+    ]
+  in
+  List.iter
+    (fun (label, burst_size, fill_rate, amount, bound_s) ->
+      let tb = Token_bucket.create ~burst_size ~fill_rate in
+      ignore (Token_bucket.consume tb burst_size) ;
+      let done_flag = Atomic.make false in
+      let _worker =
+        Thread.create
+          (fun () ->
+            Token_bucket.delay_then_consume tb amount ;
+            Atomic.set done_flag true
+          )
+          ()
+      in
+      let start = Mtime_clock.counter () in
+      let elapsed_s () =
+        Mtime.Span.to_float_ns (Mtime_clock.count start) *. 1e-9
+      in
+      while (not (Atomic.get done_flag)) && elapsed_s () < bound_s do
+        Thread.delay 0.01
+      done ;
+      Alcotest.(check bool)
+        (Printf.sprintf "delay_then_consume terminates: %s" label)
+        true (Atomic.get done_flag)
+    )
+    cases
+
 let test_consume_quickcheck =
   let open QCheck.Gen in
   let gen_operations =
@@ -397,6 +493,18 @@ let test =
     )
   ; ("Delay until available", `Quick, test_delay_until_available)
   ; ("Edge cases", `Quick, test_edge_cases)
+  ; ( "Oversized consume drives the bucket negative"
+    , `Quick
+    , test_oversized_consume_goes_negative
+    )
+  ; ( "Second oversized consume waits for burst refill"
+    , `Quick
+    , test_second_oversized_consume_waits_for_burst
+    )
+  ; ( "delay_then_consume always terminates"
+    , `Quick
+    , test_delay_then_consume_always_terminates
+    )
   ; QCheck_alcotest.to_alcotest test_consume_quickcheck
   ]
 

--- a/ocaml/libs/rate-limit/token_bucket.ml
+++ b/ocaml/libs/rate-limit/token_bucket.ml
@@ -37,6 +37,10 @@ let peek_with_timestamp timestamp tb =
 
 let peek tb = peek_with_timestamp (Mtime_clock.elapsed ()) tb
 
+(* A request whose cost exceeds [burst_size] can never wait for its full
+   amount to accumulate (refill caps at [burst_size]). We admit such a
+   request once the bucket is full and let [tokens] go negative; the debt
+   is repaid at [fill_rate] before any later request can proceed. *)
 let consume_with_timestamp get_time tb amount =
   let rec try_consume () =
     let timestamp = get_time () in
@@ -45,8 +49,9 @@ let consume_with_timestamp get_time tb amount =
       compute_tokens timestamp old_state ~burst_size:tb.burst_size
         ~fill_rate:tb.fill_rate
     in
+    let required = Float.min amount tb.burst_size in
     let success, final_tokens =
-      if new_tokens >= amount then
+      if new_tokens >= required then
         (true, new_tokens -. amount)
       else
         (false, new_tokens)
@@ -67,7 +72,8 @@ let get_delay_until_available_timestamp timestamp tb amount =
     compute_tokens timestamp {tokens; last_refill} ~burst_size:tb.burst_size
       ~fill_rate:tb.fill_rate
   in
-  let required_tokens = max 0. (amount -. current_tokens) in
+  let required = Float.min amount tb.burst_size in
+  let required_tokens = max 0. (required -. current_tokens) in
   required_tokens /. tb.fill_rate
 
 let get_delay_until_available tb amount =

--- a/ocaml/libs/rate-limit/token_bucket.mli
+++ b/ocaml/libs/rate-limit/token_bucket.mli
@@ -25,6 +25,12 @@
     only when sufficient tokens are available - otherwise, the operations can
     be delayed until enough tokens are available.
 
+    A single request whose cost exceeds [burst_size] cannot be satisfied by
+    a full bucket. Rather than being rejected, such a request is admitted
+    once the bucket reaches [burst_size] and the token count is allowed to
+    go negative; the debt is repaid at [fill_rate] before any subsequent
+    request can proceed. [peek] therefore may return a value below zero.
+
     To avoid doing unnecessary work to refill the bucket, token amounts are
     only updated when a consume operation is carried out. The buckets keep a
     last_refill timestamp which is updated on consume in tandem with the token
@@ -51,15 +57,20 @@ val peek : t -> float
    *)
 
 val consume : t -> float -> bool
-(** Consume tokens from the bucket in a thread-safe manner.
+(** Consume tokens from the bucket in a thread-safe manner. Succeeds when
+    the bucket contains at least [min amount burst_size] tokens; on success
+    [amount] is subtracted, which may leave the token count negative if
+    [amount > burst_size].
      @param tb Token bucket
      @param amount How many tokens to consume
      @return Whether the tokens were successfully consumed
    *)
 
 val get_delay_until_available : t -> float -> float
-(** Get number of seconds that need to pass until bucket is expected to have
-    enough tokens to fulfil the request
+(** Get number of seconds that need to pass until [consume tb amount] is
+    expected to succeed. For [amount > burst_size] this is the time until
+    the bucket reaches [burst_size] (after which the request is admitted
+    and the bucket goes negative).
     @param tb Token bucket
     @param amount How many tokens we want to consume
     @return Number of seconds until tokens are available

--- a/ocaml/quicktest/quicktest_rate_limit.ml
+++ b/ocaml/quicktest/quicktest_rate_limit.ml
@@ -2,14 +2,27 @@ module Caller = Client.Client.Caller
 module Rate_limit = Client.Client.Rate_limit
 module Pool = Client.Client.Pool
 
-(* Create an RPC function that uses a specific User-Agent header *)
+(* Create an RPC function that uses a specific User-Agent header. Mirrors the
+   transport chosen for the framework's default RPC so that the throttled and
+   unthrottled measurements go over the same channel. *)
 let make_rpc_with_user_agent user_agent =
   let http =
     Http.Request.make ~user_agent ~version:"1.1" ~keep_alive:false Http.Post "/"
   in
+  let open Xmlrpc_client in
+  let transport =
+    if !Quicktest_args.using_unix_domain_socket then
+      Unix Xapi_globs.unix_domain_socket
+    else
+      SSL
+        ( SSL.make ~use_fork_exec_helper:false
+            ~verify_cert:(Stunnel_client.pool ()) ()
+        , !Quicktest_args.host
+        , 443
+        )
+  in
   fun xml ->
-    Xmlrpc_client.XMLRPC_protocol.rpc ~srcstr:"quicktest" ~dststr:"xapi"
-      ~transport:(Unix Xapi_globs.unix_domain_socket) ~http xml
+    XMLRPC_protocol.rpc ~srcstr:"quicktest" ~dststr:"xapi" ~transport ~http xml
 
 (* Build a caller + rate-limit pair and link them. Returns a cleanup
    thunk that tears them down in dependency order. *)
@@ -50,10 +63,13 @@ let rate_limit_throttling_test rpc session_id () =
   let test_user_agent =
     "quicktest-rate-limit-throttle-" ^ Uuidx.(to_string (make ()))
   in
-  let burst_size = 0.5 in
-  let fill_rate = 2.0 in
-  (* Token cost for pool.get_all from xapi_caller.ml (default_token_cost) *)
-  let call_cost = 0.1 in
+  (* pool.get_all is not listed in call-costs.conf, so its cost falls back to
+     xapi_caller.ml's default_token_cost of 1.0. Pick burst/fill so 100 calls
+     take a few seconds while still throttling well below the unthrottled
+     rate. *)
+  let burst_size = 10.0 in
+  let fill_rate = 40.0 in
+  let call_cost = 1.0 in
   with_throttled_caller rpc session_id ~name:"quicktest-throttle"
     ~user_agent:test_user_agent ~burst_size ~fill_rate (fun caller_ref _ ->
       let throttled_rpc = make_rpc_with_user_agent test_user_agent in
@@ -87,22 +103,23 @@ let rate_limit_throttling_test rpc session_id () =
         in
         Printf.printf "%d throttled calls took %.3f seconds\n%!" num_calls
           elapsed_throttled ;
-        let throttle_ratio =
-          elapsed_throttled /. max elapsed_unthrottled 0.001
-        in
-        Printf.printf "Throttle ratio: %.2fx slower\n%!" throttle_ratio ;
-        (* Throttled calls should take noticeably longer - at least 2x slower *)
-        Alcotest.(check bool)
-          "Rate limiting causes observable slowdown" true (throttle_ratio > 2.0) ;
-        (* Absolute upper bound: time should not exceed theoretical maximum
-           based on token bucket math: (total_cost - burst) / fill_rate *)
+        (* Token-bucket adds a fixed delay once the initial burst is drained:
+           (N*cost - burst)/fill_rate. The unthrottled baseline captures
+           per-call RPC overhead, so subtracting it isolates the throttler's
+           contribution. Bound above and below to catch both under- and
+           over-limiting. Requires both paths to share a transport. *)
         let num_calls_f = Float.of_int num_calls in
-        let total_cost = num_calls_f *. call_cost in
-        let max_time = (total_cost -. burst_size) /. fill_rate in
-        Printf.printf "Max expected time: %.3f seconds\n%!" max_time ;
+        let floor =
+          Float.max 0.0 (((num_calls_f *. call_cost) -. burst_size) /. fill_rate)
+        in
+        let tolerance_low = 0.10 *. floor in
+        let tolerance_high = 0.5 +. (0.20 *. floor) in
         Alcotest.(check bool)
-          "Execution time within theoretical bound" true
-          (elapsed_throttled <= max_time)
+          "Throttled call time above predicted rate limit overhead" true
+          (elapsed_throttled >= floor -. tolerance_low) ;
+        Alcotest.(check bool)
+          "Throttled time below unthrottled + rate limit overhead" true
+          (elapsed_throttled <= floor +. elapsed_unthrottled +. tolerance_high)
   )
 
 (* Test that invalid rate limits are rejected *)

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -522,7 +522,7 @@ let get_test_clusterd_rpc context = context.test_clusterd_rpc
 let get_client context = context.client |> Option.map Http_svr.string_of_client
 
 let get_client_ip context =
-  context.client |> Option.map (fun (_, ip) -> Ipaddr.to_string ip)
+  context.client |> Option.map (fun (_, ip) -> Http_svr.canonical_ip_string ip)
 
 let get_user_agent context =
   match context.origin with

--- a/ocaml/xapi/xapi_caller.ml
+++ b/ocaml/xapi/xapi_caller.ml
@@ -36,8 +36,19 @@ type entry = {
 
 let caller_table : entry Caller_table.t = Caller_table.create ()
 
-(* Serialises the read-then-create path that auto-populates unknown callers. *)
-let create_mutex = Mutex.create ()
+(* Serialises ALL mutations of [caller_table] on the master. Caller_table
+   itself uses Atomic for lock-free reads, but its writers are non-CAS
+   Atomic.get/set pairs and its higher-level "delete then insert" refresh
+   is not atomic - two concurrent refreshes for the same caller can
+   otherwise interleave so that the later insert is silently refused
+   as a duplicate, leaving the table with stale state. Held around
+   create/destroy/refresh_caller_rate_limit and the auto-create path.
+   NOT held by [register] because that runs single-threaded at startup. *)
+let caller_table_mutex = Mutex.create ()
+
+let with_caller_table_mutex f =
+  Mutex.lock caller_table_mutex ;
+  Fun.protect ~finally:(fun () -> Mutex.unlock caller_table_mutex) f
 
 let pattern_of_db_string : string -> Caller_table.Key.match_pattern =
  fun s ->
@@ -92,32 +103,20 @@ let validate_request_fields ~user_agent ~client_ip =
           )
       )
 
-let insert_entry ~caller_ref ~caller_uuid ~pattern_key ~rate_limit_ref =
-  let entry =
-    {
-      caller_ref
-    ; pattern_key
-    ; stats= Caller_statistics.create ~caller_uuid
-    ; rate_limit_ref
-    }
-  in
+(* All [insert_entry_locked] callers must hold [caller_table_mutex], except
+   [register] which runs single-threaded at startup. *)
+let insert_entry_locked ~caller_ref ~stats ~pattern_key ~rate_limit_ref =
+  let entry = {caller_ref; pattern_key; stats; rate_limit_ref} in
   if not (Caller_table.insert caller_table ~pattern:pattern_key entry) then
     debug
       "Caller_table.insert refused entry (duplicate or all-wildcard) for \
        caller %s"
       (Ref.string_of caller_ref)
 
-let create ~__context ~name_label ~name_description ~user_agent ~client_ip =
-  validate_request_fields ~user_agent ~client_ip ;
-  let pattern_key = pattern_key_of_fields ~user_agent ~client_ip in
-  if Caller_table.Key.is_all_wildcard pattern_key then
-    raise
-      Api_errors.(
-        Server_error
-          ( invalid_value
-          , ["user_agent/client_ip"; "all-wildcard pattern not allowed"]
-          )
-      ) ;
+(* Body of [create]; assumes [caller_table_mutex] is held and that
+   [pattern_key] has already been validated. *)
+let create_locked ~__context ~name_label ~name_description ~user_agent
+    ~client_ip ~pattern_key =
   match Caller_table.get_exact caller_table ~pattern:pattern_key with
   | Some entry ->
       (* Idempotent: an in-memory entry already mirrors this pattern. Update
@@ -133,14 +132,33 @@ let create ~__context ~name_label ~name_description ~user_agent ~client_ip =
       Db.Caller.create ~__context ~ref ~uuid ~name_label ~name_description
         ~user_agent ~client_ip ~last_access:Clock.Date.epoch ~groups:[]
         ~rate_limit:Ref.null ;
-      insert_entry ~caller_ref:ref ~caller_uuid:uuid ~pattern_key
-        ~rate_limit_ref:Ref.null ;
+      insert_entry_locked ~caller_ref:ref
+        ~stats:(Caller_statistics.create ~caller_uuid:uuid)
+        ~pattern_key ~rate_limit_ref:Ref.null ;
       ref
+
+let create ~__context ~name_label ~name_description ~user_agent ~client_ip =
+  validate_request_fields ~user_agent ~client_ip ;
+  let pattern_key = pattern_key_of_fields ~user_agent ~client_ip in
+  if Caller_table.Key.is_all_wildcard pattern_key then
+    raise
+      Api_errors.(
+        Server_error
+          ( invalid_value
+          , ["user_agent/client_ip"; "all-wildcard pattern not allowed"]
+          )
+      ) ;
+  with_caller_table_mutex (fun () ->
+      create_locked ~__context ~name_label ~name_description ~user_agent
+        ~client_ip ~pattern_key
+  )
 
 let destroy ~__context ~self =
   let record = Db.Caller.get_record ~__context ~self in
   let pattern_key = pattern_key_of_record record in
-  Caller_table.delete caller_table ~pattern:pattern_key ;
+  with_caller_table_mutex (fun () ->
+      Caller_table.delete caller_table ~pattern:pattern_key
+  ) ;
   Db.Caller.destroy ~__context ~self
 
 let add_group ~__context ~self ~group =
@@ -219,19 +237,38 @@ let query_all_usage ~__context =
   )
 
 (** Re-read the caller's rate_limit ref from DB and rebuild its entry. Called
-    by Xapi_rate_limit whenever the caller's rate_limit field changes. *)
+    by Xapi_rate_limit whenever the caller's rate_limit field changes.
+
+    Held under [caller_table_mutex] so the DB read + delete + insert are
+    seen as one step: concurrent refreshes for the same caller can
+    otherwise both start from the DB state seen before either mutation,
+    and the later insert then silently loses to the earlier one.
+
+    User_agent and client_ip are StaticRO in the datamodel, so a caller's
+    pattern_key never changes; we preserve the existing [stats] across
+    the swap so that attaching or detaching a rate_limit doesn't reset
+    the "calls / tokens since Xapi startup" counters. *)
 let refresh_caller_rate_limit ~__context caller_ref =
-  match
-    try Some (Db.Caller.get_record ~__context ~self:caller_ref) with _ -> None
-  with
-  | None ->
-      ()
-  | Some record ->
-      let pattern_key = pattern_key_of_record record in
-      Caller_table.delete caller_table ~pattern:pattern_key ;
-      insert_entry ~caller_ref ~pattern_key
-        ~rate_limit_ref:record.API.caller_rate_limit
-        ~caller_uuid:record.caller_uuid
+  with_caller_table_mutex (fun () ->
+      match
+        try Some (Db.Caller.get_record ~__context ~self:caller_ref)
+        with _ -> None
+      with
+      | None ->
+          ()
+      | Some record ->
+          let pattern_key = pattern_key_of_record record in
+          let stats =
+            match Caller_table.get_exact caller_table ~pattern:pattern_key with
+            | Some existing ->
+                existing.stats
+            | None ->
+                Caller_statistics.create ~caller_uuid:record.caller_uuid
+          in
+          Caller_table.delete caller_table ~pattern:pattern_key ;
+          insert_entry_locked ~caller_ref ~stats ~pattern_key
+            ~rate_limit_ref:record.API.caller_rate_limit
+  )
 
 (* Install the caller_table refresh callback at module load time. The API
    server can accept requests before [register] runs, and any
@@ -314,20 +351,22 @@ let maybe_autocreate ~task_create ~user_agent ~client_ip ~existing =
   let fully_specified_request = user_agent <> "" && client_ip <> "" in
   if (not fully_specified_request) || any_fully_specified existing then
     ()
-  else (
-    Mutex.lock create_mutex ;
-    Fun.protect
-      ~finally:(fun () -> Mutex.unlock create_mutex)
-      (fun () ->
-        let target = target_of_request ~user_agent ~client_ip in
-        let existing = Caller_table.get caller_table ~caller_id:target in
-        if any_fully_specified existing then
-          ()
-        else
-          task_create (fun __context ->
+  else
+    task_create (fun __context ->
+        with_caller_table_mutex (fun () ->
+            (* Re-check under the lock: another thread may have auto-created
+               a matching row while we were racing to acquire the mutex. *)
+            let target = target_of_request ~user_agent ~client_ip in
+            let existing = Caller_table.get caller_table ~caller_id:target in
+            if any_fully_specified existing then
+              ()
+            else
               try
+                let pattern_key =
+                  pattern_key_of_fields ~user_agent ~client_ip
+                in
                 let caller_ref =
-                  create ~__context
+                  create_locked ~__context
                     ~name_label:
                       (Printf.sprintf "user_agent: %s, client_ip: %s" user_agent
                          client_ip
@@ -337,16 +376,15 @@ let maybe_autocreate ~task_create ~user_agent ~client_ip ~existing =
                          "Autogenerated caller for user_agent %s, client_ip %s"
                          user_agent client_ip
                       )
-                    ~user_agent ~client_ip
+                    ~user_agent ~client_ip ~pattern_key
                 in
                 Db.Caller.set_last_access ~__context ~self:caller_ref
                   ~value:(Clock.Date.now ())
               with e ->
                 warn "Auto-create of caller for (%s, %s) failed: %s" user_agent
                   client_ip (Printexc.to_string e)
-          )
-      )
-  )
+        )
+    )
 
 let submit ~submit_fn ~user_agent ~client_ip ~callback ~task_create amount =
   if not !Xapi_globs.rate_limit_enabled then
@@ -420,13 +458,14 @@ let register ~__context =
       "Rate limiting disabled (rate_limit=false); skipping caller registration"
   else (
     load_token_costs () ;
+    (* Runs single-threaded at start-of-day, so bypasses caller_table_mutex. *)
     List.iter
       (fun self ->
         let record = Db.Caller.get_record ~__context ~self in
         let pattern_key = pattern_key_of_record record in
-        insert_entry ~caller_ref:self ~pattern_key
-          ~rate_limit_ref:record.API.caller_rate_limit
-          ~caller_uuid:record.caller_uuid
+        insert_entry_locked ~caller_ref:self
+          ~stats:(Caller_statistics.create ~caller_uuid:record.caller_uuid)
+          ~pattern_key ~rate_limit_ref:record.API.caller_rate_limit
       )
       (Db.Caller.get_all ~__context) ;
     start_reporter ()

--- a/ocaml/xapi/xapi_caller.ml
+++ b/ocaml/xapi/xapi_caller.ml
@@ -233,6 +233,13 @@ let refresh_caller_rate_limit ~__context caller_ref =
         ~rate_limit_ref:record.API.caller_rate_limit
         ~caller_uuid:record.caller_uuid
 
+(* Install the caller_table refresh callback at module load time. The API
+   server can accept requests before [register] runs, and any
+   [Rate_limit.add_caller] that lands in that window would otherwise leave
+   the caller_table entry with rate_limit_ref = Ref.null (because
+   [notify_caller_changed] would fall through to the default no-op). *)
+let () = Xapi_rate_limit.set_caller_refresh_callback refresh_caller_rate_limit
+
 (* One token corresponds to a cheap DB read; expensive services cost multiples.
    The costs are loaded at startup from [Xapi_globs.call_costs_file], one
    "Class.method = cost" per line (key=value, '#' comments), so the values can be
@@ -413,7 +420,6 @@ let register ~__context =
       "Rate limiting disabled (rate_limit=false); skipping caller registration"
   else (
     load_token_costs () ;
-    Xapi_rate_limit.set_caller_refresh_callback refresh_caller_rate_limit ;
     List.iter
       (fun self ->
         let record = Db.Caller.get_record ~__context ~self in

--- a/ocaml/xapi/xapi_http.ml
+++ b/ocaml/xapi/xapi_http.ml
@@ -372,7 +372,7 @@ let add_handler (name, handler) =
     let client_id =
       match (req.Http.Request.user_agent, client_info) with
       | Some user_agent, Some (_, ip) ->
-          Some (user_agent, Ipaddr.to_string ip)
+          Some (user_agent, Http_svr.canonical_ip_string ip)
       | _ ->
           None
     in

--- a/ocaml/xapi/xapi_rate_limit.ml
+++ b/ocaml/xapi/xapi_rate_limit.ml
@@ -93,14 +93,17 @@ let destroy ~__context ~self =
   Db.Rate_limit.destroy ~__context ~self
 
 let add_caller ~__context ~self ~caller =
-  (* One rate limit per caller: clear any existing attachment first. *)
+  (* One rate limit per caller. Set the new value directly: the datamodel's
+     reverse-relation machinery removes the caller from any previous
+     Rate_limit's [callers] set automatically. The previous implementation
+     cleared to Ref.null first and then set the target, which briefly
+     left the caller unlimited and triggered two full refreshes (each
+     an extra DB read for the callback). *)
   let previous = Db.Caller.get_rate_limit ~__context ~self:caller in
-  if previous <> Ref.null && previous <> self then (
-    Db.Caller.set_rate_limit ~__context ~self:caller ~value:Ref.null ;
+  if previous <> self then (
+    Db.Caller.set_rate_limit ~__context ~self:caller ~value:self ;
     notify_caller_changed ~__context caller
-  ) ;
-  Db.Caller.set_rate_limit ~__context ~self:caller ~value:self ;
-  notify_caller_changed ~__context caller
+  )
 
 let remove_caller ~__context ~self ~caller =
   let current = Db.Caller.get_rate_limit ~__context ~self:caller in
@@ -109,23 +112,22 @@ let remove_caller ~__context ~self ~caller =
     notify_caller_changed ~__context caller
   )
 
+(* No [notify_caller_changed] on parameter changes: the caller_table entry
+   still points at the same rate_limit_ref, and [install_bucket] has
+   already swapped the in-memory bucket - the next [find_bucket] on the
+   dispatch path picks up the new parameters. Notifying attached callers
+   here would just be an extra DB read per caller with no state change. *)
 let set_burst_size ~__context ~self ~value =
   let fill_rate = Db.Rate_limit.get_fill_rate ~__context ~self in
   validate_params ~burst_size:value ~fill_rate ;
   Db.Rate_limit.set_burst_size ~__context ~self ~value ;
-  install_bucket ~self ~burst_size:value ~fill_rate ;
-  List.iter
-    (notify_caller_changed ~__context)
-    (Db.Rate_limit.get_callers ~__context ~self)
+  install_bucket ~self ~burst_size:value ~fill_rate
 
 let set_fill_rate ~__context ~self ~value =
   let burst_size = Db.Rate_limit.get_burst_size ~__context ~self in
   validate_params ~burst_size ~fill_rate:value ;
   Db.Rate_limit.set_fill_rate ~__context ~self ~value ;
-  install_bucket ~self ~burst_size ~fill_rate:value ;
-  List.iter
-    (notify_caller_changed ~__context)
-    (Db.Rate_limit.get_callers ~__context ~self)
+  install_bucket ~self ~burst_size ~fill_rate:value
 
 let register ~__context =
   if not !Xapi_globs.rate_limit_enabled then


### PR DESCRIPTION
This PR has a few minor changes, including:
- Allow token buckets to go negative if an incoming request costs more than the token bucket capacity
- Initialise the caller tracking on module load so no callers are missed
- Improve quicktest to remove flakiness