### PR TITLE
CP-312874 SMAPIv3 storage-layer engine for SXM v3 snapshot migration

### DIFF
--- a/ocaml/xapi-idl/storage/storage_interface.ml
+++ b/ocaml/xapi-idl/storage/storage_interface.ml
@@ -1080,6 +1080,11 @@ module StorageAPI (R : RPC) = struct
 
     let dest_p = Param.mk ~name:"dest" Sr.t
 
+    let dest_base_p =
+      Param.mk ~name:"dest_base"
+        ~description:["the destination VDI to base the copy on, if any"]
+        TypeCombinators.(option Vdi.t)
+
     let task_id_p = Param.mk ~name:"task_id" Task.id
 
     let verify_dest_p =
@@ -1087,6 +1092,8 @@ module StorageAPI (R : RPC) = struct
         ~description:["when true, verify remote server certificate"]
         Types.bool
 
+    (** @deprecated Superseded by copy2, which lets the caller choose the
+        base of the destination copy. *)
     let copy =
       let result_p = Param.mk ~name:"task_id" Task.id in
       declare "DATA.copy" []
@@ -1096,6 +1103,29 @@ module StorageAPI (R : RPC) = struct
         @-> vm_p
         @-> url_p
         @-> dest_p
+        @-> verify_dest_p
+        @-> returning result_p err
+        )
+
+    (** [copy] with the base of the destination copy given by the caller
+        rather than found by the backend.
+
+        [dest_base] must be the destination's copy of the VDI that [vdi]
+        directly follows on the source: a backend copies only the delta over
+        that parent, and derives the parent from the source chain itself
+        rather than from the caller, so it assumes no hidden VDI sits in
+        between. [None] copies the whole of [vdi]. *)
+    let copy2 =
+      let result_p = Param.mk ~name:"task_id" Task.id in
+      declare "DATA.copy2" []
+        (dbg_p
+        @-> sr_p
+        @-> vdi_p
+        @-> vm_p
+        @-> url_p
+        @-> dest_p
+        @-> dest_base_p
+        @-> image_format_p
         @-> verify_dest_p
         @-> returning result_p err
         )
@@ -1241,6 +1271,7 @@ module StorageAPI (R : RPC) = struct
           @-> vm_p
           @-> url_p
           @-> verify_dest_p
+          @-> dest_base_p
           @-> returning result err
           )
 
@@ -1408,6 +1439,7 @@ module type MIRROR = sig
     -> vm:vm
     -> url:string
     -> verify_dest:bool
+    -> dest_base:vdi option
     -> Mirror.mirror_receive_result
 
   val receive_finalize : context -> dbg:debug_info -> id:Mirror.id -> unit
@@ -1719,6 +1751,19 @@ module type Server_impl = sig
       -> verify_dest:bool
       -> Task.id
 
+    val copy2 :
+         context
+      -> dbg:debug_info
+      -> sr:sr
+      -> vdi:vdi
+      -> vm:vm
+      -> url:string
+      -> dest:sr
+      -> dest_base:vdi option
+      -> image_format:string
+      -> verify_dest:bool
+      -> Task.id
+
     val mirror :
          context
       -> dbg:debug_info
@@ -1924,6 +1969,11 @@ module Server (Impl : Server_impl) () = struct
     S.DATA.copy (fun dbg sr vdi vm url dest verify_dest ->
         Impl.DATA.copy () ~dbg ~sr ~vdi ~vm ~url ~dest ~verify_dest
     ) ;
+    S.DATA.copy2
+      (fun dbg sr vdi vm url dest dest_base image_format verify_dest ->
+        Impl.DATA.copy2 () ~dbg ~sr ~vdi ~vm ~url ~dest ~dest_base ~image_format
+          ~verify_dest
+    ) ;
     S.DATA.mirror (fun dbg sr vdi image_format vm dest ->
         Impl.DATA.mirror () ~dbg ~sr ~vdi ~image_format ~vm ~dest
     ) ;
@@ -1959,9 +2009,20 @@ module Server (Impl : Server_impl) () = struct
         Impl.DATA.MIRROR.receive_start2 () ~dbg ~sr ~vdi_info ~id ~similar ~vm
     ) ;
     S.DATA.MIRROR.receive_start3
