### PR TITLE
Add debug messages for all connection methods in the `xe` CLI client

### DIFF
--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -377,6 +377,7 @@ let with_open_tcp server f =
       | addrinfo :: _ ->
           addrinfo.Unix.ai_addr
     in
+    debug "Connecting via TCP to [%s] port [%d]\n%!" server port ;
     let open Safe_resources in
     Unixfd.with_open_connection ~loc:__LOC__ addr @@ fun ufd ->
     Unixfd.with_channels ufd f
@@ -386,15 +387,20 @@ let with_open_channels f =
     try Ok (f chs) with e -> Backtrace.is_important e ; Error e
   in
   let result =
-    if is_localhost !xapiserver then
+    if is_localhost !xapiserver then (
       try
+        let unix_socket_path = Filename.concat "/var/lib/xcp" "xapi" in
+        debug "Connecting to Unix socket [%s]%!" unix_socket_path ;
         let open Safe_resources in
-        Unixfd.with_open_connection
-          (Unix.ADDR_UNIX (Filename.concat "/var/lib/xcp" "xapi"))
+        Unixfd.with_open_connection (Unix.ADDR_UNIX unix_socket_path)
           ~loc:__LOC__
-        @@ fun chs -> Unixfd.with_channels chs wrap
-      with _ -> with_open_tcp !xapiserver wrap
-    else
+        @@ fun chs ->
+        debug "\n%!" ;
+        Unixfd.with_channels chs wrap
+      with _ ->
+        debug " failed\n%!" ;
+        with_open_tcp !xapiserver wrap
+    ) else
       with_open_tcp !xapiserver wrap
   in
   match result with Ok r -> r | Error e -> raise e


### PR DESCRIPTION
## Summary

This PR adds debug messages to `ocaml/xe-cli/newcli.ml` to improve diagnosability of the `xe` command-line client when the `--debug` flag is used.

## Context

The `xe` client forwards its arguments to the `Xapi` server, which does the actual processing. Depending on the context, the client connects to the server using one of the following methods:

- *Remote server, SSL*: connection via stunnel
- *Remote server, plain TCP*: unencrypted TCP connection
- *Local server, Unix socket*: preferred method when client and server run on the same host
- *Local server, plain TCP*: fallback when the Unix socket connection fails

Before this PR, a debug message indicating which server the client was attempting to connect to was emitted only in the first case (remote server via SSL/stunnel). The three other connection methods produced no such message, making it harder to understand the client's behavior when troubleshooting or exploring the code.

## Changes

Debug messages are now emitted for all four connection methods when =--debug= is passed on `xe`'s command line. This makes it possible to always know which server the client is connecting to, and via which method, regardless of the connection type being used.

## Notes

This behaviour was discovered incidentally while investigating unrelated work. There is no associated issue.