### PR TITLE
CP-312082 Implement APIs for configuration of lldp

### DIFF
--- a/doc/content/design/lldp.md
+++ b/doc/content/design/lldp.md
@@ -22,7 +22,7 @@ The following are introduced by this design:
 The implementation uses XAPI for configuration, networkd for per-host application of configuration, and [`lldpd`](https://github.com/lldpd/lldpd) as the LLDP agent in dom0 user space.
 XAPI stores LLDP configuration in the database and exposes LLDP neighbor data through XenAPI.
 networkd configures the LLDP agent to apply LLDP configuration for individual physical NICs and queries the LLDP agent for received LLDP TLVs.
-`lldpd` runs as a daemon process in dom0 user space. It receives and sends LLDPDUs via PF_PACKET + SOCK_RAW sockets. It is actively maintained by upstream as the time being.
+`lldpd` runs as a daemon process in dom0 user space. It receives and sends LLDPDUs via PF_PACKET + SOCK_RAW sockets. It is actively maintained by upstream for the time being.
 
 ## XAPI database changes
 
@@ -37,7 +37,7 @@ When `false`, LLDP is disabled on the NIC associated with each managed physical 
 
 This setting does not apply to other types of PIFs, such as non-managed PIFs, bond PIFs, VLAN PIFs, tunnel PIFs, or SR-IOV PIFs.
 
-`PIF.lldp_mode` determines the final effective state on individul PIF.
+`PIF.lldp_mode` determines the final effective state on individual PIF.
 
 LLDP receiving and advertising are always enabled or disabled together.
 
@@ -72,7 +72,7 @@ Values:
 - `nearestcustomerbridge`: `01:80:C2:00:00:00`
 
 This value controls the multicast MAC address used for LLDP transmission.
-After a change, it is applied when `pool.set_lldp_enabled` or `PIF.set_lldp_mode` is called with `force=true`.
+After a change, it is applied when `pool.set_lldp_enabled` or `PIF.set_lldp_mode` is called (can apply with `force=true` if enabled or mode is not changed).
 This value is not considered to change often. Changing it does not trigger any application action for simplicity.
 
 Default after update/RPU from a version/release without LLDP support to a version/release with LLDP support: `nearestbridge`.
@@ -122,7 +122,7 @@ Behavior:
 ## The networkd database
 
 The `interface_config_t` record in the networkd database is extended with LLDP configuration. networkd can configure LLDP independently using its own database when XAPI is unavailable, for example during host boot.
-The default enabled setting is `false` to minimize impact without high-level configuration from XAPI or the user. This database can be updated as XAPI pushes configurtions to networkd through networkd calls.
+The default enabled setting is `false` to minimize impact without high-level configuration from XAPI or the user. This database can be updated as XAPI pushes configurations to networkd through networkd calls.
 
 ```ocaml
 type lldp_multicast_address =
@@ -136,8 +136,8 @@ type lldp = {
 ; chassis_id: string [@default ""]
 ; system_name: string [@default ""]
 ; system_description: string [@default ""]
-; enabled: bool [@default false];
-; address: lldp_multicast_address list [@default [Nearestbridge]];
+; enabled: bool [@default false]
+; address: lldp_multicast_address list [@default [Nearestbridge]]
 }
 [@@deriving rpcty]
 
@@ -212,7 +212,7 @@ type iface_stats = {
   lldp_neighbor: lldp_rx option;
 }
 ```
-networkd queries `lldpd` for the LLDP TLVs recevied on individual NICs and writes them into `/dev/shm/network_stats`.
+networkd queries `lldpd` for the LLDP TLVs received on individual NICs and writes them into `/dev/shm/network_stats`.
 Monitor_dbcalls.monitor_dbcall_thread in XAPI reads the in-memory file `/dev/shm/network_stats` periodically, and exposes the data through `PIF_metrics.lldp_neighbor` by storing them in XenAPI map form.
 
 ## Scenarios

--- a/doc/content/design/lldp.md
+++ b/doc/content/design/lldp.md
@@ -51,15 +51,15 @@ Type: `enum pif_lldp_mode`
 
 Values:
 
-- `default`: follow `pool.lldp_enabled`;
+- `inherited`: follow `pool.lldp_enabled`;
 - `enabled`: LLDP is enabled on the NIC associated with the managed physical PIF;
 - `disabled`: LLDP is disabled on the NIC associated with the managed physical PIF.
 
 This setting does not apply to other types of PIFs, such as non-managed PIFs, bond PIFs, VLAN PIFs, tunnel PIFs, or SR-IOV PIFs.
 
-Default after update/RPU from a version/release without LLDP support to a version/release with LLDP support: `default`.
+Default after update/RPU from a version/release without LLDP support to a version/release with LLDP support: `inherited`.
 
-Default after fresh install: `default`.
+Default after fresh install: `inherited`.
 
 ### `pool.lldp_multicast_address`
 
@@ -110,7 +110,7 @@ Behavior:
 Parameters:
 
 - `self`: the PIF reference;
-- `value`: `default`, `enabled`, or `disabled`;
+- `value`: `inherited`, `enabled`, or `disabled`;
 - `force`: `bool`, default `false`.
 
 Behavior:
@@ -172,9 +172,9 @@ The effective LLDP state on a NIC is determined by `pool.lldp_enabled`, `PIF.lld
 
 | `pool.lldp_enabled` | `PIF.lldp_mode` | parameter passed to networkd | NIC driver in blocking list | effective LLDP state |
 | --- | --- | --- | --- | --- |
-| `true` | `default` | `true` | `no` | `enabled` |
-| `true` | `default` | `true` | `yes` | `disabled` |
-| `false` | `default` | `false` | `*` | `disabled` |
+| `true` | `inherited` | `true` | `no` | `enabled` |
+| `true` | `inherited` | `true` | `yes` | `disabled` |
+| `false` | `inherited` | `false` | `*` | `disabled` |
 | `*` | `enabled` | `true` | `*` | `enabled` |
 | `*` | `disabled` | `false` | `*` | `disabled` |
 

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -2265,6 +2265,42 @@ module PIF = struct
       ~lifecycle:[(Published, rel_tampa, "")]
       ~allowed_roles:_R_POOL_OP ()
 
+  let lldp_mode =
+    Enum
+      ( "pif_lldp_mode"
+      , [
+          ("default", "LLDP is enabled or disabled based on pool.lldp_enabled.")
+        ; ( "enabled"
+          , "LLDP is enabled on the NIC of the managed physical PIF, \
+             overriding pool.lldp_enabled."
+          )
+        ; ( "disabled"
+          , "LLDP is disabled on the NIC of the managed physical PIF, \
+             overriding pool.lldp_enabled."
+          )
+        ]
+      )
+
+  let set_lldp_mode =
+    call ~name:"set_lldp_mode" ~lifecycle:[]
+      ~doc:
+        "Set the LLDP mode of this PIF, then apply the change by re-plugging \
+         the PIF. Only valid for managed physical PIFs."
+      ~params:
+        [
+          (Ref _pif, "self", "the PIF object to reconfigure")
+        ; ( lldp_mode
+          , "value"
+          , "the LLDP mode to set (default, enabled or disabled)"
+          )
+        ; ( Bool
+          , "force"
+          , "When true, apply the change even if value already matches the \
+             current PIF.lldp_mode; otherwise apply only when value differs."
+          )
+        ]
+      ~allowed_roles:_R_POOL_OP ()
+
   let scan =
     call ~name:"scan"
       ~doc:
@@ -2574,22 +2610,6 @@ module PIF = struct
         ]
       )
 
-  let lldp_mode =
-    Enum
-      ( "pif_lldp_mode"
-      , [
-          ("default", "LLDP is enabled or disabled based on pool.lldp_enabled.")
-        ; ( "enabled"
-          , "LLDP is enabled on the NIC of the managed physical PIF, \
-             overriding pool.lldp_enabled."
-          )
-        ; ( "disabled"
-          , "LLDP is disabled on the NIC of the managed physical PIF, \
-             overriding pool.lldp_enabled."
-          )
-        ]
-      )
-
   let t =
     create_obj ~in_db:true
       ~lifecycle:
@@ -2624,6 +2644,7 @@ module PIF = struct
         ; db_introduce
         ; db_forget
         ; set_property
+        ; set_lldp_mode
         ]
       ~contents:
         [

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -2269,7 +2269,9 @@ module PIF = struct
     Enum
       ( "pif_lldp_mode"
       , [
-          ("default", "LLDP is enabled or disabled based on pool.lldp_enabled.")
+          ( "inherited"
+          , "LLDP is enabled or disabled based on pool.lldp_enabled."
+          )
         ; ( "enabled"
           , "LLDP is enabled on the NIC of the managed physical PIF, \
              overriding pool.lldp_enabled."
@@ -2291,7 +2293,7 @@ module PIF = struct
           (Ref _pif, "self", "the PIF object to reconfigure")
         ; ( lldp_mode
           , "value"
-          , "the LLDP mode to set (default, enabled or disabled)"
+          , "the LLDP mode to set (inherited, enabled or disabled)"
           )
         ; ( Bool
           , "force"
@@ -2929,7 +2931,7 @@ module PIF = struct
             ~default_value:(Some (VRef null_ref)) "PCI"
             "Link to underlying PCI device"
         ; field ~qualifier:DynamicRO ~ty:lldp_mode ~lifecycle:[]
-            ~default_value:(Some (VEnum "default")) "lldp_mode"
+            ~default_value:(Some (VEnum "inherited")) "lldp_mode"
             "The LLDP mode of the physical NIC for the PIF. This setting does \
              not apply to other types of PIFs, such as non-managed PIFs, bond \
              PIFs, VLAN PIFs, tunnel PIFs, or SR-IOV PIFs."

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -2574,6 +2574,22 @@ module PIF = struct
         ]
       )
 
+  let lldp_mode =
+    Enum
+      ( "pif_lldp_mode"
+      , [
+          ("default", "LLDP is enabled or disabled based on pool.lldp_enabled.")
+        ; ( "enabled"
+          , "LLDP is enabled on the NIC of the managed physical PIF, \
+             overriding pool.lldp_enabled."
+          )
+        ; ( "disabled"
+          , "LLDP is disabled on the NIC of the managed physical PIF, \
+             overriding pool.lldp_enabled."
+          )
+        ]
+      )
+
   let t =
     create_obj ~in_db:true
       ~lifecycle:
@@ -2891,6 +2907,11 @@ module PIF = struct
             ~lifecycle:[(Published, rel_kolkata, "")]
             ~default_value:(Some (VRef null_ref)) "PCI"
             "Link to underlying PCI device"
+        ; field ~qualifier:DynamicRO ~ty:lldp_mode ~lifecycle:[]
+            ~default_value:(Some (VEnum "default")) "lldp_mode"
+            "The LLDP mode of the physical NIC for the PIF. This setting does \
+             not apply to other types of PIFs, such as non-managed PIFs, bond \
+             PIFs, VLAN PIFs, tunnel PIFs, or SR-IOV PIFs."
         ]
       ()
 end

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -2489,8 +2489,8 @@ let t =
             "When true, LLDP is enabled on the NIC associated with each \
              managed physical PIF on every host in the pool. When false, it is \
              disabled. However, it can be overwritten by PIF.lldp_mode \
-             settings when mode is not default. LLDP receiving and advertising \
-             are always enabled or disabled together."
+             settings when mode is not inherited. LLDP receiving and \
+             advertising are always enabled or disabled together."
         ; field ~writer_roles:_R_POOL_OP ~qualifier:RW ~lifecycle:[]
             ~ty:lldp_multicast_address
             ~default_value:(Some (VEnum "nearestbridge"))

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1190,6 +1190,29 @@ let set_igmp_snooping_enabled =
     ~doc:"Enable or disable IGMP Snooping on the pool."
     ~allowed_roles:_R_POOL_OP ()
 
+let set_lldp_enabled =
+  call ~name:"set_lldp_enabled" ~lifecycle:[]
+    ~doc:
+      "Enable or disable LLDP on the NIC of every managed physical PIF in the \
+       pool, then apply the change by re-plugging the affected PIFs."
+    ~params:
+      [
+        (Ref _pool, "self", "The pool")
+      ; (Bool, "value", "true to enable LLDP, false to disable it")
+      ; ( Bool
+        , "force"
+        , "When true, apply the change to all managed physical PIFs even if \
+           value already matches pool.lldp_enabled; otherwise apply only when \
+           value differs from pool.lldp_enabled."
+        )
+      ]
+    ~result:
+      ( Map (Ref _pif, String)
+      , "A map of the PIFs that failed to be reconfigured and the \
+         corresponding error message."
+      )
+    ~allowed_roles:_R_POOL_OP ()
+
 let has_extension =
   call ~name:"has_extension"
     ~lifecycle:
@@ -1869,6 +1892,7 @@ let t =
       ; enable_ssl_legacy
       ; disable_ssl_legacy
       ; set_igmp_snooping_enabled
+      ; set_lldp_enabled
       ; has_extension
       ; add_to_guest_agent_config
       ; remove_from_guest_agent_config

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1782,6 +1782,24 @@ let exchange_crls_on_join =
     ~allowed_roles:(_R_POOL_OP ++ _R_CLIENT_CERT)
     ~hide_from_docs:true ~lifecycle:[] ()
 
+let lldp_multicast_address =
+  Enum
+    ( "lldp_multicast_address"
+    , [
+        ( "nearestbridge"
+        , "Nearest bridge group address (MAC 01:80:C2:00:00:0E). LLDP frames \
+           reach only the immediate neighbor on the physical link."
+        )
+      ; ( "nearestnontpmrbridge"
+        , "Nearest non-TPMR (Two-Port MAC Relay) bridge group address (MAC \
+           01:80:C2:00:00:03)."
+        )
+      ; ( "nearestcustomerbridge"
+        , "Nearest customer bridge group address (MAC 01:80:C2:00:00:00)."
+        )
+      ]
+    )
+
 (** A pool class *)
 let t =
   create_obj ~in_db:true
@@ -2442,6 +2460,19 @@ let t =
              /import_metadata calls and disaster recovery (VM.recover and \
              VM_appliance.recover); it does not apply to VM.clone or VM.copy, \
              which inherit the source VM's state."
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Bool
+            ~default_value:(Some (VBool false)) "lldp_enabled"
+            "When true, LLDP is enabled on the NIC associated with each \
+             managed physical PIF on every host in the pool. When false, it is \
+             disabled. However, it can be overwritten by PIF.lldp_mode \
+             settings when mode is not default. LLDP receiving and advertising \
+             are always enabled or disabled together."
+        ; field ~writer_roles:_R_POOL_OP ~qualifier:RW ~lifecycle:[]
+            ~ty:lldp_multicast_address
+            ~default_value:(Some (VEnum "nearestbridge"))
+            "lldp_multicast_address"
+            "The multicast MAC address used for LLDP advertising. To apply a \
+             change, use pool.set_lldp_enabled with force=true."
         ]
       )
     ()

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -2488,15 +2488,15 @@ let t =
             ~default_value:(Some (VBool false)) "lldp_enabled"
             "When true, LLDP is enabled on the NIC associated with each \
              managed physical PIF on every host in the pool. When false, it is \
-             disabled. However, it can be overwritten by PIF.lldp_mode \
-             settings when mode is not inherited. LLDP receiving and \
-             advertising are always enabled or disabled together."
+             disabled. However, it can be overridden by PIF.lldp_mode settings \
+             when mode is not inherited. LLDP receiving and advertising are \
+             always enabled or disabled together."
         ; field ~writer_roles:_R_POOL_OP ~qualifier:RW ~lifecycle:[]
             ~ty:lldp_multicast_address
             ~default_value:(Some (VEnum "nearestbridge"))
             "lldp_multicast_address"
             "The multicast MAC address used for LLDP advertising. To apply a \
-             change, use pool.set_lldp_enabled with force=true."
+             change, use pool.set_lldp_enabled(with force=true)."
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "b88f7174944ef37e6f2c53b5232465e9"
+let last_known_schema_hash = "e5bb3f3b53e89a81d7a7fcee7ead9efe"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -338,7 +338,8 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~ext_auth_cache_expiry:300L ~update_sync_frequency ~update_sync_day
     ~update_sync_enabled ~recommendations ~license_server
     ~ha_reboot_vm_on_internal_shutdown ~limit_console_sessions
-    ~vm_console_idle_timeout ~auto_update_vm_secureboot_certificates ;
+    ~vm_console_idle_timeout ~auto_update_vm_secureboot_certificates
+    ~lldp_enabled:false ~lldp_multicast_address:`nearestbridge ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -498,6 +498,16 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "pool-set-lldp-enabled"
+    , {
+        reqd= ["value"]
+      ; optn= ["uuid"; "force"]
+      ; help=
+          "Enable or disable LLDP on every managed physical PIF in the pool."
+      ; implementation= No_fd Cli_operations.pool_set_lldp_enabled
+      ; flags= []
+      }
+    )
   ; ( "pool-set-vswitch-controller"
     , {
         reqd= ["address"]
@@ -2120,6 +2130,17 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; optn= []
       ; help= "Change the primary address type used by this PIF."
       ; implementation= No_fd Cli_operations.pif_set_primary_address_type
+      ; flags= []
+      }
+    )
+  ; ( "pif-set-lldp-mode"
+    , {
+        reqd= ["uuid"; "value"]
+      ; optn= ["force"]
+      ; help=
+          "Set the LLDP mode (default, enabled or disabled) of a managed \
+           physical PIF."
+      ; implementation= No_fd Cli_operations.pif_set_lldp_mode
       ; flags= []
       }
     )

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -2138,7 +2138,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
         reqd= ["uuid"; "value"]
       ; optn= ["force"]
       ; help=
