### PR TITLE
Fix memory issues with caller rrd

### DIFF
--- a/ocaml/idl/datamodel_caller.ml
+++ b/ocaml/idl/datamodel_caller.ml
@@ -112,6 +112,11 @@ let t =
           "Rate limiter attached to this caller, if any. Populated via \
            Rate_limit.add_caller rather than set directly."
           ~default_value:(Some (VRef null_ref))
+      ; field ~qualifier:DynamicRO ~ty:Bool ~lifecycle "auto_registered"
+          "True if this caller was created automatically by the rate limiter \
+           rather than by an administrator. Auto-registered callers are \
+           subject to the max-auto-registered-callers cap."
+          ~default_value:(Some (VBool false))
       ]
     ~messages:
       [

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 908
+let schema_minor_vsn = 909
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -29,6 +29,8 @@ let prototyped_of_field = function
       Some "26.16.1-next"
   | "Rate_limit", "uuid" ->
       Some "26.16.1-next"
+  | "Caller", "auto_registered" ->
+      Some "26.16.1-next"
   | "Caller", "rate_limit" ->
       Some "26.16.1-next"
   | "Caller", "groups" ->

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "b88f7174944ef37e6f2c53b5232465e9"
+let last_known_schema_hash = "812a94da8125fe0f145561522cb309f2"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/libs/rate-limit/rate_limit.ml
+++ b/ocaml/libs/rate-limit/rate_limit.ml
@@ -116,7 +116,7 @@ let submit_async
     ; worker_thread_cond
     ; should_terminate
     ; _
-    } ~callback amount =
+    } ~callback ~caller_details amount =
   check_not_terminated should_terminate ;
   let run_immediately =
     with_lock process_queue_lock (fun () ->
@@ -133,10 +133,10 @@ let submit_async
   if run_immediately then
     callback ()
   else
-    D.debug "%s: rate limiting call" __FUNCTION__
+    D.debug "%s: rate limiting call from %s" __FUNCTION__ caller_details
 
 (* Block and execute on the same thread *)
-let submit_sync bucket_data ~callback amount =
+let submit_sync bucket_data ~callback ~caller_details amount =
   check_not_terminated bucket_data.should_terminate ;
   let channel_opt =
     with_lock bucket_data.process_queue_lock (fun () ->
@@ -160,6 +160,6 @@ let submit_sync bucket_data ~callback amount =
   | None ->
       callback ()
   | Some channel ->
-      D.debug "%s: rate limiting call" __FUNCTION__ ;
+      D.debug "%s: rate limiting call from %s" __FUNCTION__ caller_details ;
       Event.sync (Event.receive channel) ;
       callback ()

--- a/ocaml/libs/rate-limit/rate_limit.mli
+++ b/ocaml/libs/rate-limit/rate_limit.mli
@@ -32,14 +32,16 @@ val delete : t -> unit
     until the worker thread has finished. Subsequent calls to [submit_async]
     or [submit_sync] will raise [Invalid_argument]. *)
 
-val submit_async : t -> callback:(unit -> unit) -> float -> unit
+val submit_async :
+  t -> callback:(unit -> unit) -> caller_details:string -> float -> unit
 (** [submit_async t ~callback amount] submits a callback under rate limiting.
     If tokens are immediately available and no callbacks are queued, the
     callback runs synchronously on the calling thread. Otherwise it is
     enqueued and will be executed by a worker thread when tokens become
     available. Returns immediately. *)
 
-val submit_sync : t -> callback:(unit -> 'a) -> float -> 'a
+val submit_sync :
+  t -> callback:(unit -> 'a) -> caller_details:string -> float -> 'a
 (** [submit_sync t ~callback amount] submits a callback under rate limiting
     and blocks until it completes, returning the callback's result. If tokens
     are immediately available and no callbacks are queued, the callback runs

--- a/ocaml/libs/rate-limit/test/test_rate_limit.ml
+++ b/ocaml/libs/rate-limit/test/test_rate_limit.ml
@@ -25,10 +25,12 @@ let test_create_invalid () =
 let test_submit () =
   let rl = Rate_limit.create ~burst_size:10.0 ~fill_rate:10.0 in
   (* Drain the bucket *)
-  Rate_limit.submit_async rl ~callback:(fun () -> ()) 10.0 ;
+  Rate_limit.submit_async rl ~callback:(fun () -> ()) ~caller_details:"" 10.0 ;
   let executed = ref false in
   let start_counter = Mtime_clock.counter () in
-  Rate_limit.submit_async rl ~callback:(fun () -> executed := true) 5.0 ;
+  Rate_limit.submit_async rl
+    ~callback:(fun () -> executed := true)
+    ~caller_details:"" 5.0 ;
   let elapsed_span = Mtime_clock.count start_counter in
   let elapsed_seconds = Mtime.Span.to_float_ns elapsed_span *. 1e-9 in
   (* submit should return immediately (non-blocking) *)
@@ -42,7 +44,7 @@ let test_submit_fairness () =
   (* Test that callbacks are executed in FIFO order regardless of token cost *)
   let rl = Rate_limit.create ~burst_size:5.0 ~fill_rate:5.0 in
   (* Drain the bucket *)
-  Rate_limit.submit_async rl ~callback:(fun () -> ()) 5.0 ;
+  Rate_limit.submit_async rl ~callback:(fun () -> ()) ~caller_details:"" 5.0 ;
   let execution_order = ref [] in
   let order_mutex = Mutex.create () in
   let record_execution id =
@@ -51,10 +53,18 @@ let test_submit_fairness () =
     Mutex.unlock order_mutex
   in
   (* Submit callbacks with varying costs - order should be preserved *)
-  Rate_limit.submit_async rl ~callback:(fun () -> record_execution 1) 1.0 ;
-  Rate_limit.submit_async rl ~callback:(fun () -> record_execution 2) 3.0 ;
-  Rate_limit.submit_async rl ~callback:(fun () -> record_execution 3) 1.0 ;
-  Rate_limit.submit_async rl ~callback:(fun () -> record_execution 4) 2.0 ;
+  Rate_limit.submit_async rl
+    ~callback:(fun () -> record_execution 1)
+    ~caller_details:"" 1.0 ;
+  Rate_limit.submit_async rl
+    ~callback:(fun () -> record_execution 2)
+    ~caller_details:"" 3.0 ;
+  Rate_limit.submit_async rl
+    ~callback:(fun () -> record_execution 3)
+    ~caller_details:"" 1.0 ;
+  Rate_limit.submit_async rl
+    ~callback:(fun () -> record_execution 4)
+    ~caller_details:"" 2.0 ;
   (* Wait for all callbacks to complete (total cost = 7 tokens, rate = 5/s) *)
   Thread.delay 2.0 ;
   let order = List.rev !execution_order in
@@ -65,13 +75,19 @@ let test_submit_fairness () =
 let test_submit_sync () =
   let rl = Rate_limit.create ~burst_size:10.0 ~fill_rate:10.0 in
   (* Test 1: Returns callback result immediately when tokens available *)
-  let result = Rate_limit.submit_sync rl ~callback:(fun () -> 42) 5.0 in
+  let result =
+    Rate_limit.submit_sync rl ~callback:(fun () -> 42) ~caller_details:"" 5.0
+  in
   Alcotest.(check int) "returns callback result" 42 result ;
   (* Test 2: Blocks and waits for tokens, then returns result *)
   (* Drain the bucket *)
-  Rate_limit.submit_async rl ~callback:(fun () -> ()) 5.0 ;
+  Rate_limit.submit_async rl ~callback:(fun () -> ()) ~caller_details:"" 5.0 ;
   let start_counter = Mtime_clock.counter () in
-  let result2 = Rate_limit.submit_sync rl ~callback:(fun () -> "hello") 5.0 in
+  let result2 =
+    Rate_limit.submit_sync rl
+      ~callback:(fun () -> "hello")
+      ~caller_details:"" 5.0
+  in
   let elapsed_span = Mtime_clock.count start_counter in
   let elapsed_seconds = Mtime.Span.to_float_ns elapsed_span *. 1e-9 in
   Alcotest.(check string) "returns string result" "hello" result2 ;
@@ -83,7 +99,7 @@ let test_submit_sync_with_queued_items () =
   (* Test that submit_sync respects FIFO ordering when queue has items *)
   let rl = Rate_limit.create ~burst_size:5.0 ~fill_rate:10.0 in
   (* Drain the bucket *)
-  Rate_limit.submit_async rl ~callback:(fun () -> ()) 5.0 ;
+  Rate_limit.submit_async rl ~callback:(fun () -> ()) ~caller_details:"" 5.0 ;
   let execution_order = ref [] in
   let order_mutex = Mutex.create () in
   let record_execution id =
@@ -92,13 +108,17 @@ let test_submit_sync_with_queued_items () =
     Mutex.unlock order_mutex
   in
   (* Submit async items first *)
-  Rate_limit.submit_async rl ~callback:(fun () -> record_execution 1) 1.0 ;
-  Rate_limit.submit_async rl ~callback:(fun () -> record_execution 2) 1.0 ;
+  Rate_limit.submit_async rl
+    ~callback:(fun () -> record_execution 1)
+    ~caller_details:"" 1.0 ;
+  Rate_limit.submit_async rl
+    ~callback:(fun () -> record_execution 2)
+    ~caller_details:"" 1.0 ;
   (* Now submit_sync should queue behind the async items *)
   let result =
     Rate_limit.submit_sync rl
       ~callback:(fun () -> record_execution 3 ; "sync_result")
-      1.0
+      ~caller_details:"" 1.0
   in
   Alcotest.(check string)
     "submit_sync returns correct result" "sync_result" result ;
@@ -111,13 +131,17 @@ let test_submit_sync_concurrent () =
   (* Test multiple concurrent submit_sync calls *)
   let rl = Rate_limit.create ~burst_size:1.0 ~fill_rate:10.0 in
   (* Drain the bucket to force queueing *)
-  Rate_limit.submit_async rl ~callback:(fun () -> ()) 1.0 ;
+  Rate_limit.submit_async rl ~callback:(fun () -> ()) ~caller_details:"" 1.0 ;
   let results = Array.make 5 0 in
   let threads =
     Array.init 5 (fun i ->
         Thread.create
           (fun () ->
-            let r = Rate_limit.submit_sync rl ~callback:(fun () -> i + 1) 1.0 in
+            let r =
+              Rate_limit.submit_sync rl
+                ~callback:(fun () -> i + 1)
+                ~caller_details:"" 1.0
+            in
             results.(i) <- r
           )
           ()
@@ -139,7 +163,7 @@ let test_no_skip_ahead_during_worker_delay () =
      newly-arriving cheap caller could opportunistically consume without
      the fix. *)
   let rl = Rate_limit.create ~burst_size:10.0 ~fill_rate:100.0 in
-  Rate_limit.submit_async rl ~callback:(fun () -> ()) 10.0 ;
+  Rate_limit.submit_async rl ~callback:(fun () -> ()) ~caller_details:"" 10.0 ;
   let execution_order = ref [] in
   let order_mutex = Mutex.create () in
   let record_execution id =
@@ -147,9 +171,13 @@ let test_no_skip_ahead_during_worker_delay () =
     execution_order := id :: !execution_order ;
     Mutex.unlock order_mutex
   in
-  Rate_limit.submit_async rl ~callback:(fun () -> record_execution 1) 10.0 ;
+  Rate_limit.submit_async rl
+    ~callback:(fun () -> record_execution 1)
+    ~caller_details:"" 10.0 ;
   Thread.delay 0.02 ;
-  Rate_limit.submit_async rl ~callback:(fun () -> record_execution 2) 1.0 ;
+  Rate_limit.submit_async rl
+    ~callback:(fun () -> record_execution 2)
+    ~caller_details:"" 1.0 ;
   Thread.delay 0.2 ;
   let order = List.rev !execution_order in
   Alcotest.(check (list int))
@@ -160,13 +188,17 @@ let test_submit_sync_interleaved () =
   (* Test interleaving submit and submit_sync *)
   let rl = Rate_limit.create ~burst_size:2.0 ~fill_rate:10.0 in
   (* Drain the bucket *)
-  Rate_limit.submit_async rl ~callback:(fun () -> ()) 2.0 ;
+  Rate_limit.submit_async rl ~callback:(fun () -> ()) ~caller_details:"" 2.0 ;
   let async_executed = ref false in
   (* Submit async first *)
-  Rate_limit.submit_async rl ~callback:(fun () -> async_executed := true) 1.0 ;
+  Rate_limit.submit_async rl
+    ~callback:(fun () -> async_executed := true)
+    ~caller_details:"" 1.0 ;
   (* Submit sync should wait for async to complete first *)
   let sync_result =
-    Rate_limit.submit_sync rl ~callback:(fun () -> !async_executed) 1.0
+    Rate_limit.submit_sync rl
+      ~callback:(fun () -> !async_executed)
+      ~caller_details:"" 1.0
   in
   Alcotest.(check bool)
     "sync callback sees async already executed" true sync_result ;

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -45,6 +45,7 @@ let () =
      ; ("Test_storage_migrate_state", Test_storage_migrate_state.test)
      ; ("Test_bios_strings", Test_bios_strings.test)
      ; ("Test_certificates", Test_certificates.test)
+     ; ("Test_caller_limit", Test_caller_limit.test)
      ]
     @ Test_guest_agent.tests
     @ Test_nm.tests

--- a/ocaml/tests/test_caller_limit.ml
+++ b/ocaml/tests/test_caller_limit.ml
@@ -1,0 +1,123 @@
+(*
+ * Copyright (C) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(* Exercises the cap on auto-registered callers (Xapi_globs.max_auto_registered_callers)
+   and the least-recently-called eviction policy in Xapi_caller. The in-memory
+   caller_table is process-global, so all cases share one database context and
+   clean up through the public [destroy] between phases. *)
+
+let context = lazy (Test_common.make_test_database ())
+
+(* Run the auto-create/rate-limit machinery synchronously by giving [submit_sync]
+   a [task_create] that runs its closure inline against the test context. *)
+let call ~__context ~user_agent ~client_ip =
+  Xapi_caller.submit_sync ~user_agent ~client_ip
+    ~callback:(fun () -> ())
+    ~task_create:(fun f -> f __context)
+    1.0
+
+(* Drop every caller so the global caller_table and the database start empty. *)
+let reset ~__context =
+  List.iter
+    (fun self -> Xapi_caller.destroy ~__context ~self)
+    (Db.Caller.get_all ~__context)
+
+let user_agents ~__context =
+  Db.Caller.get_all ~__context
+  |> List.map (fun self -> Db.Caller.get_user_agent ~__context ~self)
+  |> List.sort String.compare
+
+let check_user_agents ~__context msg expected =
+  Alcotest.(check (list string)) msg expected (user_agents ~__context)
+
+let with_setup ~limit f =
+  let __context = Lazy.force context in
+  reset ~__context ;
+  Xapi_globs.rate_limit_enabled := true ;
+  Xapi_globs.max_auto_registered_callers := limit ;
+  f ~__context
+
+(* At the cap, a further distinct caller evicts the auto-registered caller with
+   the least recent call - not merely the oldest by creation. *)
+let test_evicts_least_recently_called () =
+  with_setup ~limit:2 (fun ~__context ->
+      call ~__context ~user_agent:"agent-1" ~client_ip:"10.0.0.1" ;
+      call ~__context ~user_agent:"agent-2" ~client_ip:"10.0.0.2" ;
+      check_user_agents ~__context "two callers auto-registered"
+        ["agent-1"; "agent-2"] ;
+      (* Touch agent-1 again so agent-2 becomes the least recently called. *)
+      call ~__context ~user_agent:"agent-1" ~client_ip:"10.0.0.1" ;
+      (* A third distinct caller trips the cap and evicts agent-2. *)
+      call ~__context ~user_agent:"agent-3" ~client_ip:"10.0.0.3" ;
+      check_user_agents ~__context "agent-2 (least recently called) evicted"
+        ["agent-1"; "agent-3"]
+  )
+
+(* Manually created callers are not auto-registered: they neither count towards
+   the cap nor get evicted by it. *)
+let test_manual_callers_not_evicted () =
+  with_setup ~limit:2 (fun ~__context ->
+      let (_ : API.ref_Caller) =
+        Xapi_caller.create ~__context ~name_label:"manual"
+          ~name_description:"manually created" ~user_agent:"manual-agent"
+          ~client_ip:"192.168.0.1"
+      in
+      call ~__context ~user_agent:"agent-1" ~client_ip:"10.0.0.1" ;
+      call ~__context ~user_agent:"agent-2" ~client_ip:"10.0.0.2" ;
+      (* Trips the cap: an auto caller is evicted, the manual one is not. *)
+      call ~__context ~user_agent:"agent-3" ~client_ip:"10.0.0.3" ;
+      let agents = user_agents ~__context in
+      Alcotest.(check bool)
+        "manual caller survives eviction" true
+        (List.mem "manual-agent" agents) ;
+      Alcotest.(check int)
+        "cap counts only auto-registered callers" 3 (List.length agents)
+  )
+
+(* A limit of 0 disables auto-registration: no callers are auto-created. *)
+let test_zero_limit_disables_autoregistration () =
+  with_setup ~limit:0 (fun ~__context ->
+      call ~__context ~user_agent:"agent-1" ~client_ip:"10.0.0.1" ;
+      call ~__context ~user_agent:"agent-2" ~client_ip:"10.0.0.2" ;
+      check_user_agents ~__context "no callers auto-registered when limit is 0"
+        []
+  )
+
+(* A negative limit means unbounded - every distinct caller is registered and
+   none are evicted. *)
+let test_negative_limit_is_unbounded () =
+  with_setup ~limit:(-1) (fun ~__context ->
+      call ~__context ~user_agent:"agent-1" ~client_ip:"10.0.0.1" ;
+      call ~__context ~user_agent:"agent-2" ~client_ip:"10.0.0.2" ;
+      call ~__context ~user_agent:"agent-3" ~client_ip:"10.0.0.3" ;
+      check_user_agents ~__context "no eviction when limit is negative"
+        ["agent-1"; "agent-2"; "agent-3"]
+  )
+
+let test =
+  [
+    ( "test_evicts_least_recently_called"
+    , `Quick
+    , test_evicts_least_recently_called
+    )
+  ; ("test_manual_callers_not_evicted", `Quick, test_manual_callers_not_evicted)
+  ; ( "test_zero_limit_disables_autoregistration"
+    , `Quick
+    , test_zero_limit_disables_autoregistration
+    )
+  ; ( "test_negative_limit_is_unbounded"
+    , `Quick
+    , test_negative_limit_is_unbounded
+    )
+  ]

--- a/ocaml/tests/test_caller_limit.ml
+++ b/ocaml/tests/test_caller_limit.ml
@@ -105,11 +105,48 @@ let test_negative_limit_is_unbounded () =
         ["agent-1"; "agent-2"; "agent-3"]
   )
 
+(* The RRD reporter aggregates per-caller usage into per-group totals. A caller
+   in several groups contributes to each; a caller in no group contributes to
+   none. *)
+let test_group_totals_aggregate_callers () =
+  with_setup ~limit:100 (fun ~__context ->
+      let mk user_agent client_ip =
+        Xapi_caller.create ~__context ~name_label:user_agent
+          ~name_description:"" ~user_agent ~client_ip
+      in
+      let c1 = mk "a1" "10.0.0.1" in
+      let c2 = mk "a2" "10.0.0.2" in
+      let _ungrouped = mk "a3" "10.0.0.3" in
+      (* Accumulate stats: one call for a1, two for a2, one for the ungrouped
+         caller a3 (which should not show up in any group total). *)
+      call ~__context ~user_agent:"a1" ~client_ip:"10.0.0.1" ;
+      call ~__context ~user_agent:"a2" ~client_ip:"10.0.0.2" ;
+      call ~__context ~user_agent:"a2" ~client_ip:"10.0.0.2" ;
+      call ~__context ~user_agent:"a3" ~client_ip:"10.0.0.3" ;
+      Xapi_caller.add_group ~__context ~self:c1 ~group:"g1" ;
+      Xapi_caller.add_group ~__context ~self:c2 ~group:"g1" ;
+      Xapi_caller.add_group ~__context ~self:c2 ~group:"g2" ;
+      let summary =
+        Xapi_caller.group_totals ()
+        |> List.map (fun (g, tokens, calls) ->
+            Printf.sprintf "%s:%.0f:%d" g tokens calls
+        )
+        |> List.sort String.compare
+      in
+      (* g1 = a1 (1) + a2 (2); g2 = a2 (2); a3 is in no group. *)
+      Alcotest.(check (list string))
+        "per-group token/call totals" ["g1:3:3"; "g2:2:2"] summary
+  )
+
 let test =
   [
     ( "test_evicts_least_recently_called"
     , `Quick
     , test_evicts_least_recently_called
+    )
+  ; ( "test_group_totals_aggregate_callers"
+    , `Quick
+    , test_group_totals_aggregate_callers
     )
   ; ("test_manual_callers_not_evicted", `Quick, test_manual_callers_not_evicted)
   ; ( "test_zero_limit_disables_autoregistration"

--- a/ocaml/xapi/xapi_caller.ml
+++ b/ocaml/xapi/xapi_caller.ml
@@ -21,20 +21,40 @@ module Caller_statistics = Rate_limit_lib.Caller_statistics
 module Config_file = Xcp_service.Config_file
 module Unixext = Xapi_stdext_unix.Unixext
 
+(* Monotonically increasing logical clock, bumped once per matched call. Each
+   entry records the value it last saw in [last_call]; the smallest value
+   therefore identifies the caller with the least recent call. A single atomic
+   fetch-and-add per call keeps the dispatch path lock-free - we deliberately
+   avoid a real time source (and its dependency) here since only the relative
+   ordering matters for eviction. *)
+let call_sequence = Atomic.make 0
+
+let next_call_sequence () = Atomic.fetch_and_add call_sequence 1
+
 (** A single in-memory caller_table entry. The pattern_key is the table's
     primary key; [caller_ref] records which DB row this entry mirrors;
     [stats] tracks call counts and token use since startup;
     [rate_limit_ref] points at the rate-limit row (Ref.null when none),
     resolved to a live bucket via [Xapi_rate_limit.find_bucket] at dispatch
-    time. *)
+    time; [auto_registered] is true for callers created by [maybe_autocreate]
+    rather than by an administrator; [last_call] is the [call_sequence] value
+    seen on this caller's most recent call, used to pick the eviction victim. *)
 type entry = {
     caller_ref: API.ref_Caller
   ; pattern_key: Caller_table.Key.pattern_key
   ; stats: Caller_statistics.t
   ; rate_limit_ref: API.ref_Rate_limit
+  ; auto_registered: bool
+  ; last_call: int Atomic.t
 }
 
 let caller_table : entry Caller_table.t = Caller_table.create ()
+
+(* Number of auto-registered entries currently in [caller_table]. Mutated only
+   under [caller_table_mutex] (or single-threaded in [register]) so it stays in
+   step with the table. Lets [maybe_autocreate] decide in O(1) whether the cap
+   has been reached without scanning the table. *)
+let auto_registered_count = ref 0
 
 (* Serialises ALL mutations of [caller_table] on the master. Caller_table
    itself uses Atomic for lock-free reads, but its writers are non-CAS
@@ -104,19 +124,50 @@ let validate_request_fields ~user_agent ~client_ip =
       )
 
 (* All [insert_entry_locked] callers must hold [caller_table_mutex], except
-   [register] which runs single-threaded at startup. *)
-let insert_entry_locked ~caller_ref ~stats ~pattern_key ~rate_limit_ref =
-  let entry = {caller_ref; pattern_key; stats; rate_limit_ref} in
+   [register] which runs single-threaded at startup. Does not touch
+   [auto_registered_count]; the create/destroy helpers own that counter so a
+   delete-then-insert refresh does not perturb it. A freshly inserted entry is
+   stamped with the current [call_sequence] so a just-registered caller is
+   treated as recently used rather than an immediate eviction candidate. *)
+let insert_entry_locked ~caller_ref ~stats ~pattern_key ~rate_limit_ref
+    ~auto_registered ?last_call () =
+  let last_call =
+    match last_call with
+    | Some v ->
+        v
+    | None ->
+        Atomic.make (next_call_sequence ())
+  in
+  let entry =
+    {caller_ref; pattern_key; stats; rate_limit_ref; auto_registered; last_call}
+  in
   if not (Caller_table.insert caller_table ~pattern:pattern_key entry) then
     debug
       "Caller_table.insert refused entry (duplicate or all-wildcard) for \
        caller %s"
       (Ref.string_of caller_ref)
 
+(* Promote an auto-registered entry to an administrator-owned one: an explicit
+   admin action (creating a caller for the same pattern, or attaching a
+   rate-limit rule) has taken ownership of it, so it should no longer count
+   against the auto-registration cap or be a candidate for LRU eviction.
+   Assumes [caller_table_mutex] is held and that [entry] is the live table entry
+   for its pattern with [auto_registered = true]. Preserves the existing stats
+   and recency stamp across the swap. *)
+let promote_entry_locked ~__context entry =
+  Db.Caller.set_auto_registered ~__context ~self:entry.caller_ref ~value:false ;
+  decr auto_registered_count ;
+  Caller_table.delete caller_table ~pattern:entry.pattern_key ;
+  insert_entry_locked ~caller_ref:entry.caller_ref ~stats:entry.stats
+    ~pattern_key:entry.pattern_key ~rate_limit_ref:entry.rate_limit_ref
+    ~auto_registered:false ~last_call:entry.last_call ()
+
 (* Body of [create]; assumes [caller_table_mutex] is held and that
-   [pattern_key] has already been validated. *)
+   [pattern_key] has already been validated. [auto_registered] marks whether the
+   new row is created by the rate limiter (subject to the cap) or by an
+   administrator. *)
 let create_locked ~__context ~name_label ~name_description ~user_agent
-    ~client_ip ~pattern_key =
+    ~client_ip ~pattern_key ~auto_registered =
   match Caller_table.get_exact caller_table ~pattern:pattern_key with
   | Some entry ->
       (* Idempotent: an in-memory entry already mirrors this pattern. Update
@@ -125,16 +176,21 @@ let create_locked ~__context ~name_label ~name_description ~user_agent
         ~value:name_label ;
       Db.Caller.set_name_description ~__context ~self:entry.caller_ref
         ~value:name_description ;
+      (* An explicit admin [create] for a pattern already held by an
+         auto-registered caller takes ownership of it. *)
+      if (not auto_registered) && entry.auto_registered then
+        promote_entry_locked ~__context entry ;
       entry.caller_ref
   | None ->
       let uuid = Uuidx.(to_string (make () : [`Caller] t)) in
       let ref = Ref.make () in
       Db.Caller.create ~__context ~ref ~uuid ~name_label ~name_description
         ~user_agent ~client_ip ~last_access:Clock.Date.epoch ~groups:[]
-        ~rate_limit:Ref.null ;
+        ~rate_limit:Ref.null ~auto_registered ;
       insert_entry_locked ~caller_ref:ref
         ~stats:(Caller_statistics.create ~caller_uuid:uuid)
-        ~pattern_key ~rate_limit_ref:Ref.null ;
+        ~pattern_key ~rate_limit_ref:Ref.null ~auto_registered () ;
+      if auto_registered then incr auto_registered_count ;
       ref
 
 let create ~__context ~name_label ~name_description ~user_agent ~client_ip =
@@ -150,16 +206,25 @@ let create ~__context ~name_label ~name_description ~user_agent ~client_ip =
       ) ;
   with_caller_table_mutex (fun () ->
       create_locked ~__context ~name_label ~name_description ~user_agent
-        ~client_ip ~pattern_key
+        ~client_ip ~pattern_key ~auto_registered:false
   )
 
-let destroy ~__context ~self =
+(* Body of [destroy]; assumes [caller_table_mutex] is held. Also used by the
+   eviction path. Keeps [auto_registered_count] in step with the table. *)
+let destroy_locked ~__context ~self =
   let record = Db.Caller.get_record ~__context ~self in
   let pattern_key = pattern_key_of_record record in
-  with_caller_table_mutex (fun () ->
-      Caller_table.delete caller_table ~pattern:pattern_key
+  ( match Caller_table.get_exact caller_table ~pattern:pattern_key with
+  | Some entry when entry.auto_registered ->
+      decr auto_registered_count
+  | _ ->
+      ()
   ) ;
+  Caller_table.delete caller_table ~pattern:pattern_key ;
   Db.Caller.destroy ~__context ~self
+
+let destroy ~__context ~self =
+  with_caller_table_mutex (fun () -> destroy_locked ~__context ~self)
 
 let add_group ~__context ~self ~group =
   Db.Caller.add_groups ~__context ~self ~value:group
@@ -244,10 +309,12 @@ let query_all_usage ~__context =
     otherwise both start from the DB state seen before either mutation,
     and the later insert then silently loses to the earlier one.
 
-    User_agent and client_ip are StaticRO in the datamodel, so a caller's
-    pattern_key never changes; we preserve the existing [stats] across
-    the swap so that attaching or detaching a rate_limit doesn't reset
-    the "calls / tokens since Xapi startup" counters. *)
+    pattern_key never changes; we preserve the existing [stats] and recency
+    stamp across the swap so that attaching or detaching a rate_limit doesn't
+    reset the "calls / tokens since Xapi startup" counters. The rate_limit ref is
+    taken from the freshly read record; the auto-registered flag likewise, except
+    that attaching a rate-limit rule to an auto-registered caller promotes it
+    (see below). *)
 let refresh_caller_rate_limit ~__context caller_ref =
   with_caller_table_mutex (fun () ->
       match
@@ -258,16 +325,42 @@ let refresh_caller_rate_limit ~__context caller_ref =
           ()
       | Some record ->
           let pattern_key = pattern_key_of_record record in
-          let stats =
-            match Caller_table.get_exact caller_table ~pattern:pattern_key with
-            | Some existing ->
-                existing.stats
-            | None ->
-                Caller_statistics.create ~caller_uuid:record.caller_uuid
+          let existing =
+            Caller_table.get_exact caller_table ~pattern:pattern_key
           in
+          let stats, last_call =
+            match existing with
+            | Some existing ->
+                (existing.stats, Some existing.last_call)
+            | None ->
+                (Caller_statistics.create ~caller_uuid:record.caller_uuid, None)
+          in
+          (* Attaching a rate-limit rule is an explicit admin action: promote an
+             auto-registered caller so it is no longer subject to the
+             auto-registration cap or LRU eviction. This is the one refresh path
+             where the flag can flip true -> false, so keep
+             [auto_registered_count] in step here - both the delete below and
+             [insert_entry_locked] leave the counter untouched. *)
+          let promote =
+            record.API.caller_auto_registered
+            && record.API.caller_rate_limit <> Ref.null
+          in
+          let auto_registered =
+            record.API.caller_auto_registered && not promote
+          in
+          if promote then (
+            Db.Caller.set_auto_registered ~__context ~self:caller_ref
+              ~value:false ;
+            match existing with
+            | Some e when e.auto_registered ->
+                decr auto_registered_count
+            | _ ->
+                ()
+          ) ;
           Caller_table.delete caller_table ~pattern:pattern_key ;
           insert_entry_locked ~caller_ref ~stats ~pattern_key
-            ~rate_limit_ref:record.API.caller_rate_limit
+            ~rate_limit_ref:record.API.caller_rate_limit ~auto_registered
+            ?last_call ()
   )
 
 (* Install the caller_table refresh callback at module load time. The API
@@ -317,8 +410,16 @@ let get_token_cost name =
 let bookkeeping_and_bucket ~task_create ~user_agent ~client_ip ~cost =
   let target = target_of_request ~user_agent ~client_ip in
   let matches = Caller_table.get caller_table ~caller_id:target in
+  (* Stamp recency lock-free on the dispatch path: one atomic write per matched
+     entry, using the same value for every match in this call. Read back by
+     [evict_lru_auto_registered_locked] to pick the least recently used
+     caller. *)
+  let seq = next_call_sequence () in
   List.iter
-    (fun entry -> Caller_statistics.register_call ~token_amount:cost entry.stats)
+    (fun entry ->
+      Caller_statistics.register_call ~token_amount:cost entry.stats ;
+      Atomic.set entry.last_call seq
+    )
     matches ;
   if matches <> [] then
     task_create (fun __context ->
@@ -347,6 +448,36 @@ let bookkeeping_and_bucket ~task_create ~user_agent ~client_ip ~cost =
   in
   (matches, bucket)
 
+(* Drop the auto-registered caller with the least recent call. Assumes
+   [caller_table_mutex] is held. Only ever scans the (bounded) in-memory table
+   and reads recency from an atomic, so no DB reads are needed to choose the
+   victim; the O(n) scan runs only on the rare "at capacity" auto-create. *)
+let evict_lru_auto_registered_locked ~__context =
+  let victim =
+    entries_of_table ()
+    |> List.filter (fun entry -> entry.auto_registered)
+    |> List.fold_left
+         (fun acc entry ->
+           match acc with
+           | Some best
+             when Atomic.get best.last_call <= Atomic.get entry.last_call ->
+               acc
+           | _ ->
+               Some entry
+         )
+         None
+  in
+  match victim with
+  | None ->
+      ()
+  | Some entry ->
+      debug
+        "Auto-registered caller limit (%d) reached; evicting least recently \
+         used caller %s"
+        !Xapi_globs.max_auto_registered_callers
+        (Ref.string_of entry.caller_ref) ;
+      destroy_locked ~__context ~self:entry.caller_ref
+
 let maybe_autocreate ~task_create ~user_agent ~client_ip ~existing =
   let fully_specified_request = user_agent <> "" && client_ip <> "" in
   if (not fully_specified_request) || any_fully_specified existing then
@@ -358,10 +489,16 @@ let maybe_autocreate ~task_create ~user_agent ~client_ip ~existing =
                a matching row while we were racing to acquire the mutex. *)
             let target = target_of_request ~user_agent ~client_ip in
             let existing = Caller_table.get caller_table ~caller_id:target in
-            if any_fully_specified existing then
+            let limit = !Xapi_globs.max_auto_registered_callers in
+            if any_fully_specified existing || limit = 0 then
+              (* A limit of 0 disables auto-registration entirely. *)
               ()
             else
               try
+                (* Enforce the cap before adding a new auto-registered caller.
+                   A negative limit means unbounded, so no eviction. *)
+                if limit > 0 && !auto_registered_count >= limit then
+                  evict_lru_auto_registered_locked ~__context ;
                 let pattern_key =
                   pattern_key_of_fields ~user_agent ~client_ip
                 in
@@ -376,7 +513,7 @@ let maybe_autocreate ~task_create ~user_agent ~client_ip ~existing =
                          "Autogenerated caller for user_agent %s, client_ip %s"
                          user_agent client_ip
                       )
