### PR TITLE
Resolve blockers for SMAPIv3 snapshot-aware migration

### DIFF
--- a/ocaml/xapi-idl/storage/storage_interface.ml
+++ b/ocaml/xapi-idl/storage/storage_interface.ml
@@ -978,6 +978,23 @@ module StorageAPI (R : RPC) = struct
       declare "VDI.set_content_id" []
         (dbg_p @-> sr_p @-> vdi_p @-> content_id_p @-> returning unit_p err)
 
+    (** [set_snapshot_metadata sr vdi snapshot_of snapshot_time is_a_snapshot] tells
+        the storage backend that [vdi] is a snapshot of [snapshot_of] taken at
+        [snapshot_time]. *)
+    let set_snapshot_metadata =
+      let snapshot_of_p = Param.mk ~name:"snapshot_of" Vdi.t in
+      let snapshot_time_p = Param.mk ~name:"snapshot_time" Types.string in
+      let is_a_snapshot_p = Param.mk ~name:"is_a_snapshot" Types.bool in
+      declare "VDI.set_snapshot_metadata" []
+        (dbg_p
+        @-> sr_p
+        @-> vdi_p
+        @-> snapshot_of_p
+        @-> snapshot_time_p
+        @-> is_a_snapshot_p
+        @-> returning unit_p err
+        )
+
     (** [compose task sr parent child] layers the updates from [child] onto [parent],
         modifying [child] *)
     let compose =
@@ -1628,6 +1645,16 @@ module type Server_impl = sig
       -> content_id:content_id
       -> unit
 
+    val set_snapshot_metadata :
+         context
+      -> dbg:debug_info
+      -> sr:sr
+      -> vdi:vdi
+      -> snapshot_of:vdi
+      -> snapshot_time:string
+      -> is_a_snapshot:bool
+      -> unit
+
     val compose :
       context -> dbg:debug_info -> sr:sr -> vdi1:vdi -> vdi2:vdi -> unit
 