-          "Set the LLDP mode (default, enabled or disabled) of a managed \
+          "Set the LLDP mode (inherited, enabled or disabled) of a managed \
            physical PIF."
       ; implementation= No_fd Cli_operations.pif_set_lldp_mode
       ; flags= []

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1945,6 +1945,20 @@ let pool_disable_client_certificate_auth _printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
   Client.Pool.disable_client_certificate_auth ~rpc ~session_id ~self:pool
 
+let pool_set_lldp_enabled printer rpc session_id params =
+  let pool = get_pool_with_default rpc session_id params "uuid" in
+  let value = bool_of_string "value" (List.assoc "value" params) in
+  let force = get_bool_param params "force" in
+  let failures =
+    Client.Pool.set_lldp_enabled ~rpc ~session_id ~self:pool ~value ~force
+  in
+  let table =
+    List.map
+      (fun (pif, msg) -> (Client.PIF.get_uuid ~rpc ~session_id ~self:pif, msg))
+      failures
+  in
+  printer (Cli_printer.PTable [table])
+
 let pool_sync_updates printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
   let force = get_bool_param params "force" in
@@ -6710,6 +6724,14 @@ let pif_set_primary_address_type _printer rpc session_id params =
       ~primary_address_type
   in
   ()
+
+let pif_set_lldp_mode _printer rpc session_id params =
+  let pif =
+    Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+  in
+  let value = Record_util.pif_lldp_mode_of_string (List.assoc "value" params) in
+  let force = get_bool_param params "force" in
+  Client.PIF.set_lldp_mode ~rpc ~session_id ~self:pif ~value ~force
 
 let pif_unplug _printer rpc session_id params =
   let pif =

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -736,6 +736,11 @@ let pif_record rpc session_id pif =
               (x ()).API.pIF_igmp_snooping_status
           )
           ()