-                    ~user_agent ~client_ip ~pattern_key
+                    ~user_agent ~client_ip ~pattern_key ~auto_registered:true
                 in
                 Db.Caller.set_last_access ~__context ~self:caller_ref
                   ~value:(Clock.Date.now ())
@@ -459,6 +596,7 @@ let register ~__context =
   else (
     load_token_costs () ;
     (* Runs single-threaded at start-of-day, so bypasses caller_table_mutex. *)
+    auto_registered_count := 0 ;
     List.iter
       (fun self ->
         let record = Db.Caller.get_record ~__context ~self in
@@ -466,7 +604,42 @@ let register ~__context =
         insert_entry_locked ~caller_ref:self
           ~stats:(Caller_statistics.create ~caller_uuid:record.caller_uuid)
           ~pattern_key ~rate_limit_ref:record.API.caller_rate_limit
+          ~auto_registered:record.API.caller_auto_registered () ;
+        if record.API.caller_auto_registered then incr auto_registered_count
       )
       (Db.Caller.get_all ~__context) ;
+    (* Auto-registered callers persist across restarts, so the database may
+       already hold more than the current cap (e.g. after lowering it, or after
+       disabling auto-registration with a limit of 0). Trim the excess, dropping
+       those with the least recent call first. A negative limit means unbounded,
+       so nothing is trimmed. Recency here comes from the persisted [last_access]
+       field - the only recency signal available before any calls have been seen
+       this boot. This reads [last_access] once per auto-registered caller, but
+       only on the rare boot where the database already exceeds the cap. *)
+    let limit = !Xapi_globs.max_auto_registered_callers in
+    ( if limit >= 0 && !auto_registered_count > limit then
+        let auto_callers =
+          entries_of_table ()
+          |> List.filter (fun entry -> entry.auto_registered)
+          |> List.map (fun entry ->
+              let last_access =
+                try Db.Caller.get_last_access ~__context ~self:entry.caller_ref
+                with _ -> Clock.Date.epoch
+              in
+              (entry.caller_ref, last_access)
+          )
+          |> List.sort (fun (_, a) (_, b) -> Clock.Date.compare a b)
+        in
+        let to_drop = !auto_registered_count - limit in
+        auto_callers
+        |> List.filteri (fun i _ -> i < to_drop)
+        |> List.iter (fun (self, _) ->
+            debug
+              "Auto-registered caller count exceeds limit (%d) at startup; \
+               evicting least recently used caller %s"
+              limit (Ref.string_of self) ;
+            destroy_locked ~__context ~self
+        )
+    ) ;
     start_reporter ()
   )