@@ -1838,6 +1865,11 @@ module Server (Impl : Server_impl) () = struct
     S.VDI.get_by_name (fun dbg sr name -> Impl.VDI.get_by_name () ~dbg ~sr ~name) ;
     S.VDI.set_content_id (fun dbg sr vdi content_id ->
         Impl.VDI.set_content_id () ~dbg ~sr ~vdi ~content_id
+    ) ;
+    S.VDI.set_snapshot_metadata
+      (fun dbg sr vdi snapshot_of snapshot_time is_a_snapshot ->
+        Impl.VDI.set_snapshot_metadata () ~dbg ~sr ~vdi ~snapshot_of
+          ~snapshot_time ~is_a_snapshot
     ) ;
     S.VDI.compose (fun dbg sr vdi1 vdi2 ->
         Impl.VDI.compose () ~dbg ~sr ~vdi1 ~vdi2

--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
+++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
@@ -155,6 +155,10 @@ module VDI = struct
   let set_content_id ctx ~dbg ~sr ~vdi ~content_id =
     Storage_interface.unimplemented __FUNCTION__
 
+  let set_snapshot_metadata ctx ~dbg ~sr ~vdi ~snapshot_of ~snapshot_time
+      ~is_a_snapshot =
+    Storage_interface.unimplemented __FUNCTION__
+
   let compose ctx ~dbg ~sr ~vdi1 ~vdi2 =
     Storage_interface.unimplemented __FUNCTION__
 

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1465,6 +1465,14 @@ module VDIImpl (M : META) = struct
     >>>= (fun sr ->
     clone ~dbg ~sr
       ~vdi:(Storage_interface.Vdi.string_of vdi_info.Storage_interface.vdi)
+    >>>= update_keys ~dbg ~sr ~key:_vdi_type_key
+           ~value:
+             ( match vdi_info.Storage_interface.ty with
+             | "" ->
+                 None
+             | s ->
+                 Some s
+             )
     >>>= fun response -> return (vdi_of_volume response)
     )
     |> wrap

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1814,6 +1814,20 @@ end
 module DATAImpl (M : META) = struct
   module VDI = VDIImpl (M)
 
+  (* per-(sr,vdi) cache to avoid Volume.stat RPC on every mirror poll.
+     No mutex: this module runs single-threaded under Lwt. *)
+  let vdi_stat_cache = Base.Hashtbl.create ~size:16 (module Base.String)
+
+  let stat_resolve_clone_on_boot ~dbg ~sr ~vdi =
+    VDI.stat ~dbg ~sr ~vdi >>>= fun response ->
+    match
+      List.assoc_opt _clone_on_boot_key response.Xapi_storage.Control.keys
+    with
+    | None ->
+        return response
+    | Some temporary ->
+        VDI.stat ~dbg ~sr ~vdi:temporary
+
   let stat dbg sr vdi' _vm key =
     let open Storage_interface in
     let convert_key = function
@@ -1823,16 +1837,16 @@ module DATAImpl (M : META) = struct
           Data_client.MirrorV1 k
     in
 
+    let sr_str = Sr.string_of sr in
     let vdi = Vdi.string_of vdi' in
+    let cache_key = sr_str ^ "/" ^ vdi in
+
     Attached_SRs.find sr >>>= fun sr ->
-    VDI.stat ~dbg ~sr ~vdi >>>= fun response ->
-    ( match
-        List.assoc_opt _clone_on_boot_key response.Xapi_storage.Control.keys
-      with
+    ( match Base.Hashtbl.find vdi_stat_cache cache_key with
+      | Some cached_response ->
+          return cached_response
       | None ->
-          return response
-      | Some temporary ->
-          VDI.stat ~dbg ~sr ~vdi:temporary
+          stat_resolve_clone_on_boot ~dbg ~sr ~vdi
       )
     >>>= fun response ->
     choose_datapath response >>>= fun (rpc, _datapath, _uri) ->
@@ -1840,6 +1854,7 @@ module DATAImpl (M : META) = struct
     return_data_rpc (fun () -> Data_client.stat (rpc ~dbg) dbg key)
     >>>= function
     | {failed; complete; progress} ->
+        if complete || failed then Base.Hashtbl.remove vdi_stat_cache cache_key ;
         return Mirror.{failed; complete; progress}
 
   let stat_impl dbg sr vdi vm key = wrap @@ stat dbg sr vdi vm key
@@ -1848,19 +1863,14 @@ module DATAImpl (M : META) = struct
     let* () =
       info (fun m -> m "image_format (%s) is not currently used" image_format)
     in
+    let sr_str = Storage_interface.Sr.string_of sr in
     let vdi = Storage_interface.Vdi.string_of vdi' in
     let domain = Storage_interface.Vm.string_of vm' in
+    let cache_key = sr_str ^ "/" ^ vdi in
+
     Attached_SRs.find sr >>>= fun sr ->
-    VDI.stat ~dbg ~sr ~vdi >>>= fun response ->
-    ( match
-        List.assoc_opt _clone_on_boot_key response.Xapi_storage.Control.keys
-      with
-      | None ->
-          return response
-      | Some temporary ->
-          VDI.stat ~dbg ~sr ~vdi:temporary
-      )
-    >>>= fun response ->
+    stat_resolve_clone_on_boot ~dbg ~sr ~vdi >>>= fun response ->
+    Base.Hashtbl.set vdi_stat_cache ~key:cache_key ~data:response ;
     choose_datapath response >>>= fun (rpc, _datapath, uri) ->
     return_data_rpc (fun () ->
         Data_client.mirror (rpc ~dbg) dbg uri domain remote

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1347,6 +1347,20 @@ module VDIImpl (M : META) = struct
         Volume_client.unset (volume_rpc ~dbg ?missing) dbg sr vdi key
     )
 
+  (* Non-transactional, like other multi-key setters here; the XAPI DB
+     updated by SR.update_snapshot_info_dest is authoritative and wins on
+     SR.scan. *)
+  let set_snapshot_metadata ~dbg ~sr ~vdi ~snapshot_of ~snapshot_time
+      ~is_a_snapshot =
+    let vdi_str = Storage_interface.Vdi.string_of vdi in
+    let snapshot_of_str = Storage_interface.Vdi.string_of snapshot_of in
+    set ~dbg ~sr ~vdi:vdi_str ~key:_snapshot_of_key ~value:snapshot_of_str
+    >>>= fun () ->
+    set ~dbg ~sr ~vdi:vdi_str ~key:_snapshot_time_key ~value:snapshot_time
+    >>>= fun () ->
+    set ~dbg ~sr ~vdi:vdi_str ~key:_is_a_snapshot_key
+      ~value:(string_of_bool is_a_snapshot)
+
   let stat ~dbg ~sr ~vdi =
     (* TODO add default value to sharable? *)
     return_volume_rpc (fun () ->
@@ -1736,6 +1750,17 @@ module VDIImpl (M : META) = struct
     let* () = set ~dbg ~sr ~vdi ~key:_vdi_content_id_key ~value:content_id in
     return ()
 
+  let vdi_set_snapshot_metadata_impl dbg sr vdi snapshot_of snapshot_time
+      is_a_snapshot =
+    wrap
+    @@
+    let* sr = Attached_SRs.find sr in
+    let* () =
+      set_snapshot_metadata ~dbg ~sr ~vdi ~snapshot_of ~snapshot_time
+        ~is_a_snapshot
+    in
+    return ()
+
   let vdi_add_to_sm_config_impl dbg sr vdi key value =
     wrap
     @@
@@ -1958,6 +1983,7 @@ let bind ~volume_script_dir =
   S.VDI.data_destroy VDI.vdi_data_destroy_impl ;
   S.VDI.compose VDI.vdi_compose_impl ;
   S.VDI.set_content_id VDI.vdi_set_content_id_impl ;
+  S.VDI.set_snapshot_metadata VDI.vdi_set_snapshot_metadata_impl ;
   S.VDI.add_to_sm_config VDI.vdi_add_to_sm_config_impl ;
   S.VDI.remove_from_sm_config VDI.vdi_remove_from_sm_config_impl ;
   S.VDI.similar_content VDI.similar_content_impl ;

--- a/ocaml/xapi/storage_migrate_helper.ml
+++ b/ocaml/xapi/storage_migrate_helper.ml
@@ -345,6 +345,76 @@ end))
 
 module type SMAPIv2 = module type of Local
 
+(* Forget an orphan VDI row on the SXM destination pool. Uses the XenAPI
+   session embedded in the SXM url so the lookup runs against the dest
+   pool's DB — required for cross-pool SXM where the source pool has no
+   row for the dest SR. Empty url means a legacy intra-pool path that
+   already cleaned the row via SMAPIv1 vdi_delete; no-op then. *)
+let forget_orphan_dest_vdi ~url ~verify_dest ~sr ~vdi =
+  if url = "" then
+    SXM.debug "%s: no url, skipping dest forget" __FUNCTION__
+  else
+    SXM.log_and_ignore_exn (fun () ->
+        let parsed = Http.Url.of_string url in
+        let session_id_opt =
+          List.assoc_opt "session_id" (Http.Url.get_query_params parsed)
+          |> Option.map Ref.of_string
+        in
+        let host_opt =
+          match fst parsed with
+          | Http.Url.Http {host; _} ->
+              Some host
+          | _ ->
+              None
+        in
+        match (session_id_opt, host_opt) with
+        | Some session_id, Some host ->
+            Server_helpers.exec_with_new_task "SXM forget orphan dest VDI"
+              (fun __context ->
+                let verify_cert =
+                  if verify_dest then
+                    Stunnel_client.pool ()
+                  else
+                    None
+                in
+                let uuid = Vdi.string_of vdi in
+                let lookup host =
+                  let rpc =
+                    Helpers.make_remote_rpc ~verify_cert ~__context host
+                  in
+                  (Client.Client.VDI.get_by_uuid ~rpc ~session_id ~uuid, rpc)
+                in
+                let resolve () =
+                  try Some (lookup host) with
+                  | Api_errors.Server_error (code, master_ip :: _)
+                    when code = Api_errors.host_is_slave -> (
+                    try Some (lookup master_ip) with _ -> None
+                  )
+                  | _ ->
+                      None
+                in
+                match resolve () with
+                | None ->
+                    ()
+                | Some (vdi_ref, rpc) ->
+                    let rec_ =
+                      Client.Client.VDI.get_record ~rpc ~session_id
+                        ~self:vdi_ref
+                    in
+                    if rec_.API.vDI_is_a_snapshot then (
+                      SXM.info "%s forgetting orphan VDI %s on dest sr %s"
+                        __FUNCTION__ uuid (Sr.string_of sr) ;
+                      Client.Client.VDI.forget ~rpc ~session_id ~vdi:vdi_ref
+                    ) else
+                      SXM.warn
+                        "%s skipping non-snapshot row at vdi %s on dest sr %s"
+                        __FUNCTION__ uuid (Sr.string_of sr)
+            )
+        | _ ->
+            SXM.warn "%s url missing session_id or host, skipping forget"
+              __FUNCTION__
+    )
+
 let get_remote_backend url verify_dest =
   let remote_url = Storage_utils.connection_args_of_uri ~verify_dest url in
   let module Remote = StorageAPI (Idl.Exn.GenClient (struct

--- a/ocaml/xapi/storage_migrate_helper.mli
+++ b/ocaml/xapi/storage_migrate_helper.mli
@@ -265,6 +265,12 @@ module Local : SMAPIv2
 
 val get_remote_backend : string -> bool -> (module SMAPIv2)
 
+val forget_orphan_dest_vdi :
+  url:string -> verify_dest:bool -> sr:sr -> vdi:vdi -> unit
+(** Forget an orphan VDI row on the SXM destination pool using the XenAPI
+    session embedded in the SXM url. Best-effort; cross-pool safe; empty
+    [url] is a no-op for legacy intra-pool paths. *)
+
 val find_vdi :
   dbg:string -> sr:sr -> vdi:vdi -> (module SMAPIv2) -> vdi_info * vdi_info list
 

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -365,8 +365,16 @@ module Mux = struct
           Db.VDI.set_snapshot_of ~__context ~self:vdi ~value:snapshot_of
       )
 
+    (* Push snapshot metadata to the backend so a later SR.scan does not
+       re-overwrite XAPI DB fields with stale volume keys. *)
+    let update_backend_snapshot_metadata ~dbg sr snapshot leaf snapshot_time =
+      let module C = StorageAPI (Idl.Exn.GenClient (struct
+        let rpc = of_sr sr
+      end)) in
+      C.VDI.set_snapshot_metadata dbg sr snapshot leaf snapshot_time true
+
     let update_snapshot_info_dest () ~dbg ~sr ~vdi ~src_vdi ~snapshot_pairs =
-      with_dbg ~name:"SR.update_snapshot_info_dest" ~dbg @@ fun _di ->
+      with_dbg ~name:"SR.update_snapshot_info_dest" ~dbg @@ fun di ->
       info
         "SR.update_snapshot_info_dest dbg:%s sr:%s vdi:%s ~src_vdi:%s \
          snapshot_pairs:%s"
@@ -409,6 +417,11 @@ module Mux = struct
               in
               assert_content_ids_match ~vdi_info1:local_snapshot_info
                 ~vdi_info2:src_snapshot_info ;
+              D.log_and_ignore_exn (fun () ->
+                  update_backend_snapshot_metadata
+                    ~dbg:(Debug_info.to_string di) sr local_snapshot vdi
+                    src_snapshot_info.snapshot_time
+              ) ;
               set_snapshot_time __context ~dbg ~sr ~vdi:local_snapshot
                 ~snapshot_time:src_snapshot_info.snapshot_time ;
               set_snapshot_of __context ~dbg ~sr ~vdi:local_snapshot
@@ -705,6 +718,17 @@ module Mux = struct
         let rpc = of_sr sr
       end)) in
       C.VDI.set_content_id (Debug_info.to_string di) sr vdi content_id