+      ; make_field ~name:"lldp-mode"
+          ~get:(fun () ->
+            Record_util.pif_lldp_mode_to_string (x ()).API.pIF_lldp_mode
+          )
+          ()
       ]
   }
 
@@ -1335,6 +1340,19 @@ let pool_record rpc session_id pool =
           ~set:(fun x ->
             Client.Pool.set_igmp_snooping_enabled ~rpc ~session_id ~self:pool
               ~value:(bool_of_string x)
+          )
+          ()
+      ; make_field ~name:"lldp-enabled"
+          ~get:(fun () -> string_of_bool (x ()).API.pool_lldp_enabled)
+          ()
+      ; make_field ~name:"lldp-multicast-address"
+          ~get:(fun () ->
+            Record_util.lldp_multicast_address_to_string
+              (x ()).API.pool_lldp_multicast_address
+          )
+          ~set:(fun v ->
+            Client.Pool.set_lldp_multicast_address ~rpc ~session_id ~self:pool
+              ~value:(Record_util.lldp_multicast_address_of_string v)
           )
           ()
       ; make_field ~name:"gui-config"

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -55,7 +55,8 @@ let create_pool_record ~__context =
       ~ext_auth_cache_size:50L ~ext_auth_cache_expiry:300L ~recommendations:[]
       ~license_server:[] ~ha_reboot_vm_on_internal_shutdown:true
       ~limit_console_sessions:false ~vm_console_idle_timeout:0L