--- a/ocaml/xapi/xapi_caller.ml
+++ b/ocaml/xapi/xapi_caller.ml
@@ -38,7 +38,9 @@ let next_call_sequence () = Atomic.fetch_and_add call_sequence 1
     resolved to a live bucket via [Xapi_rate_limit.find_bucket] at dispatch
     time; [auto_registered] is true for callers created by [maybe_autocreate]
     rather than by an administrator; [last_call] is the [call_sequence] value
-    seen on this caller's most recent call, used to pick the eviction victim. *)
+    seen on this caller's most recent call, used to pick the eviction victim;
+    [groups] mirrors the caller's DB [groups] field so the RRD reporter can
+    aggregate usage per group without touching the database. *)
 type entry = {
     caller_ref: API.ref_Caller
   ; pattern_key: Caller_table.Key.pattern_key
@@ -46,6 +48,7 @@ type entry = {
   ; rate_limit_ref: API.ref_Rate_limit
   ; auto_registered: bool
   ; last_call: int Atomic.t
+  ; groups: string list
 }
 
 let caller_table : entry Caller_table.t = Caller_table.create ()
@@ -130,7 +133,7 @@ let validate_request_fields ~user_agent ~client_ip =
    stamped with the current [call_sequence] so a just-registered caller is
    treated as recently used rather than an immediate eviction candidate. *)
 let insert_entry_locked ~caller_ref ~stats ~pattern_key ~rate_limit_ref
