### PR TITLE
CA-429051: Sync original bond slave network MTU

### DIFF
--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -537,7 +537,15 @@ let bring_pif_up ~__context ?(management_interface = false) (pif : API.ref_PIF)
                 let bond_record = Db.Bond.get_record ~__context ~self:bond in
                 List.iter
                   (fun self ->
-                    Db.PIF.set_currently_attached ~__context ~self ~value:false
+                    Db.PIF.set_currently_attached ~__context ~self ~value:false ;
+                    let slave_net = Db.PIF.get_network ~__context ~self in
+                    let bond_mtu = net_rc.API.network_MTU in
+                    if Db.Network.get_MTU ~__context ~self:slave_net <> bond_mtu
+                    then (
+                      debug "Setting MTU of slave network MTU to %Ld" bond_mtu ;
+                      Db.Network.set_MTU ~__context ~self:slave_net
+                        ~value:bond_mtu
+                    )
                   )
                   bond_record.API.bond_slaves ;
                 maybe_update_master_pif_mac ~__context bond_record rc pif


### PR DESCRIPTION
When bond is created, user can configure MTU on the bond network. The underlying physical NIC and PIF object MTU is handled properly. However, the original per-NIC bond slave network MTU is not changed.
A corner case is seen that the unused bond slave network MTU may cause MTU mismatch when pool join:
The pool has bond and vlan on the bond with MTU 9000, while the joining host has single-NIC and same vlan with MTU 1500. After pool join, during restart, the joining host is configured vlan MTU 9000 and physical NIC MTU 1500. In normal case, the joining host should sync vlan and bond with pool. But here the MTU dismatching leads to drop packets with pool master, then the joining host can't leave maintain mode.
This PR prevent this case by sync the bond slave network MTU with bond network MTU.