### PR TITLE
Document which branch of xs-opam to use to build this branch

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -47,8 +47,9 @@ To build xen-api from source, we recommend using [opam](https://opam.ocaml.org/d
 5) Get the Recommended Packages.
 
     ```bash
-    # Add the xs-opam library as the main repo to check for versions at:
-    opam repo add xs-opam https://github.com/xapi-project/xs-opam.git
+    # Add branch 6.99-lcm of the xs-opam library as the main repo
+    # to check for versions at:
+    opam repo add xs-opam-6.99-lcm "https://github.com/xapi-project/xs-opam.git#6.99-lcm"
     # Remove the default, because how it handles version conflicts is different:
     opam repo remove default
     # (NOT needed with opam>=2.1.0) Have opam now figure out what versions of each package to use:


### PR DESCRIPTION
The instructions provided in `README.markdown` are not sufficient to build this branch. It indeed requires additional pinning as it depends on version 1.3 of xenctrl.

This PR thus adds the command to use to get things working.

Many thanks to @semarie for his help in figuring out what the problem was.

Signed-off-by: Seb Hinderer <sebastien.hinderer@vates.tech>