-    ~auto_registered ?last_call () =
+    ~auto_registered ~groups ?last_call () =
   let last_call =
     match last_call with
     | Some v ->
@@ -139,7 +142,15 @@ let insert_entry_locked ~caller_ref ~stats ~pattern_key ~rate_limit_ref
         Atomic.make (next_call_sequence ())
   in
   let entry =
-    {caller_ref; pattern_key; stats; rate_limit_ref; auto_registered; last_call}
+    {
+      caller_ref
+    ; pattern_key
+    ; stats
+    ; rate_limit_ref
+    ; auto_registered
+    ; last_call
+    ; groups
+    }
   in
   if not (Caller_table.insert caller_table ~pattern:pattern_key entry) then
     debug
@@ -160,7 +171,7 @@ let promote_entry_locked ~__context entry =
   Caller_table.delete caller_table ~pattern:entry.pattern_key ;
   insert_entry_locked ~caller_ref:entry.caller_ref ~stats:entry.stats
     ~pattern_key:entry.pattern_key ~rate_limit_ref:entry.rate_limit_ref
-    ~auto_registered:false ~last_call:entry.last_call ()
+    ~auto_registered:false ~groups:entry.groups ~last_call:entry.last_call ()
 
 (* Body of [create]; assumes [caller_table_mutex] is held and that
    [pattern_key] has already been validated. [auto_registered] marks whether the
@@ -189,7 +200,7 @@ let create_locked ~__context ~name_label ~name_description ~user_agent
         ~rate_limit:Ref.null ~auto_registered ;
       insert_entry_locked ~caller_ref:ref
         ~stats:(Caller_statistics.create ~caller_uuid:uuid)
-        ~pattern_key ~rate_limit_ref:Ref.null ~auto_registered () ;
+        ~pattern_key ~rate_limit_ref:Ref.null ~auto_registered ~groups:[] () ;
       if auto_registered then incr auto_registered_count ;
       ref
 
@@ -225,12 +236,6 @@ let destroy_locked ~__context ~self =
 
 let destroy ~__context ~self =
   with_caller_table_mutex (fun () -> destroy_locked ~__context ~self)
-
-let add_group ~__context ~self ~group =
-  Db.Caller.add_groups ~__context ~self ~value:group
-
-let remove_group ~__context ~self ~group =
-  Db.Caller.remove_groups ~__context ~self ~value:group
 
 let entries_of_table () = Caller_table.to_list caller_table |> List.map snd
 
@@ -301,21 +306,23 @@ let query_all_usage ~__context =
       ]
   )
 