-      ~auto_update_vm_secureboot_certificates:false
+      ~auto_update_vm_secureboot_certificates:false ~lldp_enabled:true
+      ~lldp_multicast_address:`nearestbridge
 
 let set_master_ip ~__context =
   let ip =

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1017,6 +1017,12 @@ functor
           value ;
         Local.Pool.set_igmp_snooping_enabled ~__context ~self ~value
 
+      let set_lldp_enabled ~__context ~self ~value ~force =
+        info "Pool.set_lldp_enabled: Pool = '%s', value = %B, force = %B"
+          (pool_uuid ~__context self)
+          value force ;
+        Local.Pool.set_lldp_enabled ~__context ~self ~value ~force
+
       let has_extension ~__context ~self ~name =
         info "Pool.has_extension: pool = '%s'; name = '%s'"
           (pool_uuid ~__context self)
@@ -4997,6 +5003,13 @@ functor
         in
         let host = Db.PIF.get_host ~__context ~self in
         do_op_on ~local_fn ~__context ~host ~remote_fn
+
+      let set_lldp_mode ~__context ~self ~value ~force =
+        info "PIF.set_lldp_mode: PIF = '%s'; value = '%s'; force = %B"
+          (pif_uuid ~__context self)
+          (Record_util.pif_lldp_mode_to_string value)
+          force ;
+        Local.PIF.set_lldp_mode ~__context ~self ~value ~force
 
       let set_property ~__context ~self ~name ~value =
         info "PIF.set_property: PIF = '%s'; name = '%s'; value = '%s'"

--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -144,6 +144,8 @@ let create_bond ~__context bond mtu persistent =
           ; ethtool_settings
           ; ethtool_offload
           ; persistent_i= persistent
+          ; lldp=
+              determine_lldp ~__context (Db.PIF.get_record ~__context ~self:pif)
           }
         in
         (device, bridge, config)

--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -119,6 +119,42 @@ let determine_other_config ~__context pif_rc net_rc =
   (pool_oc |> Listext.update_assoc net_oc |> Listext.update_assoc pif_oc)
   @ additional
 
+(* Build the LLDP configuration to push to networkd for the NIC of a managed
+   physical PIF. The effective state follows the configuration matrix: an
+   explicit PIF.lldp_mode of enabled/disabled overrides the pool-wide
+   pool.lldp_enabled, and 'enabled' additionally sets 'force' to override the
+   networkd driver blocklist. *)
+let determine_lldp ~__context pif_rc =
+  let pool = Helpers.get_pool ~__context in
+  let host = pif_rc.API.pIF_host in
+  let enabled, force =
+    match pif_rc.API.pIF_lldp_mode with
+    | `enabled ->
+        (true, true)
+    | `disabled ->
+        (false, false)
+    | `default ->
+        (Db.Pool.get_lldp_enabled ~__context ~self:pool, false)
+  in
+  let address =
+    match Db.Pool.get_lldp_multicast_address ~__context ~self:pool with
+    | `nearestbridge ->
+        Nearest_bridge
+    | `nearestnontpmrbridge ->
+        Nearest_non_tpmr_bridge
+    | `nearestcustomerbridge ->
+        Nearest_customer_bridge
+  in
+  Some
+    {
+      force
+    ; chassis_id= Db.Host.get_uuid ~__context ~self:host
+    ; system_name= Db.Host.get_name_label ~__context ~self:host
+    ; system_description= Db.Host.get_name_description ~__context ~self:host
+    ; enabled
+    ; address= [address]
+    }
+
 let create_bond ~__context bond mtu persistent =
   (* Get all information we need from the DB before doing anything that may drop our
      	 * management connection *)
@@ -438,6 +474,7 @@ let rec create_bridges ~__context pif_rc net_rc =
             ; ethtool_settings
             ; ethtool_offload
             ; persistent_i= persistent
+            ; lldp= determine_lldp ~__context pif_rc
             }
           )
         ]

--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -133,7 +133,7 @@ let determine_lldp ~__context pif_rc =
         (true, true)
     | `disabled ->
         (false, false)
