### PR TITLE
[backport] Start SM service after dbsync to avoid startup deadlock

### DIFF
--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -1105,7 +1105,6 @@ let server_init () =
             , [Startup.OnlyMaster]
             , Storage_access.start_smapiv1_servers
             )
-          ; ("Starting SM service", [], Storage_access.start)
           ; ("Starting SM xapi event service", [], Storage_access.events_from_sm)
           ; ("Killing stray sparse_dd processes", [], Sparse_dd_wrapper.killall)
           ; ( "Registering http handlers"
@@ -1251,7 +1250,16 @@ let server_init () =
         ) ;
         Startup.run ~__context
           [
-            ("Checking emergency network reset", [], check_network_reset)
+            (* SM must listen on org.xen.xapi.storage after dbsync. Registering the queue
+               earlier means a message from deamon like xenopsd (which restarts and reposts
+               pending operations, e.g. a DP.destroy) is handled immediatly and can take a
+               per-VDI lock that can deadlocks refresh_local_vdi_activations during dbsync.
+               Messages stay safely queued in message-switch until we register here. Dbsync
+               itself doesn't need the queue since internal storage calls go directly through
+               Storage_mux.Server.process.
+           *)
+            ("Starting SM service", [], Storage_access.start)
+          ; ("Checking emergency network reset", [], check_network_reset)
           ; ( "Upgrade bonds to Boston"
             , [Startup.NoExnRaising]
             , Sync_networking.fix_bonds ~__context


### PR DESCRIPTION
The patch fixes an issue that can happens if a VDI operation fails on a SR and keeps the lock. In such case the XAPI can be blocked during the startup. Here is the scenario:
- Xenopsd and XAPI are restarted
- Xenopsd is looking for existing VBDs and check with hypervisor the status. If it needs to be destroyed it pushes a message DP.destroy2 on org.xen.xapi.storage queue.
- XAPI starts, nothing listens on the queue
- At some point a thread is started and handle the message posted by Xenopsd. Plugins are not yet loaded so an error `No_storage_plugin_for_sr` is returned to Xenopsd. Xenopsd will retry in 5s.
- XAPI continues to boot and sync its database:
  - sync_pbds: it is where SMAPI plugins are setup and now we can handle the message to destroy the VBD
  - And here there are more syncs: sync_pci_devices, sync_pif_params, ...
  - until sync_local_vdi_activations. The deadlock can happen here. If it takes more than 5s to reach the sync of VDIs, Xenopsd has time to post its DP.destroy2. The message is handled by XAPI, the lock for the VDI is taken and the SM plugin is called. We see in production that the operation never returns and so the lock is never released. When XAPI call sync on VDIs, it will sync the VDI that has the problem. And it will wait for the lock preventing the XAPI to start correctly.

So this patch moves the registration of the queue (Storage_access.start) after the synchronisation of the XAPI database. Pending messages remains in the queue and the sync of VDIs asked by XAPI database update process during the start can be done. Of course the problem with the VDI is still there but XAPI can now start.

Tracking-reference: XCPNG-3515

Backport of PR #7179
(cherry picked from commit 246390b58448882f865a3ce695e0dc56d7b45200)