+
+    let set_snapshot_metadata () ~dbg ~sr ~vdi ~snapshot_of ~snapshot_time
+        ~is_a_snapshot =
+      with_dbg ~name:"VDI.set_snapshot_metadata" ~dbg @@ fun di ->
+      info "VDI.set_snapshot_metadata dbg:%s sr:%s vdi:%s snapshot_of:%s" dbg
+        (s_of_sr sr) (s_of_vdi vdi) (s_of_vdi snapshot_of) ;
+      let module C = StorageAPI (Idl.Exn.GenClient (struct
+        let rpc = of_sr sr
+      end)) in
+      C.VDI.set_snapshot_metadata (Debug_info.to_string di) sr vdi snapshot_of
+        snapshot_time is_a_snapshot
 
     let similar_content () ~dbg ~sr ~vdi =
       with_dbg ~name:"VDI.similar_content" ~dbg @@ fun di ->

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -887,6 +887,11 @@ module SMAPIv1 : Server_impl = struct
             ~value:content_id
       )
 
+    let set_snapshot_metadata _context ~dbg:_ ~sr:_ ~vdi:_ ~snapshot_of:_
+        ~snapshot_time:_ ~is_a_snapshot:_ =
+      (* SMAPIv1 doesn't need this - snapshot metadata is managed by xapi database only *)
+      ()
+
     let similar_content _context ~dbg ~sr ~vdi =
       with_dbg ~name:"VDI.similar_content" ~dbg @@ fun di ->
       info "VDI.similar_content dbg:%s sr:%s vdi:%s" di.log (s_of_sr sr)

--- a/ocaml/xapi/storage_smapiv1_migrate.ml
+++ b/ocaml/xapi/storage_smapiv1_migrate.ml
@@ -634,7 +634,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
         mirror_cleanup ~dbg ~sr ~snapshot
 
   let receive_start_common ~dbg ~sr ~vdi_info ~id ~image_format ~similar ~vm
-      (module SMAPI : SMAPIv2) =
+      ~url ~verify_dest (module SMAPI : SMAPIv2) =
     let on_fail : (unit -> unit) list ref = ref [] in
     let vdis = SMAPI.SR.scan dbg sr in
     (* We drop cbt_metadata VDIs that do not have any actual data *)
@@ -734,8 +734,8 @@ module MIRROR : SMAPIv2_MIRROR = struct
               ; parent_vdi= parent.vdi
               ; remote_vdi= vdi_info.vdi
               ; mirror_vm= vm
-              ; url= ""
-              ; verify_dest= false
+              ; url
+              ; verify_dest
               }
         ) ;
       let nearest_content_id = Option.map (fun x -> x.content_id) nearest in