-    | `default ->
+    | `inherited ->
         (Db.Pool.get_lldp_enabled ~__context ~self:pool, false)
   in
   let address =

--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -500,7 +500,8 @@ let create ~__context ~network ~members ~mAC ~mode ~properties =
         ~other_config:[] ~disallow_unplug:false ~ipv6_configuration_mode:`None
         ~iPv6:[""] ~ipv6_gateway:""
         ~primary_address_type:primary_slave_address_type ~managed:true
-        ~properties:pif_properties ~capabilities:[] ~pCI:Ref.null ;
+        ~properties:pif_properties ~capabilities:[] ~pCI:Ref.null
+        ~lldp_mode:`default ;
       Db.Bond.create ~__context ~ref:bond
         ~uuid:(Uuidx.to_string (Uuidx.make ()))
         ~master ~other_config:[] ~primary_slave ~mode ~properties ~links_up:0L

--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -501,7 +501,7 @@ let create ~__context ~network ~members ~mAC ~mode ~properties =
         ~iPv6:[""] ~ipv6_gateway:""
         ~primary_address_type:primary_slave_address_type ~managed:true
         ~properties:pif_properties ~capabilities:[] ~pCI:Ref.null
-        ~lldp_mode:`default ;
+        ~lldp_mode:`inherited ;
       Db.Bond.create ~__context ~ref:bond
         ~uuid:(Uuidx.to_string (Uuidx.make ()))
         ~master ~other_config:[] ~primary_slave ~mode ~properties ~links_up:0L

