### PR TITLE
xenopsd/xc: sync domain.ml with Xen 4.21's Xenctrl ABI additions

### DIFF
--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -394,8 +394,7 @@ let make ~xc ~xs vm_info vcpus domain_config uuid final_uuid no_sharept
       Ok ()
   in
   let trap_unmapped_accesses =
-    get_platform_key ~key:"trap-unmapped-accesses" ~default:is_arm
-      require_arm
+    get_platform_key ~key:"trap-unmapped-accesses" ~default:is_arm require_arm
   in
 
   info "VM = %s; Creating %s%s%s%s%s%s" (Uuidx.to_string uuid)

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -108,6 +108,7 @@ type domctl_create_config = Xenctrl.domctl_create_config = {
   ; max_maptrack_frames: int
   ; max_grant_version: int
   ; altp2m_opts: int32
+  ; altp2m_count: int32
   ; vmtrace_buf_kb: int32
   ; cpupool_id: int32
   ; arch: arch_domainconfig
@@ -518,6 +519,7 @@ let make ~xc ~xs vm_info vcpus domain_config uuid final_uuid no_sharept
             1
         )
     ; altp2m_opts= 0l
+    ; altp2m_count= 0l
     ; vmtrace_buf_kb= 0l
     ; cpupool_id= 0l
     ; arch= domain_config

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -74,6 +74,7 @@ type domain_create_flag = Xenctrl.domain_create_flag =
   | CDF_IOMMU
   | CDF_NESTED_VIRT
   | CDF_VPMU
+  | CDF_TRAP_UNMAPPED_ACCESSES
 [@@deriving rpcty]
 
 type domain_create_iommu_opts = Xenctrl.domain_create_iommu_opts =

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -380,7 +380,25 @@ let make ~xc ~xs vm_info vcpus domain_config uuid final_uuid no_sharept
   in
   let vpmu = get_platform_key ~key:"vpmu" ~default:false (fun _ -> Ok ()) in
 
-  info "VM = %s; Creating %s%s%s%s%s" (Uuidx.to_string uuid)
+  let is_arm =
+    match (domain_config : arch_domainconfig) with
+    | ARM _ ->
+        true
+    | X86 _ ->
+        false
+  in
+  let require_arm wants : (_, _) result =
+    if wants && not is_arm then
+      Error "Arm required for"
+    else
+      Ok ()
+  in
+  let trap_unmapped_accesses =
+    get_platform_key ~key:"trap-unmapped-accesses" ~default:is_arm
+      require_arm
+  in
+
+  info "VM = %s; Creating %s%s%s%s%s%s" (Uuidx.to_string uuid)
     ( if hvm then
         "HVM"
       else
@@ -405,6 +423,11 @@ let make ~xc ~xs vm_info vcpus domain_config uuid final_uuid no_sharept
         " VPMU"
       else
         ""
+    )
+    ( if trap_unmapped_accesses then
+        " TRAP_UNMAPPED_ACCESSES"
+      else
+        ""
     ) ;
 
   let config =
@@ -418,6 +441,7 @@ let make ~xc ~xs vm_info vcpus domain_config uuid final_uuid no_sharept
         ; (iommu, CDF_IOMMU)
         ; (nested_virt, CDF_NESTED_VIRT)
         ; (vpmu, CDF_VPMU)
+        ; (trap_unmapped_accesses, CDF_TRAP_UNMAPPED_ACCESSES)
         ]
         |> List.filter_map (fun (cond, flag) ->
             if cond then


### PR DESCRIPTION
`ocaml/xenopsd/xc/domain.ml` mirrors `Xenctrl.domain_create_flag` and `Xenctrl.domctl_create_config`, both of which require listing every constructor/field of the real type. Xen 4.21 added items to these types that were missing from `domain.ml`, and in one case the mirror being incomplete masked a second issue: the corresponding flag was never actually being set anywhere.

- `CDF_TRAP_UNMAPPED_ACCESSES` on `domain_create_flag` (currently Arm-only):
      - xen.git 980aff4e8fcd "xen/arm: Add way to disable traps on
        accesses to unmapped addresses" (Edgar E. Iglesias, 2025-06-16)
      - xen.git ab02a120c0a5 "tools/ocaml: Update bindings for
        CDF_TRAP_UNMAPPED_ACCESSES" (same day)
- pre-existing altp2m.nr field alongside altp2m_opts:
      - xen.git 5699554de9a9 "tools/ocaml: Add altp2m_count parameter"
        (Petr Beneš, 2025-08-25)

Both have been part of the public Xen ABI since before the 4.21.0-rc1 tag, so any build compiling xapi against Xen 4.21's actual OCaml Xenctrl bindings fails at this type check.

Once the mirror type-checked, I could actually run an Arm domain through xenopsd against a real Xen 4.21, which showed a second bug: `domain.ml` never sets `CDF_TRAP_UNMAPPED_ACCESSES` in the flags list that `make` passes to `Xenctrl.domain_create`, even though the type now lists it. Without it, Xen traps guest accesses to unmapped addresses instead of letting the guest handle them directly. On Arm this fires very early in the kernel's own boot code, before it has installed its own exception vector table, so the resulting injected exception lands at a fixed vector offset off a zero base, which itself is unmapped, and the guest immediately double-faults into an infinite loop.

libxl already sets this flag unconditionally for Arm domains (`libxl__arch_domain_prepare_config()` in `tools/libs/light/libxl_arm.c`), which is why a domain built with `xl create` for the exact same kernel/ramdisk/memory boots fine while the identical domain built through xenopsd's `Xenctrl.domain_create` never did. Confirmed by comparing the actual `xen_domctl_createdomain` contents both toolstacks send to `xc_domain_create()` for the same config: xenopsd sent flags=0x3 (`CDF_HVM|CDF_HAP`), libxl sent flags=0x103 (adding `CDF_TRAP_UNMAPPED_ACCESSES`, bit 8), which was the only difference between the  two, and setting it here reproducibly fixes the guest boot hang.

`domain_create_flag` is shared between the Arm and x86 xenopsd builds, and Xen's x86 `arch_sanitise_domain_config()` rejects domain creation with -EINVAL if this flag is set on x86 (`xen/arch/x86/domain.c`), so it's gated on the domain's `arch_domainconfig` rather than set unconditionally.

## Testing
  
Found and verified while building xapi/xenopsd for aarch64 against a freshly built Xen 4.21.1 (linking directly against Xen's own `tools/ocaml/libs/xc` output). Confirmed the build fails without the first two commits and succeeds with them applied, with no other call sites needing changes (only `domain.ml` references either type).
Confirmed the third commit by booting a plain Arm PVH domain end-to-end through xapi/xenopsd (same kernel+initramfs xapi's own dom0 uses): it hung every time with the flag unset (same crash signature) and boots cleanly and consistently once set, matching `xl create`'s own behaviour for an identical domain config.

Side question: the xenctrl opam package CI pulls in (xapi-project/xenctrl, via xs-opam) also doesn't have these Xen additions. Would that need updating as well?