### PR TITLE
CP-314075: restore VDI.resize_online for online VDI resize

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5412,7 +5412,19 @@ module VDI = struct
 
   let resize_online =
     call ~name:"resize_online" ~in_oss_since:None
-      ~lifecycle:[(Published, rel_rio, "")]
+      ~lifecycle:
+        [
+          (Published, rel_rio, "")
+        ; (Deprecated, rel_inverness, "Dummy transition")
+        ; ( Removed
+          , rel_inverness
+          , "Online VDI resize is not supported by any of the storage backends."
+          )
+        ; ( Published
+          , "26.16.1-next"
+          , "Reintroduced to allow online resize of a VDI whose SR supports it"
+          )
+        ]
       ~params:
         [
           (Ref _vdi, "vdi", "The VDI to resize")

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5412,15 +5412,7 @@ module VDI = struct
 
   let resize_online =
     call ~name:"resize_online" ~in_oss_since:None
-      ~lifecycle:
-        [
-          (Published, rel_rio, "")
-        ; (Deprecated, rel_inverness, "Dummy transition")
-        ; ( Removed
-          , rel_inverness
-          , "Online VDI resize is not supported by any of the storage backends."
-          )
-        ]
+      ~lifecycle:[(Published, rel_rio, "")]
       ~params:
         [
           (Ref _vdi, "vdi", "The VDI to resize")

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -513,6 +513,7 @@ module Lifecycle = struct
      - The rest of the changes are not idempotent, they cannot be applied twice
        in a row
      - Objects can only be removed when are prototyped or deprecated
+     - A removed object can be published again, i.e. reintroduced
   *)
   let automaton =
     {
@@ -528,7 +529,7 @@ module Lifecycle = struct
           )
         | (Published as into), _, _ -> (
             function
-            | Unreleased_s | Prototyped_s ->
+            | Unreleased_s | Prototyped_s | Removed_s ->
                 Published_s
             | from ->
                 raise_invalid_next ~from ~into

--- a/ocaml/tests/test_datamodel_lifecycle.ml
+++ b/ocaml/tests/test_datamodel_lifecycle.ml
@@ -49,6 +49,15 @@ module SuccessfulLifecycleCreation = Generic.MakeStateless (struct
             ]
           , Removed_s
           )
+        ; (* A removed element can be reintroduced by publishing it again *)
+          ( [
+              (Published, "release1", "")
+            ; (Deprecated, "release2", "")
+            ; (Removed, "release3", "")
+            ; (Published, "release4", "")
+            ]
+          , Published_s
+          )
         ]
 end)
 
@@ -81,14 +90,6 @@ module FailingLifecycleCreation = Generic.MakeStateless (struct
         [
           ( [(Removed, "release1", "")]
           , Invalid "Invalid transition Removed from Unreleased_s"
-          )
-        ; ( [
-              (Published, "release1", "")
-            ; (Deprecated, "release2", "")
-            ; (Removed, "release3", "")
-            ; (Published, "release4", "")
-            ]
-          , Invalid "Invalid transition Published from Removed_s"
           )
         ]
 end)

--- a/ocaml/tests/test_vdi_allowed_operations.ml
+++ b/ocaml/tests/test_vdi_allowed_operations.ml
@@ -621,6 +621,60 @@ let test_revert =
   ; ("Revert: Cannot revert live", `Quick, test_cannot_revert_live)
   ]
 
+(* A VDI attached to a running VM (i.e. with an active RW VBD) can only be
+   resized via VDI.resize_online, and only when the SM backend advertises the
+   VDI_RESIZE_ONLINE capability. Offline VDI.resize remains disallowed while the
+   VDI is attached. *)
+let test_online_resize =
+  let features_with_online_resize =
+    ("VDI_RESIZE_ONLINE", 1L) :: Test_common.default_sm_features
+  in
+  let with_attached_rw_vbd __context vdi_ref =
+    make_vbd ~__context ~vDI:vdi_ref ~currently_attached:true ~mode:`RW ()
+  in
+  (* Offline resize of an attached VDI is still refused. *)
+  let test_offline_resize_blocked_when_attached () =
+    let __context = Mock.make_context_with_new_db "Mock context" in
+    run_assert_equal_with_vdi ~__context
+      ~vdi_fun:(with_attached_rw_vbd __context)
+      `resize
+      (Error (Api_errors.vdi_in_use, []))
+  in
+  (* Online resize is refused unless the SM backend supports it. *)
+  let test_resize_online_blocked_without_feature () =
+    let __context = Mock.make_context_with_new_db "Mock context" in
+    run_assert_equal_with_vdi ~__context
+      ~vdi_fun:(with_attached_rw_vbd __context)
+      `resize_online
+      (Error (Api_errors.sr_operation_not_supported, []))
+  in
+  (* Online resize of an attached VDI is allowed when the SM backend advertises
+     VDI_RESIZE_ONLINE. *)
+  let test_resize_online_allowed_with_feature () =
+    let __context = Mock.make_context_with_new_db "Mock context" in
+    run_assert_equal_with_vdi ~__context
+      ~sm_fun:(fun sm ->
+        Db.SM.set_features ~__context ~self:sm
+          ~value:features_with_online_resize
+      )
+      ~vdi_fun:(with_attached_rw_vbd __context)
+      `resize_online (Ok ())
+  in
+  [
+    ( "test_offline_resize_blocked_when_attached"
+    , `Quick
+    , test_offline_resize_blocked_when_attached
+    )
+  ; ( "test_resize_online_blocked_without_feature"
+    , `Quick
+    , test_resize_online_blocked_without_feature
+    )
+  ; ( "test_resize_online_allowed_with_feature"
+    , `Quick
+    , test_resize_online_allowed_with_feature
+    )
+  ]
+
 let test =
   [
     ("test_ca98944", `Quick, test_ca98944)
@@ -635,3 +689,4 @@ let test =
     ; ("test_update_allowed_operations", `Quick, test_update_allowed_operations)
     ]
   @ test_revert
