### PR TITLE
Following action for README.markdown to README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ install:
 	chmod +x $(DESTDIR)$(DOCDIR)/doc-convert.sh
 	# backward compat with existing specfile, to be removed after it is updated
 	find $(DESTDIR) -name '*.cmxs' -delete
-	for pkg in xapi-debug xapi xe xapi-tools xapi-sdk vhd-tool qcow-stream-tool; do for f in CHANGELOG LICENSE README.markdown; do rm $(DESTDIR)$(OPTDIR)/doc/$$pkg/$$f $(DESTDIR)$(PREFIX)/doc/$$pkg/$$f -f; done; for f in META dune-package opam; do rm $(DESTDIR)$(LIBDIR)/$$pkg/$$f -f; done; done;
+	for pkg in xapi-debug xapi xe xapi-tools xapi-sdk vhd-tool qcow-stream-tool; do for f in CHANGELOG LICENSE README.md; do rm $(DESTDIR)$(OPTDIR)/doc/$$pkg/$$f $(DESTDIR)$(PREFIX)/doc/$$pkg/$$f -f; done; for f in META dune-package opam; do rm $(DESTDIR)$(LIBDIR)/$$pkg/$$f -f; done; done;
 
 
 uninstall:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ maintainers = [
     {name = "Rob Hoes"},
     {name = "Pau Ruiz Safont"},
 ]
-readme = "README.markdown"
+readme = "README.md"
 # https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Following #7181, after renaming to README.md, the Makefile need to be updated to clean the README.md.
Now koji build complains
```
error: Installed (but unpackaged) file(s) found:
   /opt/xensource/doc/xapi-debug/README.md
   /opt/xensource/doc/xapi/README.md
   /opt/xensource/doc/xe/README.md
```