### PR TITLE
[Backport] CA-430018: Fix mismatch between VGPU and PCI cards

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1465,8 +1465,8 @@ let create_metadata ~__context ~self =
       )
   in
   let vifs' = List.map (fun vif -> MD.of_vif ~__context ~vm ~vif) vifs in
-  let pcis = MD.pcis_of_vm ~__context (self, vm) in
   let vgpus = MD.vgpus_of_vm ~__context (self, vm) in
+  let pcis = MD.pcis_of_vm ~__context (self, vm) in
   let vusbs = MD.vusbs_of_vm ~__context (self, vm) in
   let domains =
     (* For suspended VMs, the last_booted_record contains the "live" xenopsd state. *)


### PR DESCRIPTION
In case of migration updating VGPU card requires changing both VGPU and PCI records.
Part of this job in done in different machines (for instance VGPU allocation needs to be done in destination host) and is done by different processes (Xapi and Xenops).
Some updates causes executing a "import_metadata" operation that read metadata while they are still changing so VGPU PCI address won't match PCI address causing the migration to fail.
Currently the code causes old pci and new vgpu which causes the migration to fail. Change order computing metadata causing new pci and old vgpu. This does not cause issues as the infer_vgpu_map always get the new vgpu from XAPI DB.



(cherry picked from commit c1ea186770360e58d09c3ddb93bc96f79f324a80)