+  @ test_online_resize

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -5747,6 +5747,17 @@ functor
             forward_vdi_op ~local_fn ~__context ~self:vdi ~remote_fn
         )
 
+      let resize_online ~__context ~vdi ~size =
+        info "VDI.resize_online: VDI = '%s'; size = %Ld"
+          (vdi_uuid ~__context vdi) size ;
+        let local_fn = Local.VDI.resize_online ~vdi ~size in
+        let remote_fn = Client.VDI.resize_online ~vdi ~size in
+        let sR = Db.VDI.get_SR ~__context ~self:vdi in
+        with_sr_andor_vdi ~__context ~sr:(sR, `vdi_resize)
+          ~vdi:(vdi, `resize_online) ~doc:"VDI.resize_online" (fun () ->
+            forward_vdi_op ~local_fn ~__context ~self:vdi ~remote_fn
+        )
+
       let generate_config ~__context ~host ~vdi =
         info "VDI.generate_config: VDI = '%s'; host = '%s'"
           (vdi_uuid ~__context vdi)

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -1066,6 +1066,12 @@ let resize ~__context ~vdi ~size =
       Db.VDI.set_virtual_size ~__context ~self:vdi ~value:new_size
   )
 
+(* Online resize follows exactly the same storage path as the offline resize;
+   the distinction lives in xapi's allowed-operations checks, which permit
+   resize_online on a VDI attached to a running VM (subject to the SM backend
+   advertising the VDI_RESIZE_ONLINE capability). *)
+let resize_online = resize
+
 let generate_config ~__context ~host:_ ~vdi =
   Sm.assert_pbd_is_plugged ~__context ~sr:(Db.VDI.get_SR ~__context ~self:vdi) ;
   Xapi_vdi_helpers.assert_managed ~__context ~vdi ;

--- a/ocaml/xapi/xapi_vdi.mli
+++ b/ocaml/xapi/xapi_vdi.mli
@@ -164,6 +164,9 @@ val _data_destroy :
 
 val resize : __context:Context.t -> vdi:[`VDI] API.Ref.t -> size:int64 -> unit
 
+val resize_online :
+  __context:Context.t -> vdi:[`VDI] API.Ref.t -> size:int64 -> unit
+
 val generate_config :
   __context:Context.t -> host:'a -> vdi:[`VDI] API.Ref.t -> string
 


### PR DESCRIPTION
Reinstate the VDI.resize_online API that was removed in 31b22ccc94dcbcae89bb4099fd303000f2c71a24 (CA-262059), so that "xe vdi-resize online=true" can resize a VDI attached to a running VM. resize_online shares the offline resize storage path (SM vdi_resize); the online/offline distinction lives in xapi's allowed-operations checks, which permit resize_online on an attached VDI only when the SM backend advertises the VDI_RESIZE_ONLINE capability. It is then up to the backend to decide whether it can satisfy the request and to fail with an appropriate error if it cannot.

- datamodel: mark resize_online as published again
- message_forwarding: restore resize_online forwarding
- xapi_vdi: resize_online implementation; revert resize live-permission change
- tests: cover resize_online allowed/blocked by VDI_RESIZE_ONLINE feature and offline resize still blocked while attached