@@ -763,7 +763,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
       (string_of_vdi_info vdi_info)
       id image_format ;
     receive_start_common ~dbg ~sr ~vdi_info ~id ~image_format ~similar
-      ~vm:(Vm.of_string "0")
+      ~vm:(Vm.of_string "0") ~url:"" ~verify_dest:false
       (module Local)
 
   let receive_start2 _ctx ~dbg ~sr ~vdi_info ~id ~image_format ~similar ~vm =
@@ -772,6 +772,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
       (string_of_vdi_info vdi_info)
       id image_format ;
     receive_start_common ~dbg ~sr ~vdi_info ~id ~image_format ~similar ~vm
+      ~url:"" ~verify_dest:false
       (module Local)
 
   let receive_start3 _ctx ~dbg ~sr ~vdi_info ~mirror_id ~image_format ~similar
@@ -786,7 +787,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
       Storage_migrate_helper.get_remote_backend url verify_dest
     in
     receive_start_common ~dbg ~sr ~vdi_info ~id:mirror_id ~image_format ~similar
-      ~vm
+      ~vm ~url ~verify_dest
       (module Remote)
 
   let receive_finalize _ctx ~dbg ~id =
@@ -808,10 +809,17 @@ module MIRROR : SMAPIv2_MIRROR = struct
           (Vdi.string_of r.leaf_vdi) ;
         SMAPI.DP.destroy2 dbg r.leaf_dp r.sr r.leaf_vdi r.mirror_vm false ;
         SMAPI.VDI.compose dbg r.sr r.parent_vdi r.leaf_vdi ;
