### PR TITLE
scripts/attach-static-vdis: Toggle nullglob to fix behavior on empty dir

### DIFF
--- a/scripts/attach-static-vdis
+++ b/scripts/attach-static-vdis
@@ -2,6 +2,8 @@
 #
 # attach-static-vdis    Attaches any statically-configured VDIs to dom0
 
+shopt -s nullglob
+
 STATE_DIR=/etc/xensource/static-vdis
 
 [ -d ${STATE_DIR} ] || exit 0
@@ -52,7 +54,7 @@ start() {
 	clear_stale_state
 	attach_all
 	RC=$?
-	echo 
+	echo
 	return $RC
 }
 


### PR DESCRIPTION
If `STATE_DIR` exists but is empty, then globs for it in the form of `STATE_DIR/*` and `STATE_DIR/*/vdi-uuid` will be passed in literal form, causing errors like:

    cat: /etc/xensource/static-vdis-test/*/vdi-uuid: No such file or directory

Toggle nullglob instead, which turns the whole glob string empty and does not enter the body of the loop iterating over the matches.