### PR TITLE
CA-375277: OCaml C stubs: release the runtime lock around blocking calls (rebase of #4916)

### DIFF
--- a/ocaml/libs/xenctrl-ext/xenctrlext_stubs.c
+++ b/ocaml/libs/xenctrl-ext/xenctrlext_stubs.c
@@ -171,7 +171,10 @@ CAMLprim value stub_xenctrlext_domain_get_acpi_s_state(value xch_val,
     xc_interface *xch = xch_of_val(xch_val);
     int domain = Int_val(domid);
 
+    caml_release_runtime_system();
     rc = xc_get_hvm_param(xch, domain, HVM_PARAM_ACPI_S_STATE, &v);
+    caml_acquire_runtime_system();
+
     if (rc != 0)
         failwith_xc(xch);
 
@@ -337,7 +340,11 @@ CAMLprim value stub_xenctrlext_domain_update_channels(value xch_val,
 static int get_cpumap_len(xc_interface *xch, value cpumap_val)
 {
     int ml_len = Wosize_val(cpumap_val);
-    int xc_len = xc_get_max_cpus(xch);
+    int xc_len;
+
+    caml_release_runtime_system();
+    xc_len = xc_get_max_cpus(xch);
+    caml_acquire_runtime_system();
 
     return (ml_len < xc_len ? ml_len : xc_len);
 }
@@ -345,10 +352,14 @@ static int get_cpumap_len(xc_interface *xch, value cpumap_val)
 static void populate_cpumap(xc_interface *xch, xc_cpumap_t cpumap,
                             value cpumap_val)
 {
+    CAMLparam1(cpumap_val);
     int i, len = get_cpumap_len(xch, cpumap_val);
+
     for (i = 0; i < len; i++)
         if (Bool_val(Field(cpumap_val, i)))
             cpumap[i / 8] |= 1 << (i & 7);
+
+    CAMLreturn0;
 }
 
 CAMLprim value stub_xenctrlext_vcpu_setaffinity_hard(value xch_val,
@@ -362,14 +373,20 @@ CAMLprim value stub_xenctrlext_vcpu_setaffinity_hard(value xch_val,
     xc_interface *xch = xch_of_val(xch_val);
     xc_cpumap_t cpumap;
 
+    caml_release_runtime_system();
     cpumap = xc_cpumap_alloc(xch);
+    caml_acquire_runtime_system();
+
     if (cpumap == NULL)
         failwith_xc(xch);
 
     populate_cpumap(xch, cpumap, cpumap_val);
 
+    caml_release_runtime_system();
     rc = xc_vcpu_setaffinity(xch, domid, vcpu, cpumap, NULL,
                              XEN_VCPUAFFINITY_HARD);
+    caml_acquire_runtime_system();
+
     free(cpumap);
     if (rc < 0)
         failwith_xc(xch);
@@ -388,14 +405,20 @@ CAMLprim value stub_xenctrlext_vcpu_setaffinity_soft(value xch_val,
     xc_interface *xch = xch_of_val(xch_val);
     xc_cpumap_t cpumap;
 
+    caml_release_runtime_system();
     cpumap = xc_cpumap_alloc(xch);
+    caml_acquire_runtime_system();
+
     if (cpumap == NULL)
         failwith_xc(xch);
 
     populate_cpumap(xch, cpumap, cpumap_val);
 
+    caml_release_runtime_system();
     rc = xc_vcpu_setaffinity(xch, domid, vcpu, NULL, cpumap,
                              XEN_VCPUAFFINITY_SOFT);
+    caml_acquire_runtime_system();
+
     free(cpumap);
     if (rc < 0)
         failwith_xc(xch);
@@ -414,7 +437,10 @@ CAMLprim value stub_xenctrlext_numainfo(value xch_val)
     int rc;
     xc_interface *xch = xch_of_val(xch_val);
 
+    caml_release_runtime_system();
     rc = xc_numainfo(xch, &max_nodes, NULL, NULL);
+    caml_acquire_runtime_system();
+
     if (rc < 0)
         failwith_xc(xch);
 
@@ -426,7 +452,10 @@ CAMLprim value stub_xenctrlext_numainfo(value xch_val)
         caml_raise_out_of_memory();
     }
 
+    caml_release_runtime_system();
     rc = xc_numainfo(xch, &max_nodes, meminfo, distance);
+    caml_acquire_runtime_system();
+
     if (rc < 0) {
         free(meminfo);
         free(distance);
@@ -468,7 +497,10 @@ CAMLprim value stub_xenctrlext_cputopoinfo(value xch_val)
     int rc;
     xc_interface *xch = xch_of_val(xch_val);
 
+    caml_release_runtime_system();
     rc = xc_cputopoinfo(xch, &max_cpus, NULL);
+    caml_acquire_runtime_system();
+
     if (rc < 0)
         failwith_xc(xch);
 
@@ -476,7 +508,10 @@ CAMLprim value stub_xenctrlext_cputopoinfo(value xch_val)
     if (!cputopo)
         caml_raise_out_of_memory();
 
+    caml_release_runtime_system();
     rc = xc_cputopoinfo(xch, &max_cpus, cputopo);
+    caml_acquire_runtime_system();
+
     if (rc < 0) {
         free(cputopo);
         failwith_xc(xch);

--- a/unixpwd/c/unixpwd_stubs.c
+++ b/unixpwd/c/unixpwd_stubs.c
@@ -13,6 +13,7 @@
  */
 
 #include <errno.h>
+#include <stdio.h>
 #include <string.h>
 
 #include <caml/alloc.h>
@@ -24,111 +25,87 @@
 
 #include "unixpwd.h"
 
-
-CAMLprim        value
-caml_unixpwd_getpwd(value caml_user)
+static value caml_unixpwd_get_(value caml_user, const char *fname, char*(*f)(const char*))
 {
     CAMLparam1(caml_user);
-    const char     *user;
-    char           *passwd;
+    char     *user;
+    char     *passwd;
+    int       saved_errno;
     CAMLlocal1(pw);
 
-    user = String_val(caml_user);
+    user = caml_stat_strdup(String_val(caml_user));
     caml_release_runtime_system();
-    passwd = unixpwd_getpwd(user);
+    errno = 0;
+    passwd = f(user);
+    saved_errno = errno;
     caml_acquire_runtime_system();
-    if (passwd == NULL && errno != 0)
-        caml_failwith(strerror(errno));
-    if (passwd == NULL)
-        caml_failwith("unspecified error in caml_unixpwd_getpwd()");
+    caml_stat_free(user); user = NULL;
+    errno = saved_errno;
+
+    if (passwd == NULL) {
+        char msg[128];
+
+        snprintf(msg, sizeof(msg), "unspecified error in %s()", fname);
+        caml_failwith(saved_errno ? strerror(saved_errno) : msg);
+    }
 
     pw = caml_copy_string(passwd);
     free(passwd);
     CAMLreturn(pw);
+}
+
+CAMLprim        value
+caml_unixpwd_getpwd(value caml_user)
+{
+    return caml_unixpwd_get_(caml_user, "unixpwd_getpwd", unixpwd_getpwd);
 }
 
 CAMLprim        value
 caml_unixpwd_getspw(value caml_user)
 {
-    CAMLparam1(caml_user);
-    const char     *user;
-    char           *passwd;
-    CAMLlocal1(pw);
-
-    user = String_val(caml_user);
-    caml_release_runtime_system();
-    passwd = unixpwd_getspw(user);
-    caml_acquire_runtime_system();
-    if (passwd == NULL && errno != 0)
-        caml_failwith(strerror(errno));
-    if (passwd == NULL)
-        caml_failwith("unspecified error in caml_unixpwd_getspw()");
-
-    pw = caml_copy_string(passwd);
-    free(passwd);
-    CAMLreturn(pw);
+    return caml_unixpwd_get_(caml_user, "unixpwd_getspw", unixpwd_getspw);
 }
-
-
 
 CAMLprim        value
 caml_unixpwd_get(value caml_user)
 {
-    CAMLparam1(caml_user);
-    const char     *user;
-    char           *passwd;
-    CAMLlocal1(pw);
+    return caml_unixpwd_get_(caml_user, "unixpwd_get", unixpwd_get);
+}
 
-    user = String_val(caml_user);
+static value caml_unixpwd_set_(value caml_user, value caml_password, const char *fname, int(*f)(const char*, char*))
+{
+    CAMLparam2(caml_user, caml_password);
+    char     *user;
+    char     *password;
+    int       rc;
+
+    user = caml_stat_strdup(String_val(caml_user));
+    password = caml_stat_strdup(String_val(caml_password));
     caml_release_runtime_system();
-    passwd = unixpwd_get(user);
+    rc = f(user, password);
     caml_acquire_runtime_system();
-    if (passwd == NULL && errno != 0)
-        caml_failwith(strerror(errno));
-    if (passwd == NULL)
-        caml_failwith("unspecified error in caml_unixpwd_get()");
+    caml_stat_free(user);
+    caml_stat_free(password);
 
-    pw = caml_copy_string(passwd);
-    free(passwd);
-    CAMLreturn(pw);
+    if (rc != 0) {
+        char msg[128];
+
+        snprintf(msg, sizeof(msg), "%s: %s", fname, strerror(rc));
+        caml_failwith(msg);
+    }
+    CAMLreturn(Val_unit);
 }
 
 CAMLprim        value
 caml_unixpwd_setpwd(value caml_user, value caml_password)
 {
-    CAMLparam2(caml_user, caml_password);
-    const char     *user;
-    char           *password;
-    int             rc;
-
-    user = String_val(caml_user);
-    password = caml_stat_strdup(String_val(caml_password));
-
-    caml_release_runtime_system();
-    rc = unixpwd_setpwd(user, password);
-    caml_acquire_runtime_system();
-
-    caml_stat_free(password);
-    if (rc != 0)
-        caml_failwith(strerror(rc));
-    CAMLreturn(Val_unit);
+    return caml_unixpwd_set_(caml_user, caml_password, "unixpwd_setpwd",
+                             unixpwd_setpwd);
 }
 
 CAMLprim        value
 caml_unixpwd_setspw(value caml_user, value caml_password)
 {
-    CAMLparam2(caml_user, caml_password);
-    const char     *user;
-    char           *password;
-    int             rc;
-
-    user = String_val(caml_user);
-    password = caml_stat_strdup(String_val(caml_password));
-    caml_release_runtime_system();
-    rc = unixpwd_setspw(user, password);
-    caml_acquire_runtime_system();
-    caml_stat_free(password);
-    if (rc != 0)
-        caml_failwith(strerror(rc));
-    CAMLreturn(Val_unit);
+    return caml_unixpwd_set_(caml_user, caml_password, "unixpwd_setspw",
+                             unixpwd_setspw);
 }


### PR DESCRIPTION
## Where this PR comes from

This is a rebase of the three C-stub commits from **[xapi-project/xen-api#4916](https://github.com/xapi-project/xen-api/pull/4916)** ("CA-391656: OCaml C stubs: release runtime lock around all xenctrl calls", by @edwintorok), which was opened as a draft and has since been closed without merging.