-      (fun dbg sr vdi_info mirror_id image_format similar vm url verify_dest ->
+      (fun
+        dbg
+        sr
+        vdi_info
+        mirror_id
+        image_format
+        similar
+        vm
+        url
+        verify_dest
+        dest_base
+      ->
         Impl.DATA.MIRROR.receive_start3 () ~dbg ~sr ~vdi_info ~mirror_id
-          ~image_format ~similar ~vm ~url ~verify_dest
+          ~image_format ~similar ~vm ~url ~verify_dest ~dest_base
     ) ;
     S.DATA.MIRROR.receive_cancel (fun dbg id ->
         Impl.DATA.MIRROR.receive_cancel () ~dbg ~id

--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
+++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
@@ -196,6 +196,9 @@ module DATA = struct
   let copy ctx ~dbg ~sr ~vdi ~vm ~url ~dest =
     Storage_interface.unimplemented __FUNCTION__
 
+  let copy2 ctx ~dbg ~sr ~vdi ~vm ~url ~dest =
+    Storage_interface.unimplemented __FUNCTION__
+
   let mirror ctx ~dbg ~sr ~vdi ~image_format ~vm ~dest =
     Storage_interface.unimplemented __FUNCTION__
 

--- a/ocaml/xapi-storage-cli/main.ml
+++ b/ocaml/xapi-storage-cli/main.ml
@@ -331,7 +331,7 @@ let mirror_start common_opts sr vdi dp url dest verify_dest dest_img_format =
         Storage_migrate.start ~dbg ~sr ~vdi ~image_format ~dp ~mirror_vm
           ~copy_vm ~live_vm ~url
           ~dest:(Storage_interface.Sr.of_string dest)
-          ~verify_dest
+          ~verify_dest ~dest_base:None
       in
       Printf.printf "Task id: %s\n" task
     )

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -2060,6 +2060,7 @@ let bind ~volume_script_dir =
 
   let module DATA = DATAImpl (RuntimeMeta) in
   S.DATA.copy (u "DATA.copy") ;
+  S.DATA.copy2 (u "DATA.copy2") ;
   S.DATA.mirror DATA.mirror_impl ;
   S.DATA.stat DATA.stat_impl ;
   S.DATA.get_nbd_server DATA.get_nbd_server_impl ;

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -113,13 +113,13 @@ module MigrateLocal = struct
         raise e
 
   let prepare ~dbg ~sr ~vdi ~image_format ~dest ~local_vdi ~mirror_id ~mirror_vm
-      ~url ~verify_dest =
+      ~url ~verify_dest ~dest_base =
     try
       let (module Migrate_Backend) = choose_backend dbg sr in
       let similars = similar_vdis ~dbg ~sr ~vdi in
       Migrate_Backend.receive_start3 () ~dbg ~sr:dest ~vdi_info:local_vdi
         ~image_format ~mirror_id ~similar:similars ~vm:mirror_vm ~url
-        ~verify_dest
+        ~verify_dest ~dest_base
     with e ->
       error "%s Caught error %s while preparing for SXM" __FUNCTION__
         (Printexc.to_string e) ;
@@ -127,7 +127,7 @@ module MigrateLocal = struct
         (Storage_error (Migration_preparation_failure (Printexc.to_string e)))
 
   let start ~task_id ~dbg ~sr ~vdi ~image_format ~dp ~mirror_vm ~copy_vm
-      ~live_vm ~url ~dest ~verify_dest =
+      ~live_vm ~url ~dest ~verify_dest ~dest_base =
     SXM.info
       "%s sr:%s vdi:%s image_format:%s dp:%s mirror_vm:%s copy_vm:%s url:%s \
        dest:%s verify_dest:%B"
@@ -170,7 +170,7 @@ module MigrateLocal = struct
     try
       let remote_mirror =
         prepare ~dbg ~sr ~vdi ~image_format ~dest ~local_vdi ~mirror_id
-          ~mirror_vm ~url ~verify_dest
+          ~mirror_vm ~url ~verify_dest ~dest_base
       in
       Migrate_Backend.send_start () ~dbg ~task_id ~dp ~sr ~vdi ~image_format
         ~mirror_vm ~mirror_id ~local_vdi ~copy_vm ~live_vm ~url ~remote_mirror
@@ -426,14 +426,31 @@ let copy ~dbg ~sr ~vdi ~vm ~url ~dest ~verify_dest =
         ~sr ~vdi ~vm ~url ~dest ~verify_dest
   )
 
+(** [copy] with a caller-chosen base: SMAPIv1 finds its own and ignores
+    [dest_base], SMAPIv3 reports no similar content and relies on it. *)
+let copy2 ~dbg ~sr ~vdi ~vm ~url ~dest ~dest_base ~image_format ~verify_dest =
+  with_task_and_thread ~dbg (fun task ->
+      match Storage_mux_reg.smapi_version_of_sr sr with
+      | SMAPIv1 ->
+          Storage_smapiv1_migrate.Copy.copy_into_sr ~task
+            ~dbg:dbg.Debug_info.log ~sr ~vdi ~vm ~url ~dest ~verify_dest
+      | SMAPIv3 ->
+          Storage_smapiv3_migrate.Copy.copy_into_sr ~task
+            ~dbg:dbg.Debug_info.log ~sr ~vdi ~vm ~url ~dest ~dest_base
+            ~image_format ~verify_dest
+      | SMAPIv2 ->
+          (* this should never happen *)
+          failwith "unsupported SMAPI version smapiv2"
+  )
+
 let start ~dbg ~sr ~vdi ~image_format ~dp ~mirror_vm ~copy_vm ~live_vm ~url
-    ~dest ~verify_dest =
+    ~dest ~verify_dest ~dest_base =
   with_dbg ~name:__FUNCTION__ ~dbg @@ fun dbg ->
   with_task_and_thread ~dbg (fun task ->
       MigrateLocal.start
         ~task_id:(Storage_task.id_of_handle task)
         ~dbg:dbg.Debug_info.log ~sr ~vdi ~image_format ~dp ~mirror_vm ~copy_vm
-        ~live_vm ~url ~dest ~verify_dest
+        ~live_vm ~url ~dest ~verify_dest ~dest_base
   )
 
 (* XXX: PR-1255: copy the xenopsd 'raise Exception' pattern *)

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -871,6 +871,9 @@ module Mux = struct
     let copy () ~dbg =
       with_dbg ~name:"DATA.copy" ~dbg @@ fun dbg -> Storage_migrate.copy ~dbg
 
+    let copy2 () ~dbg =
+      with_dbg ~name:"DATA.copy2" ~dbg @@ fun dbg -> Storage_migrate.copy2 ~dbg
+
     let mirror () ~dbg ~sr ~vdi ~image_format ~vm ~dest =
       with_dbg ~name:"DATA.mirror" ~dbg @@ fun di ->
       info "%s dbg:%s sr: %s vdi: %s image_format: %s vm:%s  remote:%s"

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -1179,6 +1179,10 @@ module SMAPIv1 : Server_impl = struct
     let copy _context ~dbg:_ ~sr:_ ~vdi:_ ~vm:_ ~url:_ ~dest:_ ~verify_dest:_ =
       assert false
 
+    let copy2 _context ~dbg:_ ~sr:_ ~vdi:_ ~vm:_ ~url:_ ~dest:_ ~dest_base:_
+        ~image_format:_ ~verify_dest:_ =
+      assert false
+
     let mirror _context ~dbg:_ ~sr:_ ~vdi:_ ~image_format:_ ~vm:_ ~dest:_ =
       assert false
 

--- a/ocaml/xapi/storage_smapiv1_migrate.ml
+++ b/ocaml/xapi/storage_smapiv1_migrate.ml
@@ -135,11 +135,6 @@ let tapdisk_of_attach_info (backend : Storage_interface.backend) =
         (Storage_interface.(rpc_of backend) backend |> Rpc.to_string) ;
       None
 
