### PR TITLE
[backport] CA-428532: Ensure db flush is executed in shutdown_agent

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -811,8 +811,13 @@ let restart_agent ~__context ~host:_ =
 let shutdown_agent ~__context =
   debug "Host.shutdown_agent: Host agent will shutdown in 1s!!!!" ;
   let host_uuid = Helpers.get_localhost_uuid () in
-  Xapi_hooks.xapi_pre_shutdown ~__context ~host_uuid
-    ~reason:Xapi_hooks.reason__clean_shutdown ;
+  ( try
+      Xapi_hooks.xapi_pre_shutdown ~__context ~host_uuid
+        ~reason:Xapi_hooks.reason__clean_shutdown
+    with exn ->
+      warn "%s: xapi_pre_shutdown hook failed: %s" __FUNCTION__
+        (Printexc.to_string exn)
+  ) ;
   Xapi_fuse.light_fuse_and_dont_restart ~fuse_length:1. ()
 
 let disable ~__context ~host ~auto_enable =


### PR DESCRIPTION
In `shutdown_agent`, the `xapi_pre_shutdown` may raise exception, then the `light_fuse_and_dont_restart` is skipped. A DB data loss is found because db flush in that funtion is not executed.

Backport of PR #7164
(cherry picked from commit 331227c1a4debd00eee3c9673c71ccaa6305f6eb)