### PR TITLE
[ci] Don't use timedatectl to set timezone in actions

### DIFF
--- a/.github/workflows/generate-and-build-sdks.yml
+++ b/.github/workflows/generate-and-build-sdks.yml
@@ -73,7 +73,7 @@ jobs:
       # isn't using UTC
       - name: Set Timezone to Tokyo for datetime tests
         run: |
-          sudo timedatectl set-timezone Asia/Tokyo
+          sudo ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
       - name: Run CI for SDKs
         uses: ./.github/workflows/sdk-ci
@@ -139,7 +139,7 @@ jobs:
       # isn't using UTC
       - name: Set Timezone to Tokyo for datetime tests
         run: |
-          sudo timedatectl set-timezone Asia/Tokyo
+          sudo ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
       - name: Build Java SDK
         shell: bash


### PR DESCRIPTION
Multiple Test SDK builds jobs failed recently.
This may be caused by hosted runner environments run systemd services in a restricted contrainer state, blocking DBus connections required by timedatectl.
Replace by linking the system zoneinfo to set the timezone.