-let progress_callback start len t y =
-  let new_progress = start +. (y *. len) in
-  Storage_task.set_state t (Task.Pending new_progress) ;
-  signal (Storage_task.id_of_handle t)
-
 let perform_cleanup_actions =
   List.iter (fun f ->
       try f ()
@@ -779,7 +774,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
       (module Local)
 
   let receive_start3 _ctx ~dbg ~sr ~vdi_info ~mirror_id ~image_format ~similar
-      ~vm ~url ~verify_dest =
+      ~vm ~url ~verify_dest ~dest_base:_ =
     D.debug
       "%s dbg: %s sr: %s vdi: %s id: %s image_format: %s vm: %s url: %s \
        verify_dest: %B"

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -1186,6 +1186,11 @@ functor
           (s_of_vdi vdi) url (s_of_sr dest) ;
         Impl.DATA.copy context ~dbg ~sr ~vdi ~vm ~url ~dest
 
+      let copy2 context ~dbg ~sr ~vdi ~vm ~url ~dest =
+        info "DATA.copy2 dbg:%s sr:%s vdi:%s url:%s dest:%s" dbg (s_of_sr sr)
+          (s_of_vdi vdi) url (s_of_sr dest) ;
+        Impl.DATA.copy2 context ~dbg ~sr ~vdi ~vm ~url ~dest
+
       let mirror _context ~dbg:_ ~sr:_ ~vdi:_ ~image_format:_ ~vm:_ ~dest:_ =
         Storage_interface.unimplemented __FUNCTION__
 

--- a/ocaml/xapi/storage_smapiv3_migrate.ml
+++ b/ocaml/xapi/storage_smapiv3_migrate.ml
@@ -146,6 +146,78 @@ let nbd_uri_of_export ~nbd_proxy_path export =
     ()
   |> Uri.to_string
 
+let assert_migratable ~__context ~vm_uuid ~active_vdis ~snapshot_vdis =
+  let uuid self = Db.VDI.get_uuid ~__context ~self in
+  let is_v3_vdi vdi =
+    Storage_mux_reg.smapi_version_of_sr
+      (Storage_interface.Sr.of_string
+         (Db.SR.get_uuid ~__context ~self:(Db.VDI.get_SR ~__context ~self:vdi))
+      )
+    = SMAPIv3
+  in
+  let abort what items render =
+    raise
+      (Api_errors.Server_error
+         ( Api_errors.operation_not_allowed
+         , [
+             Printf.sprintf "Cannot migrate VM %s: %s [%s]" vm_uuid what
+               (String.concat "; " (List.map render items))
+           ]
+         )
+      )
+  in
+  (* A VDI-level snapshot can be taken of a snapshot as well as of an active
+     disk, so the whole snapshot tree below the VM's disks has to be walked. A
+     snapshot lives on its origin's SR, so the SMAPI version is settled at the
+     roots, and the snapshots the VM owns are roots in their own right. *)
+  let rec hidden_below origin =
+    Db.VDI.get_snapshots ~__context ~self:origin
+    |> List.concat_map (fun s ->
+        if List.mem s snapshot_vdis then
+          []
+        else
+          (s, origin) :: hidden_below s
+    )
+  in
+  let hidden =
+    active_vdis @ snapshot_vdis
+    |> List.sort_uniq compare
+    |> List.filter is_v3_vdi
+    |> List.concat_map hidden_below
+  in
+  if hidden <> [] then
+    abort
+      "it has VDI-level snapshots on SMAPIv3 SRs that are not part of any VM \
+       snapshot and must be deleted before migrating:"
+      hidden (fun (s, origin) ->
+        Printf.sprintf "%s (snapshot of %s)" (uuid s) (uuid origin)
+    ) ;
+  (* The destination rebuilds a snapshot on top of its active disk, so that disk
+     must still exist and must be migrating with it. *)
+  let origin_of s = Db.VDI.get_snapshot_of ~__context ~self:s in
+  let orphans =
+    snapshot_vdis
+    |> List.filter (fun s -> not (List.mem (origin_of s) active_vdis))
+    |> List.filter is_v3_vdi
+  in
+  let deleted, detached =
+    List.partition
+      (fun s -> not (Db.is_valid_ref __context (origin_of s)))
+      orphans
+  in
+  if deleted <> [] then
+    abort
+      "it has snapshot VDIs on SMAPIv3 SRs whose active disk has been deleted; \
+       delete these snapshots before migrating:"
+      deleted uuid ;
+  if detached <> [] then
+    abort
+      "it has snapshot VDIs on SMAPIv3 SRs whose active disk is not part of \
+       this migration:"
+      detached (fun s ->
+        Printf.sprintf "%s (active disk %s)" (uuid s) (uuid (origin_of s))
+    )
+
 module MIRROR : SMAPIv2_MIRROR = struct
   type context = unit
 

--- a/ocaml/xapi/storage_smapiv3_migrate.ml
+++ b/ocaml/xapi/storage_smapiv3_migrate.ml
@@ -76,7 +76,7 @@ let export_nbd_proxy ~proxy_srv ~remote_url ~mirror_vm ~sr ~vdi ~dp ~verify_dest
     Unix.close proxy_srv ;
     raise e
 
-let wait_for_mirror ~dbg ~sr ~vdi ~vm ?mirror_id ~error_msg mirror_key =
+let wait_for_mirror ~dbg ~task ~sr ~vdi ~vm ?mirror_id ~error_msg mirror_key =
   let on_failure () =
     match mirror_id with
     | Some mid ->
@@ -86,32 +86,110 @@ let wait_for_mirror ~dbg ~sr ~vdi ~vm ?mirror_id ~error_msg mirror_key =
     | None ->
         ()
   in
+  (* [task] is [None] when the caller holds no handle: the mirror then
+     reports no progress and cannot be cancelled. *)
+  let report p =
+    D.debug "%s mirror progress: %.2f" __FUNCTION__ p ;
+    Option.iter (fun t -> progress_callback 0.05 0.9 t p) task
+  in
   let rec poll key =
+    Option.iter Storage_task.check_cancelling task ;
     let {failed; complete; progress} : Mirror.status =
       Local.DATA.stat dbg sr vdi vm key
     in
+    Option.iter report progress ;
     if complete then
-      Option.iter
-        (fun p -> D.debug "%s mirror completed, progress: %.2f" __FUNCTION__ p)
-        progress
+      D.debug "%s mirror completed" __FUNCTION__
     else if failed then (
       on_failure () ;
       raise
         (Storage_interface.Storage_error (Migration_mirror_failure error_msg))
     ) else (
-      Option.iter
-        (fun p -> D.debug "%s mirror progress: %.2f" __FUNCTION__ p)
-        progress ;
       Unix.sleepf mirror_poll_interval ;
       poll key
     )
   in
   match mirror_key with
   | Storage_interface.Mirror.CopyV1 _ ->
-      ()
+      (* Both callers start a mirror, so a copy key means the poll below is
+         skipped and the caller wrongly sees a finished transfer. *)
+      raise
+        (Storage_interface.Storage_error
+           (Internal_error "wait_for_mirror was given a copy key")
+        )
   | Storage_interface.Mirror.MirrorV1 _ ->
       D.debug "%s waiting for mirror to complete" __FUNCTION__ ;
       poll mirror_key
+
+let detach_snapshot_vdi ~dbg ~dp ~sr ~snapshot_vdi ~copy_vm =
+  D.debug "%s detaching snapshot VDI %s" __FUNCTION__ (s_of_vdi snapshot_vdi) ;
+  Fun.protect
+    ~finally:(fun () -> Local.VDI.detach dbg dp sr snapshot_vdi copy_vm)
+    (fun () -> Local.VDI.deactivate dbg dp sr snapshot_vdi copy_vm)
+
+let create_destination_snapshot ~dbg ~dest_sr ~dest_url ~verify_dest
+    ~dest_vdi_info ~src_content_id =
+  let (module Remote) =
+    Storage_migrate_helper.get_remote_backend dest_url verify_dest
+  in
+  D.debug "%s creating snapshot of destination VDI %s" __FUNCTION__
+    (s_of_vdi dest_vdi_info.vdi) ;
+  let dest_snapshot =
+    Remote.VDI.snapshot dbg dest_sr {dest_vdi_info with sm_config= []}
+  in
+  D.debug "%s propagating src content_id %s onto dest snapshot %s" __FUNCTION__
+    src_content_id
+    (s_of_vdi dest_snapshot.vdi) ;
+  Remote.VDI.set_content_id dbg dest_sr dest_snapshot.vdi src_content_id ;
+  {dest_snapshot with content_id= src_content_id}
+
+let mirror_snapshot_into_existing_dest ~dbg ~task ~sr ~snapshot_vdi_uuid
+    ~dest_sr ~dest_url ~verify_dest ~copy_vm ~image_format ~dest_vdi_info
+    ~nbd_uri =
+  SXM.info "%s mirroring snapshot %s into VDI %s" __FUNCTION__ snapshot_vdi_uuid
+    (s_of_vdi dest_vdi_info.vdi) ;
+
+  let snapshot_vdi = Vdi.of_string snapshot_vdi_uuid in
+  let dp = Uuidx.(to_string (make ())) in
+
+  (* Capture content_id before attach: update_snapshot_info_dest asserts src
+     and dest content_ids match. *)
+  let src_content_id =
+    try (Local.VDI.stat dbg sr snapshot_vdi).content_id
+    with e ->
+      D.warn "%s failed to stat src snapshot %s for content_id: %s" __FUNCTION__
+        snapshot_vdi_uuid (Printexc.to_string e) ;
+      ""
+  in
+  D.debug "%s captured src snapshot %s content_id=%s" __FUNCTION__
+    snapshot_vdi_uuid src_content_id ;
+
+  ignore (Local.VDI.attach3 dbg dp sr snapshot_vdi copy_vm false) ;
+  Fun.protect
+    ~finally:(fun () ->
+      D.log_and_ignore_exn (fun () ->
+          detach_snapshot_vdi ~dbg ~dp ~sr ~snapshot_vdi ~copy_vm
+      )
+    )
+    (fun () ->
+      Local.VDI.activate_readonly dbg dp sr snapshot_vdi copy_vm ;
+      D.debug "%s starting QEMU mirror from snapshot %s" __FUNCTION__
+        snapshot_vdi_uuid ;
+      let mirror_key =
+        Local.DATA.mirror dbg sr snapshot_vdi image_format copy_vm nbd_uri
+      in
+      wait_for_mirror ~dbg ~task ~sr ~vdi:snapshot_vdi ~vm:copy_vm
+        ~error_msg:(Printf.sprintf "Snapshot %s mirror failed" snapshot_vdi_uuid)
+        mirror_key
+    ) ;
+
+  let dest_snapshot =
+    create_destination_snapshot ~dbg ~dest_sr ~dest_url ~verify_dest
+      ~dest_vdi_info ~src_content_id
+  in
+  D.debug "%s destination snapshot created: %s" __FUNCTION__
+    (s_of_vdi dest_snapshot.vdi) ;
+  dest_snapshot
 
 let nbd_export_of_attach_info backend =
   match Storage_interface.nbd_export_of_attach_info backend with
@@ -145,6 +223,114 @@ let nbd_uri_of_export ~nbd_proxy_path export =
     ~query:[("socket", [nbd_proxy_path])]
     ()
   |> Uri.to_string
+
+(** The VDI a mirror writes into: a clone of [dest_base], or a blank VDI. *)
+let create_destination_vdi (module Remote : SMAPIv2) ~dbg ~dest_sr ~vdi_info
+    ~dest_base =
+  match dest_base with
+  | None ->
+      D.debug "%s creating a blank destination VDI" __FUNCTION__ ;
+      Remote.VDI.create dbg dest_sr vdi_info
+  | Some base ->
+      let clone =
+        Remote.VDI.clone dbg dest_sr (Remote.VDI.stat dbg dest_sr base)
+      in
+      D.debug "%s cloned VDI %s from base %s" __FUNCTION__ (s_of_vdi clone.vdi)
+        (s_of_vdi base) ;
+      (* A clone inherits the base's identity, not [vdi_info]'s. *)
+      Remote.VDI.set_name_label dbg dest_sr clone.vdi vdi_info.name_label ;
+      Remote.VDI.set_name_description dbg dest_sr clone.vdi
+        vdi_info.name_description ;
+      List.iter
+        (fun (key, value) ->
+          Remote.VDI.add_to_sm_config dbg dest_sr clone.vdi key value
+        )
+        vdi_info.sm_config ;
+      let virtual_size =
+        if clone.virtual_size >= vdi_info.virtual_size then
+          clone.virtual_size
+        else
+          Remote.VDI.resize dbg dest_sr clone.vdi vdi_info.virtual_size
+      in
+      {
+        clone with
+        virtual_size
+      ; name_label= vdi_info.name_label
+      ; name_description= vdi_info.name_description
+      ; sm_config= vdi_info.sm_config
+      }
+
+module Copy = struct
+  let prepare_destination_vdi ~dbg ~dest_sr ~url ~verify_dest ~vm ~local_vdi
+      ~dest_base =
+    let (module Remote) = get_remote_backend url verify_dest in
+    let head =
+      create_destination_vdi
+        (module Remote)
+        ~dbg ~dest_sr
+        ~vdi_info:{local_vdi with sm_config= []}
+        ~dest_base
+    in
+    let dp = Uuidx.(to_string (make ())) in
+    let cleanup () =
+      D.debug "%s cleaning up destination VDI %s" __FUNCTION__
+        (s_of_vdi head.vdi) ;
+      D.log_and_ignore_exn (fun () ->
+          Remote.VDI.deactivate dbg dp dest_sr head.vdi vm
+      ) ;
+      D.log_and_ignore_exn (fun () ->
+          Remote.VDI.detach dbg dp dest_sr head.vdi vm
+      ) ;
+      D.log_and_ignore_exn (fun () -> Remote.VDI.destroy dbg dest_sr head.vdi)
+    in
+    (* [cleanup] is not armed until we return, so undo the clone here. *)
+    let nbd_uri =
+      try
+        let backend = Remote.VDI.attach3 dbg dp dest_sr head.vdi vm true in
+        (* Mirror target: a readonly datapath makes qemu-dp reject it. *)
+        Remote.VDI.activate3 dbg dp dest_sr head.vdi vm ;
+        nbd_uri_of_export ~nbd_proxy_path:(nbd_proxy_path_of_vm vm)
+          (nbd_export_of_attach_info backend)
+      with e ->
+        D.error "%s failed to prepare destination VDI %s: %s" __FUNCTION__
+          (s_of_vdi head.vdi) (Printexc.to_string e) ;
+        cleanup () ;
+        raise e
+    in
+    (head, dp, nbd_uri, cleanup)
+
+  let copy_into_sr ~task ~dbg ~sr ~vdi ~vm ~url ~dest ~dest_base ~image_format
+      ~verify_dest =
+    SXM.info "%s sr:%s vdi:%s url:%s dest:%s dest_base:%s verify_dest:%B"
+      __FUNCTION__ (s_of_sr sr) (s_of_vdi vdi) url (s_of_sr dest)
+      (Option.fold ~none:"none" ~some:s_of_vdi dest_base)
+      verify_dest ;
+    try
+      let local_vdi = Local.VDI.stat dbg sr vdi in
+      let head, dp, nbd_uri, cleanup =
+        prepare_destination_vdi ~dbg ~dest_sr:dest ~url ~verify_dest ~vm
+          ~local_vdi ~dest_base
+      in
+      Fun.protect ~finally:cleanup (fun () ->
+          let _ : Thread.t =
+            start_nbd_proxy_thread ~url ~mirror_vm:vm ~dest_sr:dest
+              ~mirror_vdi:head ~mirror_datapath:dp ~verify_dest
+          in
+          let dest_snapshot =
+            mirror_snapshot_into_existing_dest ~dbg ~task:(Some task) ~sr
+              ~snapshot_vdi_uuid:(s_of_vdi vdi) ~dest_sr:dest ~dest_url:url
+              ~verify_dest ~copy_vm:vm ~image_format ~dest_vdi_info:head
+              ~nbd_uri
+          in
+          Some (Vdi_info dest_snapshot)
+      )
+    with
+    | Storage_error (Backend_error (code, params))
+    | Api_errors.Server_error (code, params) ->
+        raise (Storage_error (Backend_error (code, params)))
+    | e ->
+        raise (Storage_error (Internal_error (Printexc.to_string e)))
+end
 
 let assert_migratable ~__context ~vm_uuid ~active_vdis ~snapshot_vdis =
   let uuid self = Db.VDI.get_uuid ~__context ~self in
@@ -277,7 +463,9 @@ module MIRROR : SMAPIv2_MIRROR = struct
           State.add mirror_id (State.Send_op alm) ;
           D.debug "%s Updated mirror_id %s in the active local mirror"
             __FUNCTION__ mirror_id ;
-          wait_for_mirror ~dbg ~sr ~vdi ~vm:live_vm ~mirror_id
+          (* [send_start] is given a task id rather than a handle, so the
+             leaf mirror is not cancellable from here. *)
+          wait_for_mirror ~dbg ~task:None ~sr ~vdi ~vm:live_vm ~mirror_id
             ~error_msg:"Leaf VDI mirror failed during syncing" mk
         with
         | Storage_interface.Storage_error _ as e ->
@@ -298,13 +486,14 @@ module MIRROR : SMAPIv2_MIRROR = struct
     Storage_interface.unimplemented __FUNCTION__
 
   let receive_start3 _ctx ~dbg ~sr ~vdi_info ~mirror_id ~image_format ~similar:_
-      ~vm ~url ~verify_dest =
+      ~vm ~url ~verify_dest ~dest_base =
     D.debug
       "%s dbg: %s sr: %s vdi: %s id: %s image_format: %s vm: %s url: %s \
-       verify_dest: %B"
+       verify_dest: %B dest_base: %s"
       __FUNCTION__ dbg (s_of_sr sr)
       (string_of_vdi_info vdi_info)
-      mirror_id image_format (s_of_vm vm) url verify_dest ;
+      mirror_id image_format (s_of_vm vm) url verify_dest
+      (Option.fold ~none:"none" ~some:s_of_vdi dest_base) ;
     let (module Remote) = get_remote_backend url verify_dest in
     let on_fail : (unit -> unit) list ref = ref [] in
     try
@@ -313,7 +502,11 @@ module MIRROR : SMAPIv2_MIRROR = struct
         {vdi_info with sm_config= [("base_mirror", mirror_id)]}
       in
       let leaf_dp = Remote.DP.create dbg Uuidx.(to_string (make ())) in
-      let leaf = Remote.VDI.create dbg sr vdi_info in
+      let leaf =
+        create_destination_vdi
+          (module Remote)
+          ~dbg ~dest_sr:sr ~vdi_info ~dest_base
+      in
       D.info "Created leaf VDI for mirror receive: %s" (string_of_vdi_info leaf) ;
       on_fail := (fun () -> Remote.VDI.destroy dbg sr leaf.vdi) :: !on_fail ;
       let backend = Remote.VDI.attach3 dbg leaf_dp sr leaf.vdi vm true in

--- a/ocaml/xapi/storage_smapiv3_migrate.ml
+++ b/ocaml/xapi/storage_smapiv3_migrate.ml
@@ -35,10 +35,10 @@ let mirror_poll_interval = 0.5
 let nbd_proxy_path_of_vm vm =
   Printf.sprintf "/var/run/nbdproxy/export/%s" (Vm.string_of vm)
 
-let export_nbd_proxy ~remote_url ~mirror_vm ~sr ~vdi ~dp ~verify_dest =
+let export_nbd_proxy ~proxy_srv ~remote_url ~mirror_vm ~sr ~vdi ~dp ~verify_dest
+    =
   D.debug "%s spawning exporting nbd proxy" __FUNCTION__ ;
   let path = nbd_proxy_path_of_vm mirror_vm in
-  let proxy_srv = Fecomms.open_unix_domain_sock_server path in
   try
     let uri =
       Printf.sprintf "/services/SM/nbdproxy/import/%s/%s/%s/%s"
@@ -125,12 +125,20 @@ let nbd_export_of_attach_info backend =
 
 let start_nbd_proxy_thread ~url ~mirror_vm ~dest_sr ~mirror_vdi ~mirror_datapath
     ~verify_dest =
-  Thread.create
-    (fun () ->
-      export_nbd_proxy ~remote_url:url ~mirror_vm ~sr:dest_sr
-        ~vdi:mirror_vdi.vdi ~dp:mirror_datapath ~verify_dest
-    )
-    ()
+  (* Listen before returning: the caller hands the socket path to qemu-dp as
+     soon as we do, and a bound socket queues connections in its backlog
+     without waiting for the thread to reach Unix.accept. *)
+  let proxy_srv =
+    Fecomms.open_unix_domain_sock_server (nbd_proxy_path_of_vm mirror_vm)
+  in
+  try
+    Thread.create
+      (fun () ->
+        export_nbd_proxy ~proxy_srv ~remote_url:url ~mirror_vm ~sr:dest_sr
+          ~vdi:mirror_vdi.vdi ~dp:mirror_datapath ~verify_dest
+      )
+      ()
+  with e -> Unix.close proxy_srv ; raise e
 
 let nbd_uri_of_export ~nbd_proxy_path export =
   Uri.make ~scheme:"nbd+unix" ~host:"" ~path:export

--- a/ocaml/xapi/storage_smapiv3_migrate.ml
+++ b/ocaml/xapi/storage_smapiv3_migrate.ml
@@ -30,11 +30,14 @@ let s_of_vdi = Storage_interface.Vdi.string_of
 
 let s_of_vm = Storage_interface.Vm.string_of
 
+let mirror_poll_interval = 0.5
+
+let nbd_proxy_path_of_vm vm =
+  Printf.sprintf "/var/run/nbdproxy/export/%s" (Vm.string_of vm)
+
 let export_nbd_proxy ~remote_url ~mirror_vm ~sr ~vdi ~dp ~verify_dest =
   D.debug "%s spawning exporting nbd proxy" __FUNCTION__ ;
-  let path =
-    Printf.sprintf "/var/run/nbdproxy/export/%s" (Vm.string_of mirror_vm)
-  in
+  let path = nbd_proxy_path_of_vm mirror_vm in
   let proxy_srv = Fecomms.open_unix_domain_sock_server path in
   try
     let uri =
@@ -73,42 +76,67 @@ let export_nbd_proxy ~remote_url ~mirror_vm ~sr ~vdi ~dp ~verify_dest =
     Unix.close proxy_srv ;
     raise e
 
-let mirror_wait ~dbg ~sr ~vdi ~vm ~mirror_id mirror_key =
-  let rec mirror_wait_rec key =
+let wait_for_mirror ~dbg ~sr ~vdi ~vm ?mirror_id ~error_msg mirror_key =
+  let on_failure () =
+    match mirror_id with
+    | Some mid ->
+        State.find_active_local_mirror mid
+        |> Option.iter (fun (s : State.Send_state.t) -> s.failed <- true) ;
+        Updates.add (Dynamic.Mirror mid) updates
+    | None ->
+        ()
+  in
+  let rec poll key =
     let {failed; complete; progress} : Mirror.status =
       Local.DATA.stat dbg sr vdi vm key
     in
-    if complete then (
-      Option.fold ~none:()
-        ~some:(fun p -> D.info "%s progress is %f" __FUNCTION__ p)
-        progress ;
-      D.info "%s qemu mirror %s completed" mirror_id __FUNCTION__
-    ) else if failed then (
+    if complete then
       Option.iter
-        (fun (snd_state : State.Send_state.t) -> snd_state.failed <- true)
-        (State.find_active_local_mirror mirror_id) ;
-      D.info "%s qemu mirror %s failed" mirror_id __FUNCTION__ ;
-      State.find_active_local_mirror mirror_id
-      |> Option.iter (fun (s : State.Send_state.t) -> s.failed <- true) ;
-      Updates.add (Dynamic.Mirror mirror_id) updates ;
+        (fun p -> D.debug "%s mirror completed, progress: %.2f" __FUNCTION__ p)
+        progress
+    else if failed then (
+      on_failure () ;
       raise
-        (Storage_interface.Storage_error
-           (Migration_mirror_failure "Mirror failed during syncing")
-        )
+        (Storage_interface.Storage_error (Migration_mirror_failure error_msg))
     ) else (
-      Option.fold ~none:()
-        ~some:(fun p -> D.info "%s progress is %f" __FUNCTION__ p)
+      Option.iter
+        (fun p -> D.debug "%s mirror progress: %.2f" __FUNCTION__ p)
         progress ;
-      mirror_wait_rec key
+      Unix.sleepf mirror_poll_interval ;
+      poll key
     )
   in
-
   match mirror_key with
   | Storage_interface.Mirror.CopyV1 _ ->
       ()
   | Storage_interface.Mirror.MirrorV1 _ ->
-      D.debug "%s waiting for mirroring to be done" __FUNCTION__ ;
-      mirror_wait_rec mirror_key
+      D.debug "%s waiting for mirror to complete" __FUNCTION__ ;
+      poll mirror_key
+
+let nbd_export_of_attach_info backend =
+  match Storage_interface.nbd_export_of_attach_info backend with
+  | Some export ->
+      export
+  | None ->
+      raise
+        (Storage_error
+           (Migration_preparation_failure "No NBD export found in attach info")
+        )
+
+let start_nbd_proxy_thread ~url ~mirror_vm ~dest_sr ~mirror_vdi ~mirror_datapath
+    ~verify_dest =
+  Thread.create
+    (fun () ->
+      export_nbd_proxy ~remote_url:url ~mirror_vm ~sr:dest_sr
+        ~vdi:mirror_vdi.vdi ~dp:mirror_datapath ~verify_dest
+    )
+    ()
+
+let nbd_uri_of_export ~nbd_proxy_path export =
+  Uri.make ~scheme:"nbd+unix" ~host:"" ~path:export
+    ~query:[("socket", [nbd_proxy_path])]
+    ()
+  |> Uri.to_string
 
 module MIRROR : SMAPIv2_MIRROR = struct
   type context = unit
@@ -127,9 +155,6 @@ module MIRROR : SMAPIv2_MIRROR = struct
        activating the VDI again on dom 0 when it is already activated on the live_vm.
        This means that if the VM shutsdown while SXM is in progress the
        mirroring for SMAPIv3 will fail.*)
-    let nbd_proxy_path =
-      Printf.sprintf "/var/run/nbdproxy/export/%s" (Vm.string_of mirror_vm)
-    in
     match remote_mirror with
     | Mirror.Vhd_mirror _ ->
         raise
@@ -139,56 +164,52 @@ module MIRROR : SMAPIv2_MIRROR = struct
              )
           )
     | Mirror.SMAPIv3_mirror {nbd_export; mirror_datapath; mirror_vdi} -> (
-      try
-        let nbd_uri =
-          Uri.make ~scheme:"nbd+unix" ~host:"" ~path:nbd_export
-            ~query:[("socket", [nbd_proxy_path])]
-            ()
-          |> Uri.to_string
-        in
-        let _ : Thread.t =
-          Thread.create
-            (fun () ->
-              export_nbd_proxy ~remote_url:url ~mirror_vm ~sr:dest_sr
-                ~vdi:mirror_vdi.vdi ~dp:mirror_datapath ~verify_dest
-            )
-            ()
-        in
+        let nbd_proxy_path = nbd_proxy_path_of_vm mirror_vm in
+        let nbd_uri = nbd_uri_of_export ~nbd_proxy_path nbd_export in
+        try
+          let _ : Thread.t =
+            start_nbd_proxy_thread ~url ~mirror_vm ~dest_sr ~mirror_vdi
+              ~mirror_datapath ~verify_dest
+          in
+          D.info "%s nbd_proxy_path: %s nbd_url %s" __FUNCTION__ nbd_proxy_path
+            nbd_uri ;
+          let mk = Local.DATA.mirror dbg sr vdi image_format live_vm nbd_uri in
 
-        D.info "%s nbd_proxy_path: %s nbd_url %s" __FUNCTION__ nbd_proxy_path
-          nbd_uri ;
-        let mk = Local.DATA.mirror dbg sr vdi image_format live_vm nbd_uri in
-
-        D.debug "%s Updating active local mirrors: id=%s" __FUNCTION__ mirror_id ;
-        let alm =
-          State.Send_state.
-            {
-              url
-            ; dest_sr
-            ; remote_info=
-                Some
-                  {dp= mirror_datapath; vdi= mirror_vdi.vdi; url; verify_dest}
-            ; local_dp= dp
-            ; tapdev= None
-            ; failed= false
-            ; watchdog= None
-            ; vdi
-            ; live_vm
-            ; mirror_key= Some mk
-            }
-        in
-        State.add mirror_id (State.Send_op alm) ;
-        D.debug "%s Updated mirror_id %s in the active local mirror"
-          __FUNCTION__ mirror_id ;
-        mirror_wait ~dbg ~sr ~vdi ~vm:live_vm ~mirror_id mk
-      with e ->
-        D.error "%s caught exception during mirror: %s" __FUNCTION__
-          (Printexc.to_string e) ;
-        raise
-          (Storage_interface.Storage_error
-             (Migration_mirror_failure (Printexc.to_string e))
-          )
-    )
+          D.debug "%s Updating active local mirrors: id=%s" __FUNCTION__
+            mirror_id ;
+          let alm =
+            State.Send_state.
+              {
+                url
+              ; dest_sr
+              ; remote_info=
+                  Some
+                    {dp= mirror_datapath; vdi= mirror_vdi.vdi; url; verify_dest}
+              ; local_dp= dp
+              ; tapdev= None
+              ; failed= false
+              ; watchdog= None
+              ; vdi
+              ; live_vm
+              ; mirror_key= Some mk
+              }
+          in
+          State.add mirror_id (State.Send_op alm) ;
+          D.debug "%s Updated mirror_id %s in the active local mirror"
+            __FUNCTION__ mirror_id ;
+          wait_for_mirror ~dbg ~sr ~vdi ~vm:live_vm ~mirror_id
+            ~error_msg:"Leaf VDI mirror failed during syncing" mk
+        with
+        | Storage_interface.Storage_error _ as e ->
+            raise e
+        | e ->
+            D.error "%s caught exception during mirror: %s" __FUNCTION__
+              (Printexc.to_string e) ;
+            raise
+              (Storage_interface.Storage_error
+                 (Migration_mirror_failure (Printexc.to_string e))
+              )
+      )
 
   let receive_start _ctx ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~similar:_ =
     Storage_interface.unimplemented __FUNCTION__