--- a/ocaml/xapi/xapi_network_sriov.ml
+++ b/ocaml/xapi/xapi_network_sriov.ml
@@ -37,7 +37,7 @@ let create_internal ~__context ~physical_PIF ~physical_rec ~network =
     ~vLAN_master_of:Ref.null ~management:false ~other_config:[]
     ~disallow_unplug:false ~ipv6_configuration_mode:`None ~iPv6:[]
     ~ipv6_gateway:"" ~primary_address_type ~managed:true ~properties:[]
-    ~capabilities:[] ~pCI:Ref.null ;
+    ~capabilities:[] ~pCI:Ref.null ~lldp_mode:`default ;
   info "network-sriov create uuid=%s" sriov_uuid ;
   Db.Network_sriov.create ~__context ~ref:sriov ~uuid:sriov_uuid ~physical_PIF
     ~logical_PIF ~requires_reboot:false ~configuration_mode:`unknown ;

--- a/ocaml/xapi/xapi_network_sriov.ml
+++ b/ocaml/xapi/xapi_network_sriov.ml
@@ -37,7 +37,7 @@ let create_internal ~__context ~physical_PIF ~physical_rec ~network =
     ~vLAN_master_of:Ref.null ~management:false ~other_config:[]
     ~disallow_unplug:false ~ipv6_configuration_mode:`None ~iPv6:[]
     ~ipv6_gateway:"" ~primary_address_type ~managed:true ~properties:[]
-    ~capabilities:[] ~pCI:Ref.null ~lldp_mode:`default ;
+    ~capabilities:[] ~pCI:Ref.null ~lldp_mode:`inherited ;
   info "network-sriov create uuid=%s" sriov_uuid ;
   Db.Network_sriov.create ~__context ~ref:sriov ~uuid:sriov_uuid ~physical_PIF
     ~logical_PIF ~requires_reboot:false ~configuration_mode:`unknown ;

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -516,7 +516,7 @@ let pool_introduce ~__context ~device ~network ~host ~mAC ~mTU ~vLAN ~physical
       ~ip_configuration_mode ~iP ~netmask ~gateway ~dNS ~bond_slave_of:Ref.null
       ~vLAN_master_of ~management ~other_config ~disallow_unplug
       ~ipv6_configuration_mode ~iPv6 ~ipv6_gateway ~primary_address_type
-      ~managed ~properties ~capabilities:[] ~pCI:Ref.null
+      ~managed ~properties ~capabilities:[] ~pCI:Ref.null ~lldp_mode:`default
   in
   pif_ref
 