-(** Re-read the caller's rate_limit ref from DB and rebuild its entry. Called
-    by Xapi_rate_limit whenever the caller's rate_limit field changes.
+(** Re-read the caller's record from DB and rebuild its in-memory entry. Called
+    by Xapi_rate_limit whenever the caller's rate_limit field changes, and
+    whenever its group membership changes.
 
     Held under [caller_table_mutex] so the DB read + delete + insert are
     seen as one step: concurrent refreshes for the same caller can
     otherwise both start from the DB state seen before either mutation,
     and the later insert then silently loses to the earlier one.
 
+    User_agent and client_ip are StaticRO in the datamodel, so a caller's
     pattern_key never changes; we preserve the existing [stats] and recency
-    stamp across the swap so that attaching or detaching a rate_limit doesn't
-    reset the "calls / tokens since Xapi startup" counters. The rate_limit ref is
-    taken from the freshly read record; the auto-registered flag likewise, except
-    that attaching a rate-limit rule to an auto-registered caller promotes it
-    (see below). *)
-let refresh_caller_rate_limit ~__context caller_ref =
+    stamp across the swap so that attaching or detaching a rate_limit (or
+    changing groups) doesn't reset the "calls / tokens since Xapi startup"
+    counters. The rate_limit ref and group membership are taken from the freshly
+    read record; the auto-registered flag likewise, except that attaching a
+    rate-limit rule to an auto-registered caller promotes it (see below). *)
+let refresh_caller_entry ~__context caller_ref =
   with_caller_table_mutex (fun () ->
       match
         try Some (Db.Caller.get_record ~__context ~self:caller_ref)
@@ -360,15 +367,56 @@ let refresh_caller_rate_limit ~__context caller_ref =
           Caller_table.delete caller_table ~pattern:pattern_key ;
           insert_entry_locked ~caller_ref ~stats ~pattern_key
             ~rate_limit_ref:record.API.caller_rate_limit ~auto_registered
-            ?last_call ()
+            ~groups:record.API.caller_groups ?last_call ()
   )