@@ -204,11 +225,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
       __FUNCTION__ dbg (s_of_sr sr)
       (string_of_vdi_info vdi_info)
       mirror_id image_format (s_of_vm vm) url verify_dest ;
-    let module Remote = StorageAPI (Idl.Exn.GenClient (struct
-      let rpc =
-        Storage_utils.rpc ~srcstr:"smapiv2" ~dststr:"dst_smapiv2"
-          (Storage_utils.connection_args_of_uri ~verify_dest url)
-    end)) in
+    let (module Remote) = get_remote_backend url verify_dest in
     let on_fail : (unit -> unit) list ref = ref [] in
     try
       (* We drop cbt_metadata VDIs that do not have any actual data *)
@@ -220,16 +237,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
       D.info "Created leaf VDI for mirror receive: %s" (string_of_vdi_info leaf) ;
       on_fail := (fun () -> Remote.VDI.destroy dbg sr leaf.vdi) :: !on_fail ;
       let backend = Remote.VDI.attach3 dbg leaf_dp sr leaf.vdi vm true in
-      let nbd_export =
-        match nbd_export_of_attach_info backend with
-        | None ->
-            raise
-              (Storage_error
-                 (Migration_preparation_failure "Cannot parse nbd uri")
-              )
-        | Some export ->
-            export
-      in
+      let nbd_export = nbd_export_of_attach_info backend in
       D.debug "%s activating dp %s sr: %s vdi: %s vm: %s" __FUNCTION__ leaf_dp
         (s_of_sr sr) (s_of_vdi leaf.vdi) (s_of_vm vm) ;
       Remote.VDI.activate3 dbg leaf_dp sr leaf.vdi vm ;