@@ -570,7 +570,7 @@ let introduce_internal ?network ?(physical = true) ~t ~__context ~host ~mAC ~mTU
       ~management:false ~other_config:[] ~disallow_unplug
       ~ipv6_configuration_mode:`None ~iPv6:[] ~ipv6_gateway:""
       ~primary_address_type ~managed ~properties:default_properties
-      ~capabilities ~pCI:pci
+      ~capabilities ~pCI:pci ~lldp_mode:`default
   in
   (* If I'm a pool slave and this pif represents my management
      	 * interface then leave it alone: if the interface goes down

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -961,6 +961,41 @@ let set_primary_address_type ~__context ~self ~primary_address_type =
   Monitor_dbcalls_cache.clear_cache_for_pif
     ~pif_name:(Db.PIF.get_device ~__context ~self)
 
+(* LLDP is configurable on any managed physical PIF, i.e. a standalone
+   physical NIC or a bond member NIC. Bond masters, VLAN, tunnel and SR-IOV
+   PIFs are excluded, as they do not represent a physical NIC. *)
+let assert_lldp_configurable ~__context ~self =
+  Xapi_pif_helpers.assert_pif_is_managed ~__context ~self ;
+  let pif_rec = Db.PIF.get_record ~__context ~self in
+  match Xapi_pif_helpers.get_pif_type pif_rec with
+  | Xapi_pif_helpers.Physical _ ->
+      ()
+  | _ ->
+      raise
+        (Api_errors.Server_error
+           (Api_errors.pif_is_not_physical, [Ref.string_of self])
+        )
+
+(* LLDP runs on the physical NIC. A standalone physical PIF is plugged
+   directly; a bond member's configuration is applied by (re)plugging the
+   bond master, which brings its member NICs up. *)
+let pif_to_plug_for_lldp ~__context ~self =
+  match Db.PIF.get_bond_slave_of ~__context ~self with
+  | bond when bond <> Ref.null ->
+      Db.Bond.get_master ~__context ~self:bond
+  | _ ->
+      self
+
+let set_lldp_mode ~__context ~self ~value ~force =
+  assert_lldp_configurable ~__context ~self ;
+  if force || Db.PIF.get_lldp_mode ~__context ~self <> value then (
+    Db.PIF.set_lldp_mode ~__context ~self ~value ;
+    let to_plug = pif_to_plug_for_lldp ~__context ~self in
+    Helpers.call_api_functions ~__context (fun rpc session_id ->
+        Client.Client.PIF.plug ~rpc ~session_id ~self:to_plug
+    )
+  )
+
 let set_property ~__context ~self ~name ~value =
   let fail () =
     raise

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -990,10 +990,13 @@ let set_lldp_mode ~__context ~self ~value ~force =
   assert_lldp_configurable ~__context ~self ;
   if force || Db.PIF.get_lldp_mode ~__context ~self <> value then (
     Db.PIF.set_lldp_mode ~__context ~self ~value ;
+    (* Re-apply to networkd only if the NIC is up; an unplugged PIF will pick
+       up the new setting the next time it is brought up. *)
     let to_plug = pif_to_plug_for_lldp ~__context ~self in
-    Helpers.call_api_functions ~__context (fun rpc session_id ->
-        Client.Client.PIF.plug ~rpc ~session_id ~self:to_plug
-    )
+    if Db.PIF.get_currently_attached ~__context ~self:to_plug then
+      Helpers.call_api_functions ~__context (fun rpc session_id ->
+          Client.Client.PIF.plug ~rpc ~session_id ~self:to_plug
+      )
   )
 
 let set_property ~__context ~self ~name ~value =

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -516,7 +516,7 @@ let pool_introduce ~__context ~device ~network ~host ~mAC ~mTU ~vLAN ~physical
       ~ip_configuration_mode ~iP ~netmask ~gateway ~dNS ~bond_slave_of:Ref.null
       ~vLAN_master_of ~management ~other_config ~disallow_unplug
       ~ipv6_configuration_mode ~iPv6 ~ipv6_gateway ~primary_address_type
-      ~managed ~properties ~capabilities:[] ~pCI:Ref.null ~lldp_mode:`default
+      ~managed ~properties ~capabilities:[] ~pCI:Ref.null ~lldp_mode:`inherited
   in
   pif_ref
 
@@ -570,7 +570,7 @@ let introduce_internal ?network ?(physical = true) ~t ~__context ~host ~mAC ~mTU
       ~management:false ~other_config:[] ~disallow_unplug
       ~ipv6_configuration_mode:`None ~iPv6:[] ~ipv6_gateway:""
       ~primary_address_type ~managed ~properties:default_properties
-      ~capabilities ~pCI:pci ~lldp_mode:`default
+      ~capabilities ~pCI:pci ~lldp_mode:`inherited
   in
   (* If I'm a pool slave and this pif represents my management
      	 * interface then leave it alone: if the interface goes down

--- a/ocaml/xapi/xapi_pif.mli
+++ b/ocaml/xapi/xapi_pif.mli
@@ -135,6 +135,14 @@ val set_primary_address_type :
   -> unit
 (** Change the primary address type between IPv4 and IPv6 *)
 
+val set_lldp_mode :
+     __context:Context.t
+  -> self:API.ref_PIF
+  -> value:[`default | `disabled | `enabled]
+  -> force:bool
+  -> unit
+(** Set the LLDP mode of a managed physical PIF and apply the change *)
+
 val set_default_properties : __context:Context.t -> self:API.ref_PIF -> unit
 (** Set the default properties of a PIF *)
 

--- a/ocaml/xapi/xapi_pif.mli
+++ b/ocaml/xapi/xapi_pif.mli
@@ -138,7 +138,7 @@ val set_primary_address_type :
 val set_lldp_mode :
      __context:Context.t
   -> self:API.ref_PIF
-  -> value:[`default | `disabled | `enabled]
+  -> value:[`disabled | `enabled | `inherited]
   -> force:bool
   -> unit
 (** Set the LLDP mode of a managed physical PIF and apply the change *)

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3862,15 +3862,23 @@ let set_lldp_enabled ~__context ~self ~value ~force =
     Db.Pool.set_lldp_enabled ~__context ~self ~value ;
     (* LLDP runs on physical NICs. Standalone physical PIFs are plugged
        directly; bonded NICs are (re)configured by plugging the bond master.
-       Both apply the per-PIF PIF.lldp_mode against the new pool setting. *)
+       Only currently-attached PIFs are re-plugged; an unplugged PIF will pick
+       up the new pool setting the next time it is brought up. *)
+    let need_pif_replugged ~r =
+      r.API.pIF_managed
+      && r.API.pIF_currently_attached
+      &&
+      match Xapi_pif_helpers.get_pif_type r with
+      | Xapi_pif_helpers.Bond_master _ ->
+          true
+      | Xapi_pif_helpers.Physical _ when r.API.pIF_bond_slave_of = Ref.null ->
+          true
+      | _ ->
+          false
+    in
     let pifs =
       Db.PIF.get_all_records ~__context
-      |> List.filter (fun (_, r) ->
-          r.API.pIF_managed
-          && ((r.API.pIF_physical && r.API.pIF_bond_slave_of = Ref.null)
-             || r.API.pIF_bond_master_of <> []
-             )
-      )
+      |> List.filter (fun (_, r) -> need_pif_replugged ~r)
       |> List.map fst
     in
     Helpers.call_api_functions ~__context (fun rpc session_id ->

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3857,6 +3857,35 @@ let set_igmp_snooping_enabled ~__context ~self ~value =
           )
   )
 