+
+(* Group names are administrator-supplied and flow verbatim into RRD data source
+   names (see [make_group_dss]), so constrain them at the point of entry:
+   restrict to characters that are safe in a data source name, and bound the
+   length so a single group cannot blow the reporter's per-data-source size
+   estimate (see [reporter_bytes_per_ds]) and reintroduce the "not enough
+   memory" failure. Rejecting bad names here (rather than mangling them at report
+   time) also keeps names collision-free, so distinct groups never merge into one
+   data source. *)
+let max_group_name_length = 64
+
+let valid_group_name_char = function
+  | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '-' | '.' ->
+      true
+  | _ ->
+      false
+
+let validate_group_name group =
+  let invalid reason =
+    raise Api_errors.(Server_error (invalid_value, ["group"; reason]))
+  in
+  if group = "" then invalid "empty group name" ;
+  if String.length group > max_group_name_length then
+    invalid
+      (Printf.sprintf "group name must be at most %d characters"
+         max_group_name_length
+      ) ;
+  if not (String.for_all valid_group_name_char group) then
+    invalid
+      "group name may only contain alphanumerics and '_', '-' or '.' characters"
+
+let add_group ~__context ~self ~group =
+  validate_group_name group ;
+  Db.Caller.add_groups ~__context ~self ~value:group ;
+  (* Keep the in-memory entry's [groups] in step so the RRD reporter aggregates
+     correctly. *)
+  refresh_caller_entry ~__context self
+
+let remove_group ~__context ~self ~group =
+  Db.Caller.remove_groups ~__context ~self ~value:group ;
+  refresh_caller_entry ~__context self
 
 (* Install the caller_table refresh callback at module load time. The API
    server can accept requests before [register] runs, and any
    [Rate_limit.add_caller] that lands in that window would otherwise leave
    the caller_table entry with rate_limit_ref = Ref.null (because
    [notify_caller_changed] would fall through to the default no-op). *)