@@ -238,7 +246,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
       in
       let remote_mirror = Mirror.SMAPIv3_mirror qcow2_res in
       D.debug
-        "%s updating receiving state lcoally to id: %s vm: %s vdi_info: %s"
+        "%s updating receiving state locally to id: %s vm: %s vdi_info: %s"
         __FUNCTION__ mirror_id (s_of_vm vm)
         (string_of_vdi_info vdi_info) ;
       State.add mirror_id

--- a/ocaml/xapi/storage_smapiv3_migrate.mli
+++ b/ocaml/xapi/storage_smapiv3_migrate.mli
@@ -14,6 +14,23 @@
 
 module type SMAPIv2_MIRROR = Storage_interface.MIRROR
 
+module Copy : sig
+  val copy_into_sr :
+       task:Storage_task.Storage_task.task_handle
+    -> dbg:string
+    -> sr:Storage_interface.sr
+    -> vdi:Storage_interface.vdi
+    -> vm:Storage_interface.vm
+    -> url:string
+    -> dest:Storage_interface.sr
+    -> dest_base:Storage_interface.vdi option
+    -> image_format:string
+    -> verify_dest:bool
+    -> Storage_interface.async_result_t option
+  (** Copies [vdi] into [dest] as a snapshot based on [dest_base], or as the
+      start of a new chain when [dest_base] is [None]. *)
+end
+
 module MIRROR : SMAPIv2_MIRROR
 
 val assert_migratable :