-        (* On SMAPIv3, compose would have removed the now invalid dummy vdi, so
-           there is no need to destroy it anymore, while this is necessary on SMAPIv1 SRs. *)
+        (* Destroy the dummy backend volume on the dest SR. On SMAPIv1
+           this also drops the dest XAPI DB row; on SMAPIv3 only the
+           backend volume is removed. *)
         D.log_and_ignore_exn (fun () -> SMAPI.VDI.destroy dbg r.sr r.dummy_vdi
         ) ;
+        (* Forget the dest XAPI DB row that survives on SMAPIv3. The forget
+           runs against the dest pool via the XenAPI session embedded in the
+           SXM url, so it works both intra-pool and cross-pool. No-op on
+           SMAPIv1 where the row was already dropped above. *)
+        Storage_migrate_helper.forget_orphan_dest_vdi ~url:r.url
+          ~verify_dest:r.verify_dest ~sr:r.sr ~vdi:r.dummy_vdi ;
         SMAPI.VDI.remove_from_sm_config dbg r.sr r.leaf_vdi "base_mirror"
       )
       recv_state ;
@@ -932,7 +940,9 @@ module MIRROR : SMAPIv2_MIRROR = struct
         D.log_and_ignore_exn (fun () -> Remote.DP.destroy dbg r.leaf_dp false) ;
         List.iter
           (fun v ->
-            D.log_and_ignore_exn (fun () -> Remote.VDI.destroy dbg r.sr v)
+            D.log_and_ignore_exn (fun () -> Remote.VDI.destroy dbg r.sr v) ;
+            Storage_migrate_helper.forget_orphan_dest_vdi ~url ~verify_dest
+              ~sr:r.sr ~vdi:v
           )
           [r.dummy_vdi; r.leaf_vdi; r.parent_vdi]
       )

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -880,6 +880,15 @@ functor
         let dbg = Debug_info.to_string di in
         Impl.VDI.set_content_id context ~dbg ~sr ~vdi ~content_id
 
