### PR TITLE
[backport] CA-430085: Fix vncsnapshot 500 error

### DIFF
--- a/ocaml/xapi/xapi_vncsnapshot.ml
+++ b/ocaml/xapi/xapi_vncsnapshot.ml
@@ -21,6 +21,8 @@ open D
 
 let vncsnapshot = "/usr/bin/vncsnapshot"
 
+let timeout = Mtime.Span.(30 * s)
+
 let vncsnapshot_handler (req : Request.t) s _ =
   debug "vncshapshot handler running" ;
   Xapi_http.with_context "Taking snapshot of VM console" req s (fun __context ->
@@ -29,27 +31,50 @@ let vncsnapshot_handler (req : Request.t) s _ =
         Console.rbac_check_for_control_domain __context req console
           Rbac_static.permission_http_get_vncsnapshot_host_console
             .Db_actions.role_name_label ;
-        let tmp = Filename.temp_file "snapshot" "jpg" in
+        let tmp = Filename.temp_file "snapshot" ".jpg" in
         let filename = Filename.basename tmp in
         Xapi_stdext_pervasives.Pervasiveext.finally
           (fun () ->
-            let vnc_port =
-              Int64.to_int (Db.Console.get_port ~__context ~self:console)
-            in
-            let pid =
-              safe_close_and_exec None None None [] vncsnapshot
-                [
-                  "-quiet"
-                ; "-allowblank"
-                ; "-encodings"
-                ; "\"raw\""
-                ; Printf.sprintf "%s:%d" "127.0.0.1" (vnc_port - 5900)
-                ; tmp
-                ]
-            in
-            let hsts_time = !Xapi_globs.hsts_max_age in
-            waitpid_fail_if_bad_exit pid ;
-            Http_svr.response_file ~hsts_time s tmp ~download_name:filename
+            match Console.address_of_console __context console with
+            | None ->
+                error "Failed to find the VNC console address" ;
+                Http_svr.headers s (Http.http_404_missing ())
+            | Some address ->
+                let target =
+                  match address with
+                  | Console.Port port ->
+                      [Printf.sprintf "127.0.0.1::%d" port]
+                  | Console.Path path ->
+                      ["-unix"; path]
+                in
+                let args =
+                  ["-allowblank"; "-encodings"; "raw"] @ target @ [tmp]
+                in
+                ( try
+                    let out, err =
+                      execute_command_get_output ~timeout vncsnapshot args
+                    in
+                    debug "vncsnapshot succeeded (stdout=%S stderr=%S)" out err
+                  with
+                | Subprocess_timeout as e ->
+                    error "vncsnapshot timed out after %s"
+                      (Fmt.to_to_string Mtime.Span.pp timeout) ;
+                    raise e
+                | Spawn_internal_error (err, out, status) as e ->
+                    let status =
+                      match status with
+                      | Unix.WEXITED n ->
+                          Printf.sprintf "exited with code %d" n
+                      | Unix.WSIGNALED n ->
+                          Printf.sprintf "was killed by signal %d" n
+                      | Unix.WSTOPPED n ->
+                          Printf.sprintf "was stopped by signal %d" n
+                    in
+                    error "vncsnapshot %s (stdout=%S stderr=%S)" status out err ;
+                    raise e
+                ) ;
+                let hsts_time = !Xapi_globs.hsts_max_age in
+                Http_svr.response_file ~hsts_time s tmp ~download_name:filename
           )
           (fun () -> try Unix.unlink tmp with _ -> ())
       with e ->


### PR DESCRIPTION
The handler took the VNC port from Db.Console.get_port, which is only correct for the control domain's console. For guest VMs the live console is provided by xenopsd and may be a TCP port or a Unix domain socket; the database port is stale (often 0), so vncsnapshot got "Connection refused" and the request failed with an HTTP 500.

Resolve the address with Console.address_of_console, the same lookup the VNC proxy uses, and pass either 127.0.0.1::<port> or -unix <path> to vncsnapshot accordingly. Respond 404 when the address cannot be found.

This is a backport of PR #7202