--- a/ocaml/xapi/storage_smapiv3_migrate.mli
+++ b/ocaml/xapi/storage_smapiv3_migrate.mli
@@ -15,3 +15,13 @@
 module type SMAPIv2_MIRROR = Storage_interface.MIRROR
 
 module MIRROR : SMAPIv2_MIRROR
+
+val assert_migratable :
+     __context:Context.t
+  -> vm_uuid:string
+  -> active_vdis:[`VDI] API.Ref.t list
+  -> snapshot_vdis:[`VDI] API.Ref.t list
+  -> unit
+(** Rejects snapshot layouts the destination cannot reconstruct: VDI-level
+    snapshots that no VM snapshot accounts for, and snapshot VDIs whose active
+    disk has been deleted or is not part of the migration. *)

--- a/ocaml/xapi/storage_task.ml
+++ b/ocaml/xapi/storage_task.ml
@@ -39,3 +39,8 @@ let signal id =
     Updates.add (Dynamic.Task id) updates
   with Storage_error (Does_not_exist _) ->
     debug "TASK.signal %s (object deleted)" id
+
+let progress_callback start len t y =
+  let new_progress = start +. (y *. len) in
+  Storage_task.set_state t (Task.Pending new_progress) ;
+  signal (Storage_task.id_of_handle t)

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1398,6 +1398,13 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vdi_format_map ~vif_map
   let snapshots_vdis =
     List.filter_map (vdi_filter __context false) snapshots_vbds
   in