+      let set_snapshot_metadata context ~dbg ~sr ~vdi ~snapshot_of
+          ~snapshot_time ~is_a_snapshot =
+        with_dbg ~name:"VDI.set_snapshot_metadata" ~dbg @@ fun di ->
+        info "VDI.set_snapshot_metadata dbg:%s sr:%s vdi:%s snapshot_of:%s"
+          di.log (s_of_sr sr) (s_of_vdi vdi) (s_of_vdi snapshot_of) ;
+        let dbg = Debug_info.to_string di in
+        Impl.VDI.set_snapshot_metadata context ~dbg ~sr ~vdi ~snapshot_of
+          ~snapshot_time ~is_a_snapshot
+
       let similar_content context ~dbg ~sr ~vdi =
         with_dbg ~name:"VDI.similar_content" ~dbg @@ fun di ->
         info "VDI.similar_content dbg:%s sr:%s vdi:%s" di.log (s_of_sr sr)


### PR DESCRIPTION
This PR does not contain the SXM v3 snapshot-migration itself. It lands the prerequisite fixes (and one optimization) that currently block it, so they can be reviewed independently. The SXM v3 and its wiring follow in two subsequent PRs.
- Snapshot metadata consistency for SMAPIv1 to SMAPIv3 migration
- Mirror polling optimization with cache
- Orphan dummy VDI not clean up after SMAPIv3 compose in SMAPIv1->SMAPIv3 SXM
- VDI type lost after snapshot revert on SMAPIv3 SR

Design refer: https://github.com/xapi-project/xen-api/blob/feature/sxm-v3/doc/content/xapi/storage/sxm/sxm-v3-with-snapshot.md