-let () = Xapi_rate_limit.set_caller_refresh_callback refresh_caller_rate_limit
+let () = Xapi_rate_limit.set_caller_refresh_callback refresh_caller_entry
 
 (* One token corresponds to a cheap DB read; expensive services cost multiples.
    The costs are loaded at startup from [Xapi_globs.call_costs_file], one
@@ -545,30 +593,98 @@ let submit_async ~user_agent ~client_ip ~callback ~task_create amount =
   submit ~submit_fn:Rate_limit.submit_async ~user_agent ~client_ip ~callback
     ~task_create amount
 
-(* We publish two derive data sources per known caller to xcp-rrdd: cumulative
-   tokens consumed and cumulative call count. *)
+(* We publish two derive data sources per caller group to xcp-rrdd: the group's
+   cumulative tokens consumed and its cumulative call count, summed over the
+   callers in that group. Reporting is per group rather than per caller, which
+   both matches how usage is analysed and bounds the number of data sources
+   (groups are administrator-defined, callers are not). Callers that belong to no
+   group are not reported. *)
 
-let reporter_uid = "xapi-rate-limit-callers"
+let reporter_uid = "xapi-rate-limit-groups"
 
-let make_caller_dss () =
-  Caller_table.to_list caller_table
-  |> List.concat_map (fun (_pattern, entry) ->
-      let uuid = Caller_statistics.get_uuid entry.stats in
+(* Sizing of the reporter's local shared-memory payload. The V2 protocol writes,
+   per data source, an 8-byte value plus its JSON metadata (name, description,
+   units, ...); a group's name-based data source comes to a few hundred bytes, so
+   512 bytes each is a safe over-estimate. Two data sources (tokens, calls) are
+   published per group. A single fixed 4 KB page previously overflowed at ~8
+   data sources, failing the writer with Failure "not enough memory". *)
+let reporter_page_size = 4096
+
+let reporter_bytes_per_ds = 512
+
+let reporter_fixed_overhead = 256
+
+(* Group names are administrator-defined and not bounded by any config, so size
+   the reporter generously. The backing file is sparse - only pages actually
+   written are committed - so an ample bound costs almost nothing, and the clamp
+   in [make_group_dss] guarantees the payload never exceeds the allocation. *)
+let reporter_max_groups = 1024
+
+(* Pages needed for two data sources per group plus fixed protocol overhead. *)
+let reporter_page_count max_groups =
+  let bytes =
+    reporter_fixed_overhead + (2 * max_groups * reporter_bytes_per_ds)
+  in
+  max 1 ((bytes + reporter_page_size - 1) / reporter_page_size)
+
+(* Ceiling on data sources written per cycle, captured when the reporter starts
+   so it matches the shared memory actually allocated. 0 means no reporter is
+   running yet. *)
+let reporter_max_datasources = ref 0
+
+(* Aggregate per-caller statistics into per-group [(group, tokens, calls)]
+   totals. Group membership is mirrored into each entry, so this needs no
+   database access - important because it runs on the reporter thread, which has
+   no context. *)
+let group_totals () =
+  let totals : (string, float * int) Hashtbl.t = Hashtbl.create 64 in
+  entries_of_table ()
+  |> List.iter (fun entry ->
       let tokens = Caller_statistics.get_token_count entry.stats in
       let calls = Caller_statistics.get_call_count entry.stats in
+      List.iter
+        (fun group ->
+          let t, c =
+            Option.value ~default:(0.0, 0) (Hashtbl.find_opt totals group)
+          in
+          Hashtbl.replace totals group (t +. tokens, c + calls)
+        )
+        entry.groups
+  ) ;
+  Hashtbl.fold (fun group (t, c) acc -> (group, t, c) :: acc) totals []
+
+let make_group_dss () =
+  let groups = group_totals () in
+  let groups =
+    let max_groups = !reporter_max_datasources / 2 in
+    if max_groups > 0 && List.length groups > max_groups then (
+      (* Defensive: never emit more data sources than the shared memory was
+         sized for. If somehow over, keep the busiest groups by token usage. *)
+      debug
+        "caller RRD reporter: %d groups exceed reporter capacity (%d); \
+         reporting the busiest"
+        (List.length groups) max_groups ;
+      groups
+      |> List.sort (fun (_, t1, _) (_, t2, _) -> compare t2 t1)
+      |> List.filteri (fun i _ -> i < max_groups)
+    ) else
+      groups
+  in
+  groups
+  |> List.concat_map (fun (group, tokens, calls) ->
       [
         ( Rrd.Host
         , Ds.ds_make
-            ~name:(Printf.sprintf "caller_%s_tokens" uuid)
+            ~name:(Printf.sprintf "group_%s_tokens" group)
             ~description:
-              (Printf.sprintf "Total tokens consumed by caller %s" uuid)
+              (Printf.sprintf "Total tokens consumed by caller group %s" group)
             ~value:(Rrd.VT_Float tokens) ~ty:Rrd.Derive ~default:true
             ~units:"tokens" ~min:0.0 ()
         )
       ; ( Rrd.Host
         , Ds.ds_make
-            ~name:(Printf.sprintf "caller_%s_calls" uuid)
-            ~description:(Printf.sprintf "Total calls by caller %s" uuid)
+            ~name:(Printf.sprintf "group_%s_calls" group)
+            ~description:(Printf.sprintf "Total calls by caller group %s" group)
             ~value:(Rrd.VT_Int64 (Int64.of_int calls))
             ~ty:Rrd.Derive ~default:true ~units:"calls" ~min:0.0 ()
         )
@@ -578,12 +694,15 @@ let make_caller_dss () =
 let reporter : Rrdd_plugin.Reporter.t option ref = ref None
 
 let start_reporter () =
+  reporter_max_datasources := 2 * reporter_max_groups ;
+  let page_count = reporter_page_count reporter_max_groups in
   try
     let r =
       Rrdd_plugin.Reporter.start_async
         (module D : Debug.DEBUG)
-        ~uid:reporter_uid ~neg_shift:0.5 ~target:(Rrdd_plugin.Reporter.Local 1)
-        ~protocol:Rrd_interface.V2 ~dss_f:make_caller_dss
+        ~uid:reporter_uid ~neg_shift:0.5
+        ~target:(Rrdd_plugin.Reporter.Local page_count)
+        ~protocol:Rrd_interface.V2 ~dss_f:make_group_dss
     in
     reporter := Some r
   with e ->
@@ -604,7 +723,8 @@ let register ~__context =
         insert_entry_locked ~caller_ref:self
           ~stats:(Caller_statistics.create ~caller_uuid:record.caller_uuid)
           ~pattern_key ~rate_limit_ref:record.API.caller_rate_limit
-          ~auto_registered:record.API.caller_auto_registered () ;
+          ~auto_registered:record.API.caller_auto_registered
+          ~groups:record.API.caller_groups () ;
         if record.API.caller_auto_registered then incr auto_registered_count
       )
       (Db.Caller.get_all ~__context) ;

--- a/ocaml/xapi/xapi_caller.ml
+++ b/ocaml/xapi/xapi_caller.ml
@@ -581,7 +581,10 @@ let submit ~submit_fn ~user_agent ~client_ip ~callback ~task_create amount =
     maybe_autocreate ~task_create ~user_agent ~client_ip ~existing:matches ;
     match bucket with
     | Some rl ->
-        submit_fn rl ~callback amount
+        let caller_details =
+          Printf.sprintf "client_ip: %s, user_agent: %s" client_ip user_agent
+        in
+        submit_fn rl ~callback ~caller_details amount
     | None ->
         callback ()
 

--- a/ocaml/xapi/xapi_caller.mli
+++ b/ocaml/xapi/xapi_caller.mli
@@ -62,6 +62,11 @@ val query_group_call_count : __context:Context.t -> group:string -> int64
 
 val query_all_usage : __context:Context.t -> string list list
 
+val group_totals : unit -> (string * float * int) list
+(** [(group, tokens, calls)] totals, summed over all callers in each group, from
+    in-memory state (no database access). This is the data published per group by
+    the RRD reporter. Callers in no group do not appear. *)
+
 val register : __context:Context.t -> unit
 (** Populate caller_table from persisted Caller rows and install
     [Xapi_rate_limit]'s caller-refresh callback. Must run after

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1202,6 +1202,14 @@ let event_next_delay, event_next_entry =
     ~delay_before:Mtime.Span.(200 * ms)
     ~delay_between:Mtime.Span.(50 * ms)
 
+(** Upper bound on the number of callers that [Xapi_caller] may auto-register.
+    When the limit is reached and a new caller must be registered, the
+    auto-registered caller with the least recent call is dropped first.
+    A value of 0 disables auto-registration entirely; a negative value means
+    unbounded. Manually created callers do not count towards this limit and are
+    never auto-evicted. *)
+let max_auto_registered_callers = ref 100
+
 let xapi_globs_spec =
   [
     ( "master_connection_reset_timeout"
@@ -1294,6 +1302,7 @@ let xapi_globs_spec =
   ; ("test-open", Int test_open) (* for consistency with xenopsd *)
   ; ("local_yum_repo_port", Int local_yum_repo_port)
   ; ("ha_best_effort_max_retries", Int ha_best_effort_max_retries)
+  ; ("max-auto-registered-callers", Int max_auto_registered_callers)
   ]
 
 let xapi_globs_spec_with_descriptions =

--- a/ocaml/xapi/xapi_http.ml
+++ b/ocaml/xapi/xapi_http.ml
@@ -360,8 +360,6 @@ let add_handler (name, handler) =
       | None ->
           handler ()
       | Some (user_agent, client_ip) ->
-          debug "Rate limiting handler %s with user_agent %s client_ip %s" name
-            user_agent client_ip ;
           Xapi_caller.submit_async ~user_agent ~client_ip ~callback:handler
             ~task_create:(Server_helpers.exec_with_new_task "Add new caller")
             Xapi_caller.default_token_cost

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -50,6 +50,12 @@ inventory = /etc/xensource-inventory
 # File mapping API calls to their rate-limiting token cost
 # call-costs-file = @ETCXENDIR@/call-costs.conf
 
+# Maximum number of callers auto-registered for rate limiting. When the limit
+# is reached, the auto-registered caller with the least recent call is dropped.
+# A value of 0 disables auto-registration; a negative value means unbounded.
+# Manually created callers are not counted.
+# max-auto-registered-callers = 100
+
 # Enable/disable the watchdog
 # nowatchdog = false
 


### PR DESCRIPTION
This PR addresses issues arising from unbounded, automatic caller registration and reporting of every caller in the following ways:
- Impose a limit of 100 auto-registered callers, configurable with xapi.conf key max-auto-registered-callers. A limit of 0 disables auto-registering, and a negative limit is treated as unlimited.
- Only publish rrd datasources for groups (manually labelled callers), rather than for individual callers.
- Publish a debug line with caller information whenever a rate limit is triggered