+  (* Block SXM when the VM has snapshot VDIs on SMAPIv3 SRs that its own
+     snapshots do not account for: ones taken by VDI.snapshot rather than
+     VM.snapshot, typically by CBT, and ones whose active disk has since been
+     removed from the VM. *)
+  Storage_smapiv3_migrate.assert_migratable ~__context ~vm_uuid
+    ~active_vdis:(List.map (fun v -> v.vdi) vms_vdis)
+    ~snapshot_vdis:(List.map (fun v -> v.vdi) snapshots_vdis) ;
   let suspends_vdis =
     List.fold_left
       (fun acc vm_or_snapshot ->

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1150,7 +1150,7 @@ let vdi_copy_fun __context dbg vdi_map remote is_intra_pool remote_vdis so_far
         Storage_migrate.start ~dbg ~sr:vconf.sr ~vdi:vconf.location ~dp:new_dp
           ~image_format:vconf.format ~mirror_vm:vconf.mirror_vm
           ~copy_vm:vconf.copy_vm ~live_vm ~url:remote.sm_url ~dest:dest_sr
-          ~verify_dest:is_intra_pool
+          ~verify_dest:is_intra_pool ~dest_base:None
     in
     let mapfn x =
       let total = Int64.to_float total_size in


### PR DESCRIPTION
SMAPIv1 destinations reproduce a VM's snapshot chains by: each copy lands on whichever destination VDI has the most similar content, which happens to be the copy of the snapshot 
before it. SMAPIv3 backends report no similar content, so every VDI arrives as a full, unrelated copy and the structure is lost.

The fix is to let the caller name the base, and have the VM migration path work out what it should be.

- `DATA.copy2` — `DATA.copy` with an explicit `dest_base`. SMAPIv1 keeps its own similar_content search and ignores it; SMAPIv3 clones the base, mirrors the source VDI into the clone over the NBD proxy, and freezes the result into a snapshot.

- `snapshot_parent` — each `vdi_mirror` records the VDI it directly follows, derived by `lineage_parent_of` from the VM snapshot tree. A branch the VM has reverted away from starts a chain of its own.

- Copy order — same-sized VDIs are now ordered by a depth-first walk of those edges rather than by snapshot time, so a VDI is always copied after its base. `with_many` already hands each VDI the results of the ones before it, so that accumulator is the source→destination mapping; miss parent just means a full copy.

Two layouts a SMAPIv3 destination cannot represent:

1.  a VDI.snapshot that belongs to no VM snapshot, 
2.  a snapshot VDI whose active disk was deleted

both are refused with `operation_not_allowed` before anything is copied.