### PR TITLE
qcow_tool_wrapper: Add progress reporting for import and export

### DIFF
--- a/ocaml/qcow-stream-tool/qcow_stream_tool.ml
+++ b/ocaml/qcow-stream-tool/qcow_stream_tool.ml
@@ -2,7 +2,8 @@ open Cmdliner
 
 module Impl = struct
   let stream_decode output =
-    Qcow_stream.stream_decode Unix.stdin output ;
+    let progress_cb x = if x < 100 then Printf.printf "%03d%!" x in
+    Qcow_stream.stream_decode ~progress_cb Unix.stdin output ;
     `Ok ()
 end
 

--- a/ocaml/xapi/qcow_tool_wrapper.ml
+++ b/ocaml/xapi/qcow_tool_wrapper.ml
@@ -86,13 +86,14 @@ let send ?relative_to (progress_cb : int -> unit) (unix_fd : Unix.file_descr)
   in
   let diff_fds = Option.map read_header relative_to_qcow_path in
 
+  let output_fd_string = Uuidx.(to_string (make ())) in
   let map_fd_string = Uuidx.(to_string (make ())) in
   let info_fd_string = Uuidx.(to_string (make ())) in
   let diff_map_fd_string = Uuidx.(to_string (make ())) in
   let diff_info_fd_string = Uuidx.(to_string (make ())) in
 
   let args =
-    [path]
+    [path; "--output"; output_fd_string]
     @ (match relative_to with None -> [] | Some vdi -> ["--diff"; vdi])
     @ ( match relative_to_qcow_path with
       | None ->
@@ -119,8 +120,10 @@ let send ?relative_to (progress_cb : int -> unit) (unix_fd : Unix.file_descr)
   in
   let qcow_tool = !Xapi_globs.qcow_to_stdout in
   let replace_fds =
-    Option.map
-      (fun (map_fd, info_fd) ->
+    [(output_fd_string, unix_fd)]
+    @
+    match input_fds with
+    | Some (map_fd, info_fd) -> (
         let rfds = [(map_fd_string, map_fd); (info_fd_string, info_fd)] in
         match diff_fds with
         | Some (diff_map_fd, diff_info_fd) ->
@@ -130,12 +133,12 @@ let send ?relative_to (progress_cb : int -> unit) (unix_fd : Unix.file_descr)
         | None ->
             rfds
       )
-      input_fds
+    | None ->
+        []
   in
   Xapi_stdext_pervasives.Pervasiveext.finally
     (fun () ->
-      Vhd_qcow_parsing.run_tool qcow_tool args ~progress_cb ~output_fd:unix_fd
-        ?replace_fds
+      Vhd_qcow_parsing.run_tool qcow_tool args ~progress_cb ~replace_fds
     )
     (fun () ->
       Option.iter (fun (x, y) -> Unix.close x ; Unix.close y) input_fds ;

--- a/ocaml/xapi/qcow_tool_wrapper.ml
+++ b/ocaml/xapi/qcow_tool_wrapper.ml
@@ -19,7 +19,7 @@ let receive (progress_cb : int -> unit) (unix_fd : Unix.file_descr)
     (path : string) =
   let args = ["stream_decode"; path] in
   let qcow_tool = !Xapi_globs.qcow_stream_tool in
-  Vhd_qcow_parsing.run_tool qcow_tool progress_cb args ~input_fd:unix_fd
+  Vhd_qcow_parsing.run_tool qcow_tool args ~progress_cb ~input_fd:unix_fd
 
 let read_header qcow_path =
   let progress_cb _ = () in
@@ -28,7 +28,7 @@ let read_header qcow_path =
       (fun () ->
         Xapi_stdext_pervasives.Pervasiveext.finally
           (fun () ->
-            Vhd_qcow_parsing.run_tool tool progress_cb args
+            Vhd_qcow_parsing.run_tool tool args ~progress_cb
               ~output_fd:pipe_writer ~replace_fds
           )
           (fun () -> Unix.close pipe_writer)
@@ -134,7 +134,7 @@ let send ?relative_to (progress_cb : int -> unit) (unix_fd : Unix.file_descr)
   in
   Xapi_stdext_pervasives.Pervasiveext.finally
     (fun () ->
-      Vhd_qcow_parsing.run_tool qcow_tool progress_cb args ~output_fd:unix_fd
+      Vhd_qcow_parsing.run_tool qcow_tool args ~progress_cb ~output_fd:unix_fd
         ?replace_fds
     )
     (fun () ->

--- a/ocaml/xapi/vhd_qcow_parsing.ml
+++ b/ocaml/xapi/vhd_qcow_parsing.ml
@@ -16,18 +16,62 @@ module D = Debug.Make (struct let name = __MODULE__ end)
 
 open D
 
-let run_tool tool ?(replace_fds = []) ?input_fd ?output_fd
-    (_progress_cb : int -> unit) (args : string list) =
+let run_tool tool ?(replace_fds = []) ?input_fd ?output_fd ~progress_cb
+    (args : string list) =
   info "Executing %s %s" tool (String.concat " " args) ;
+  let to_close = ref [] in
+  let pipe_read, pipe_write =
+    match output_fd with
+    | None ->
+        let r, w = Unix.pipe () in
+        to_close := [r; w] ;
+        (Some r, Some w)
+    | Some x ->
+        (None, Some x)
+  in
+  let close x =
+    match x with
+    | Some x ->
+        if List.mem x !to_close then (
+          Unix.close x ;
+          to_close := List.filter (fun y -> y <> x) !to_close
+        )
+    | None ->
+        ()
+  in
   (* with_logfile_fd takes a name without slashes *)
   let log_name = Filename.basename tool in
   let open Forkhelpers in
+  let protect ~finally protected =
+    Xapi_stdext_pervasives.Pervasiveext.finally protected finally
+  in
+  protect ~finally:(fun () -> close pipe_read ; close pipe_write) @@ fun () ->
   match
     with_logfile_fd log_name (fun log_fd ->
         let pid =
-          safe_close_and_exec input_fd output_fd (Some log_fd) replace_fds tool
+          safe_close_and_exec input_fd pipe_write (Some log_fd) replace_fds tool
             args
         in
+        close pipe_write ;
+        ( match pipe_read with
+        | Some pipe_read -> (
+          try
+            let buf = Bytes.make 3 '\000' in
+            while true do
+              Xapi_stdext_unix.Unixext.really_read pipe_read buf 0
+                (Bytes.length buf) ;
+              progress_cb (int_of_string (Bytes.to_string buf))
+            done
+          with
+          | End_of_file ->
+              ()
+          | e ->
+              warn "unexpected error reading progress from vhd-tool: %s"
+                (Printexc.to_string e)
+        )
+        | None ->
+            ()
+        ) ;
         let _, status = waitpid pid in
         if status <> Unix.WEXITED 0 then (
           error "qcow-tool failed, returning VDI_IO_ERROR" ;

--- a/ocaml/xapi/vhd_qcow_parsing.mli
+++ b/ocaml/xapi/vhd_qcow_parsing.mli
@@ -17,7 +17,7 @@ val run_tool :
   -> ?replace_fds:(string * Unix.file_descr) list
   -> ?input_fd:Unix.file_descr
   -> ?output_fd:Unix.file_descr
-  -> (int -> unit)
+  -> progress_cb:(int -> unit)
   -> string list
   -> unit
 

--- a/ocaml/xapi/vhd_tool_wrapper.ml
+++ b/ocaml/xapi/vhd_tool_wrapper.ml
@@ -25,60 +25,6 @@ let vhd_search_path = "/dev/mapper:."
 let update_task_progress __context x =
   TaskHelper.set_progress ~__context (float_of_int x /. 100.)
 
-let run_vhd_tool progress_cb args s s' _path =
-  let vhd_tool = !Xapi_globs.vhd_tool in
-  info "Executing %s %s" vhd_tool (String.concat " " args) ;
-  let open Forkhelpers in
-  let pipe_read, pipe_write = Unix.pipe () in
-  let to_close = ref [pipe_read; pipe_write] in
-  let close x =
-    if List.mem x !to_close then (
-      Unix.close x ;
-      to_close := List.filter (fun y -> y <> x) !to_close
-    )
-  in
-  Xapi_stdext_pervasives.Pervasiveext.finally
-    (fun () ->
-      match
-        with_logfile_fd "vhd-tool" (fun log_fd ->
-            let pid =
-              safe_close_and_exec None (Some pipe_write) (Some log_fd)
-                [(s', s)]
-                vhd_tool args
-            in
-            close pipe_write ;
-            ( try
-                let buf = Bytes.make 3 '\000' in
-                while true do
-                  Xapi_stdext_unix.Unixext.really_read pipe_read buf 0
-                    (Bytes.length buf) ;
-                  progress_cb (int_of_string (Bytes.to_string buf))
-                done
-              with
-            | End_of_file ->
-                ()
-            | e ->
-                warn "unexpected error reading progress from vhd-tool: %s"
-                  (Printexc.to_string e)
-            ) ;
-            let _, status = waitpid pid in
-            if status <> Unix.WEXITED 0 then (
-              error "vhd-tool failed, returning VDI_IO_ERROR" ;
-              raise
-                (Api_errors.Server_error
-                   (Api_errors.vdi_io_error, ["Device I/O errors"])
-                )
-            )
-        )
-      with
-      | Success (out, _) ->
-          debug "%s" out
-      | Failure (out, e) ->
-          error "vhd-tool output: %s" out ;
-          raise e
-    )
-    (fun () -> close pipe_read ; close pipe_write)
-
 let receive progress_cb format protocol (s : Unix.file_descr)
     (length : int64 option) (path : string) (prefix : string) (prezeroed : bool)
     =
@@ -114,7 +60,8 @@ let receive progress_cb format protocol (s : Unix.file_descr)
     else
       []
   in
-  run_vhd_tool progress_cb args s s' path
+  Vhd_qcow_parsing.run_tool !Xapi_globs.vhd_tool args ~progress_cb
+    ~replace_fds:[(s', s)]
 
 let read_vhd_header path ~legacy =
   let vhd_tool = !Xapi_globs.vhd_tool in
@@ -132,7 +79,7 @@ let read_vhd_header path ~legacy =
       (fun () ->
         Xapi_stdext_pervasives.Pervasiveext.finally
           (fun () ->
-            Vhd_qcow_parsing.run_tool vhd_tool progress_cb args
+            Vhd_qcow_parsing.run_tool vhd_tool args ~progress_cb
               ~output_fd:pipe_writer
           )
           (fun () -> Unix.close pipe_writer)
@@ -213,4 +160,5 @@ let send progress_cb ?relative_to (protocol : string) (dest_format : string)
     ]
     @ match relative_to with None -> [] | Some x -> ["--relative-to"; x]
   in
-  run_vhd_tool progress_cb args s s' path
+  Vhd_qcow_parsing.run_tool !Xapi_globs.vhd_tool args ~progress_cb
+    ~replace_fds:[(s', s)]

--- a/python3/libexec/qcow2-to-stdout.py
+++ b/python3/libexec/qcow2-to-stdout.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # This tool reads a disk image in any format and converts it to qcow2,
-# writing the result directly to stdout.
+# writing the result directly to the provided output file.
 #
 # Copyright (C) 2024 Igalia, S.L.
 #
@@ -150,7 +150,7 @@ class Interval:
         return self.intervals.__iter__()
 
 
-def write_qcow2_content(input_file, cluster_size, refcount_bits,
+def write_qcow2_content(input_file, output_file, cluster_size, refcount_bits,
                         data_file_name, data_file_raw, diff_file_name,
                         virtual_size, nonzero_clusters,
                         diff_virtual_size, diff_nonzero_clusters):
@@ -362,7 +362,7 @@ def write_qcow2_content(input_file, cluster_size, refcount_bits,
 
     write_features(cluster, hdr_length, data_file_name)
 
-    sys.stdout.buffer.write(cluster)
+    output_file.buffer.write(cluster)
 
     ### Write refcount table
     cur_offset = refcount_block_offset
@@ -374,7 +374,7 @@ def write_qcow2_content(input_file, cluster_size, refcount_bits,
         for idx in range(to_write):
             struct.pack_into(">Q", cluster, idx * 8, cur_offset)
             cur_offset += cluster_size
-        sys.stdout.buffer.write(cluster)
+        output_file.buffer.write(cluster)
 
     ### Write refcount blocks
     remaining_refcount_block_entries = total_allocated_clusters # One entry for each allocated cluster
@@ -399,7 +399,7 @@ def write_qcow2_content(input_file, cluster_size, refcount_bits,
                 cluster[idx // 4] |= 1 << ((idx % 4) * 2)
             elif refcount_bits == 1:
                 cluster[idx // 8] |= 1 << (idx % 8)
-        sys.stdout.buffer.write(cluster)
+        output_file.buffer.write(cluster)
 
     ### Write L1 table
     cur_offset = l2_table_offset
@@ -410,7 +410,7 @@ def write_qcow2_content(input_file, cluster_size, refcount_bits,
             if bitmap_is_set(l1_bitmap, l1_idx):
                 struct.pack_into(">Q", cluster, idx * 8, cur_offset | QCOW_OFLAG_COPIED)
                 cur_offset += cluster_size
-        sys.stdout.buffer.write(cluster)
+        output_file.buffer.write(cluster)
 
     ### Write L2 tables
     cur_offset = data_clusters_offset
@@ -427,16 +427,22 @@ def write_qcow2_content(input_file, cluster_size, refcount_bits,
                         cur_offset += cluster_size
                     else:
                         struct.pack_into(">Q", cluster, idx * 8, (l2_idx * cluster_size) | QCOW_OFLAG_COPIED)
-            sys.stdout.buffer.write(cluster)
+            output_file.buffer.write(cluster)
 
     ### Write data clusters
+    prev_percent = 0
     if data_file_name is None:
-        for idx in bitmap_iterator(l2_bitmap, total_data_clusters):
+        for count, idx in enumerate(bitmap_iterator(l2_bitmap, total_data_clusters)):
             cluster = os.pread(fd, cluster_size, cluster_size * idx)
             # If the last cluster is smaller than cluster_size pad it with zeroes
             if len(cluster) < cluster_size:
                 cluster += bytes(cluster_size - len(cluster))
-            sys.stdout.buffer.write(cluster)
+            output_file.buffer.write(cluster)
+            # Write progress percentages out
+            percent = (count * 100) // allocated_data_clusters
+            if percent > prev_percent and percent < 100:
+                print(f'{percent:03}', end='', flush=True)
+                prev_percent = percent
 
     if not data_file_raw:
         os.close(fd)
@@ -446,7 +452,7 @@ def main():
     # Command-line arguments
     parser = argparse.ArgumentParser(
         description="This program converts a QEMU disk image to qcow2 "
-        "and writes it to the standard output"
+        "and writes it to the provided output file"
     )
     parser.add_argument("input_file", help="name of the input file")
     parser.add_argument(
@@ -457,6 +463,13 @@ def main():
                 "If specified, will only export clusters that are different "
                 "between the files"),
         default=None,
+    )
+    parser.add_argument(
+        "--output",
+        dest="output",
+        help="File descriptor of the output file",
+        type=int,
+        required=True
     )
     parser.add_argument(
         "-c",
@@ -532,6 +545,7 @@ def main():
     diff_virtual_size = None
     diff_nonzero_clusters = None
 
+    output_file = os.fdopen(args.output, mode='w')
     def parse_json_files(info_fd, map_fd):
         map_f = os.fdopen(map_fd)
         info_f = os.fdopen(info_fd)
@@ -566,7 +580,7 @@ def main():
     if args.data_file and args.cluster_size == 512:
         sys.exit("[Error] External data files require a larger cluster size")
 
-    if sys.stdout.isatty():
+    if output_file.isatty():
         sys.exit("[Error] Refusing to write to a tty. Try redirecting stdout.")
 
     if args.data_file:
@@ -576,6 +590,7 @@ def main():
 
     write_qcow2_content(
         args.input_file,
+        output_file,
         args.cluster_size,
         args.refcount_bits,
         data_file_name,


### PR DESCRIPTION
Depends on https://github.com/xapi-project/xs-opam/pull/771 being merged for progress reporting to be fixed completely.

Proceeds in three steps:
1) consolidates vhd and qcow `run_tool` to use the same code (with the same progress reading logic)
2) adds progress reporting to the qcow export side (python `qcow2-to-stdout` script)
3) adds progress reporting to the qcow import side (above xs-opam PR + supplied callback)