+let set_lldp_enabled ~__context ~self ~value ~force =
+  if force || Db.Pool.get_lldp_enabled ~__context ~self <> value then (
+    Db.Pool.set_lldp_enabled ~__context ~self ~value ;
+    (* LLDP runs on physical NICs. Standalone physical PIFs are plugged
+       directly; bonded NICs are (re)configured by plugging the bond master.
+       Both apply the per-PIF PIF.lldp_mode against the new pool setting. *)
+    let pifs =
+      Db.PIF.get_all_records ~__context
+      |> List.filter (fun (_, r) ->
+          r.API.pIF_managed
+          && ((r.API.pIF_physical && r.API.pIF_bond_slave_of = Ref.null)
+             || r.API.pIF_bond_master_of <> []
+             )
+      )
+      |> List.map fst
+    in
+    Helpers.call_api_functions ~__context (fun rpc session_id ->
+        List.filter_map
+          (fun pif ->
+            try
+              Client.PIF.plug ~rpc ~session_id ~self:pif ;
+              None
+            with e -> Some (pif, ExnHelper.string_of_exn e)
+          )
+          pifs
+    )
+  ) else
+    []
+
 let has_extension ~__context ~self:_ ~name =
   let hosts = Db.Host.get_all ~__context in
   List.for_all

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -324,6 +324,15 @@ val set_igmp_snooping_enabled :
   __context:Context.t -> self:API.ref_pool -> value:bool -> unit
 (** Set on/off for IGMP Snooping *)
 
+val set_lldp_enabled :
+     __context:Context.t
+  -> self:API.ref_pool
+  -> value:bool
+  -> force:bool
+  -> (API.ref_PIF * string) list
+(** Enable or disable LLDP on every managed physical PIF in the pool, returning
+    a map of the PIFs that failed and the corresponding error message. *)
+
 val has_extension :
   __context:Context.t -> self:API.ref_pool -> name:string -> bool
 

--- a/ocaml/xapi/xapi_tunnel.ml
+++ b/ocaml/xapi/xapi_tunnel.ml
@@ -55,7 +55,7 @@ let create_internal ~__context ~transport_PIF ~network ~host ~protocol =
     ~bond_slave_of:Ref.null ~vLAN_master_of:Ref.null ~management:false
     ~other_config:[] ~disallow_unplug:false ~ipv6_configuration_mode:`None
     ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type ~managed:true
-    ~properties:[] ~capabilities:[] ~pCI:Ref.null ;
+    ~properties:[] ~capabilities:[] ~pCI:Ref.null ~lldp_mode:`default ;
   Db.Tunnel.create ~__context ~ref:tunnel
     ~uuid:(Uuidx.to_string (Uuidx.make ()))
     ~access_PIF ~transport_PIF

--- a/ocaml/xapi/xapi_tunnel.ml
+++ b/ocaml/xapi/xapi_tunnel.ml
@@ -55,7 +55,7 @@ let create_internal ~__context ~transport_PIF ~network ~host ~protocol =
     ~bond_slave_of:Ref.null ~vLAN_master_of:Ref.null ~management:false
     ~other_config:[] ~disallow_unplug:false ~ipv6_configuration_mode:`None
     ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type ~managed:true
-    ~properties:[] ~capabilities:[] ~pCI:Ref.null ~lldp_mode:`default ;
+    ~properties:[] ~capabilities:[] ~pCI:Ref.null ~lldp_mode:`inherited ;
   Db.Tunnel.create ~__context ~ref:tunnel
     ~uuid:(Uuidx.to_string (Uuidx.make ()))
     ~access_PIF ~transport_PIF

--- a/ocaml/xapi/xapi_vlan.ml
+++ b/ocaml/xapi/xapi_vlan.ml
@@ -75,7 +75,7 @@ let create_internal ~__context ~host ~tagged_PIF ~tag ~network ~device =
     ~management:false ~other_config:[] ~disallow_unplug:false
     ~ipv6_configuration_mode:`None ~iPv6:[""] ~ipv6_gateway:""
     ~primary_address_type ~managed:true ~properties:[] ~capabilities:[]
-    ~pCI:Ref.null ;
+    ~pCI:Ref.null ~lldp_mode:`default ;
   let () =
     Db.VLAN.create ~__context ~ref:vlan ~uuid:vlan_uuid ~tagged_PIF
       ~untagged_PIF ~tag ~other_config:[]

--- a/ocaml/xapi/xapi_vlan.ml
+++ b/ocaml/xapi/xapi_vlan.ml
@@ -75,7 +75,7 @@ let create_internal ~__context ~host ~tagged_PIF ~tag ~network ~device =
     ~management:false ~other_config:[] ~disallow_unplug:false
     ~ipv6_configuration_mode:`None ~iPv6:[""] ~ipv6_gateway:""
     ~primary_address_type ~managed:true ~properties:[] ~capabilities:[]
-    ~pCI:Ref.null ~lldp_mode:`default ;
+    ~pCI:Ref.null ~lldp_mode:`inherited ;
   let () =
     Db.VLAN.create ~__context ~ref:vlan ~uuid:vlan_uuid ~tagged_PIF
       ~untagged_PIF ~tag ~other_config:[]


### PR DESCRIPTION
Design doc: https://github.com/xapi-project/xen-api/blob/master/doc/content/design/lldp.md

New fileds:
pool.lldp_enabled
pool.lldp_multicast_address (RW)
pif.lldp_mode

APIs:
pool.set_lldp_enabled
PIF.set_lldp_mode

CLI:
xe pool-set-lldp-enabled
xe pif-set-lldp-mode