### PR TITLE
CP-312083: Implement API for exposing received LLDP TLVs

### DIFF
--- a/doc/content/design/lldp.md
+++ b/doc/content/design/lldp.md
@@ -83,9 +83,12 @@ Default after fresh install: `nearestbridge`.
 
 Type: `map(string, string)`
 
-Stores the received LLDP TLVs from the corresponding PIF.
+Stores the effective LLDP information for the physical NIC of the corresponding PIF:
 
-Default: empty
+- `state`: the effective LLDP state of the NIC, one of `enabled`, `disabled` or `blocked` (`blocked` means the NIC driver is in the blocking list). Always present for a managed physical NIC.
+- `system_name`, `port_id`, `port_description`: the TLVs received from the neighbour, present only when a neighbour is seen.
+
+Default: empty (also empty for PIFs that are not managed physical NICs).
 
 ## XenAPI changes
 
@@ -200,19 +203,26 @@ Some advertised values follow the default behavior of `lldpd`, while others are 
 networkd periodically queries statistics for individual NICs and writes them to the in-memory file `/dev/shm/network_stats`. The file format is defined in `ocaml/xapi-idl/network/network_stats.ml` and is extended with a new field, `lldp_neighbor`.
 
 ```ocaml
-type lldp_rx = {
+type lldp_state = Enabled | Disabled | Blocked
+
+type lldp_neighbor = {
   system_name: string option;
   port_id: string option;
   port_description: string option;
+}
+
+type lldp_rx = {
+  state: lldp_state;
+  neighbor: lldp_neighbor option;
 }
 [@@deriving rpcty]
 
 type iface_stats = {
   ...
-  lldp_neighbor: lldp_rx option;
+  lldp_rx: lldp_rx option;
 }
 ```
-networkd queries `lldpd` for the LLDP TLVs received on individual NICs and writes them into `/dev/shm/network_stats`.
+networkd derives the `state` from `lldpcli show interfaces` (a NIC reporting `RX and TX` is `Enabled`; otherwise it is `Blocked` when its driver is in the blocking list, else `Disabled`) and queries `lldpd` for the LLDP TLVs received on individual NICs, writing both into `/dev/shm/network_stats`.
 Monitor_dbcalls.monitor_dbcall_thread in XAPI reads the in-memory file `/dev/shm/network_stats` periodically, and exposes the data through `PIF_metrics.lldp_neighbor` by storing them in XenAPI map form.
 
 ## Scenarios

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -3014,6 +3014,15 @@ module PIF_metrics = struct
             ~default_value:(Some (VMap []))
             ~ty:(Map (String, String))
             "other_config" "additional configuration"
+        ; field ~qualifier:DynamicRO ~lifecycle:[]
+            ~default_value:(Some (VMap []))
+            ~ty:(Map (String, String))
+            "lldp_neighbor"
+            "The LLDP information for the physical NIC of the corresponding \
+             PIF: the effective LLDP state (key 'state', one of enabled, \
+             disabled or blocked) and, when a neighbour is seen, the received \
+             TLVs (keys 'system_name', 'port_id' and 'port_description'). \
+             Empty for PIFs that are not managed physical NICs."
         ]
       ()
 end

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 909
+let schema_minor_vsn = 910
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "4f4145585a0be563e77b01220bf3f6af"
+let last_known_schema_hash = "db58f982a09d1aded5413d5632c89560"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/networkd/bin/network_monitor_thread.ml
+++ b/ocaml/networkd/bin/network_monitor_thread.ml
@@ -132,10 +132,65 @@ let get_link_stats dbg () =
   in
   Cache.free cache ; Socket.close s ; Socket.free s ; links
 
+let lldp_query_interval = Mtime.Span.(30 * s)
+
+(* Monotonic timer gating the lldpcli query cadence; starts expired so the first
+   monitor pass queries immediately. *)
+let lldp_query_timer = ref (Clock.Timer.start ~duration:Mtime.Span.zero)
+
+(* Cache of the per-interface LLDP info reported by lldpd. lldpd is queried on a
+   slower cadence than the rest of the stats (LLDPDUs arrive ~every 30s), to
+   avoid unnecessary lldpcli calls. Only enabled (rx-and-tx) interfaces are
+   cached; a neighbour reported on a disabled interface is ignored. *)
+let lldp_cache : (string, Network_monitor.lldp_rx) Hashtbl.t = Hashtbl.create 16
+
+let refresh_lldp_cache () =
+  if Clock.Timer.has_expired !lldp_query_timer then (
+    lldp_query_timer := Clock.Timer.start ~duration:lldp_query_interval ;
+    Hashtbl.reset lldp_cache ;
+    List.iter
+      (fun dev ->
+        Hashtbl.replace lldp_cache dev
+          Network_monitor.{state= Network_stats.Enabled; neighbor= None}
+      )
+      (Lldp.get_enabled_interfaces ()) ;
+    List.iter
+      (fun (dev, neighbor) ->
+        match Hashtbl.find_opt lldp_cache dev with
+        | None ->
+            (* not enabled: drop the neighbour *)
+            ()
+        | Some {neighbor= Some n; _} ->
+            debug "Find another neighbour on %s: %s; keeping the first: %s" dev
+              (Network_stats.string_of_lldp_neighbor neighbor)
+              (Network_stats.string_of_lldp_neighbor n)
+        | Some rx ->
+            Hashtbl.replace lldp_cache dev {rx with neighbor= Some neighbor}
+      )
+      (Lldp.get_neighbors ())
+  )
+
+(* The LLDP information reported for physical [dev]: enabled interfaces come from
+   the cache; others report their effective state (from the driver blocklist)
+   with no neighbour. *)
+let lldp_rx_of dev =
+  match Hashtbl.find_opt lldp_cache dev with
+  | Some rx ->
+      rx
+  | None ->
+      let state =
+        if Lldp.is_blocked dev then
+          Network_stats.Blocked
+        else
+          Network_stats.Disabled
+      in
+      Network_monitor.{state; neighbor= None}
+
 let rec monitor dbg () =
   let open Network_interface in
   let open Network_monitor in
   ( try
+      refresh_lldp_cache () ;
       let get_stats bonds devs =
         List.map
           (fun dev ->
@@ -176,6 +231,7 @@ let rec monitor dbg () =
                   ; nb_links
                   ; links_up
                   ; interfaces
+                  ; lldp_rx= Some (lldp_rx_of dev)
                   }
                 else
                   let carrier = List.exists (fun info -> info.up) bond_slaves in
@@ -219,6 +275,7 @@ let rec monitor dbg () =
                   ; nb_links
                   ; links_up
                   ; interfaces
+                  ; lldp_rx= None
                   }
               in
               check_for_changes ~dev ~stat ;

--- a/ocaml/networkd/lib/lldp.ml
+++ b/ocaml/networkd/lib/lldp.ml
@@ -243,7 +243,7 @@ module Lldpd : AGENT = struct
     call_cli ["configure"; "ports"; dev; "lldp"; "status"; "disabled"]
 
   let get_neighbors () =
-    match Network_utils.call_script cli show_neighbors_args with
+    match Network_utils.call_script ~log:false cli show_neighbors_args with
     | output ->
         Lldp_parse.parse_neighbors output
     | exception e ->
@@ -252,7 +252,7 @@ module Lldpd : AGENT = struct
         []
 
   let get_enabled_interfaces () =
-    match Network_utils.call_script cli show_interfaces_args with
+    match Network_utils.call_script ~log:false cli show_interfaces_args with
     | output ->
         Lldp_parse.parse_enabled_interfaces output
     | exception e ->

--- a/ocaml/networkd/lib/lldp.ml
+++ b/ocaml/networkd/lib/lldp.ml
@@ -524,4 +524,8 @@ let get_neighbors = Lldpd.get_neighbors
 
 let get_enabled_interfaces = Lldpd.get_enabled_interfaces
 
+let parse_neighbors = Lldp_parse.parse_neighbors
+
+let parse_enabled_interfaces = Lldp_parse.parse_enabled_interfaces
+
 let is_blocked dev = Blocklist.mem dev

--- a/ocaml/networkd/lib/lldp.ml
+++ b/ocaml/networkd/lib/lldp.ml
@@ -50,6 +50,67 @@ module Lldp_types = struct
     | Multicast_address of I.lldp_multicast_address list
 end
 
+module Lldp_parse = struct
+  let ( let* ) = Option.bind
+
+  (* Follow [keys] through a json0 doc. Object keys are consumed one at a time;
+     arrays are transparently entered at their head without consuming a key
+     (json0 wraps every repeatable node in an array). An exhausted path returns
+     the current node as-is. *)
+  let rec json0_get json0 keys =
+    match keys with
+    | [] ->
+        Some json0
+    | k :: ks as keys -> (
+      match json0 with
+      | `Assoc l ->
+          let* json' = List.assoc_opt k l in
+          json0_get json' ks
+      | `List (json' :: _) ->
+          json0_get json' keys
+      | _ ->
+          None
+    )
+
+  let json0_get_str json0 keys =
+    match json0_get json0 keys with Some (`String s) -> Some s | _ -> None
+
+  let interfaces (output : string) : Yojson.Safe.t list =
+    match Yojson.Safe.from_string output with
+    | exception e ->
+        debug "%s: could not parse lldpcli JSON: %s" __FUNCTION__
+          (Printexc.to_string e) ;
+        []
+    | json0 -> (
+      match json0_get json0 ["lldp"; "interface"] with
+      | Some (`List l) ->
+          l
+      | _ ->
+          []
+    )
+
+  let parse_neighbors (output : string) :
+      (string * Network_stats.lldp_neighbor) list =
+    interfaces output
+    |> List.filter_map (fun iface ->
+        let* dev = json0_get_str iface ["name"] in
+        let system_name = json0_get_str iface ["chassis"; "name"; "value"] in
+        let port_id = json0_get_str iface ["port"; "id"; "value"] in
+        let port_description = json0_get_str iface ["port"; "descr"; "value"] in
+        Some (dev, Network_stats.{system_name; port_id; port_description})
+    )
+
+  let parse_enabled_interfaces (output : string) : string list =
+    interfaces output
+    |> List.filter_map (fun iface ->
+        match json0_get_str iface ["status"; "value"] with
+        | Some "RX and TX" ->
+            json0_get_str iface ["name"]
+        | _ ->
+            None
+    )
+end
+
 module type AGENT = sig
   type error = Lldp_types.error
 
@@ -70,6 +131,12 @@ module type AGENT = sig
 
   val disable : string -> (unit, error) result
   (** Stop LLDP (rx-and-tx) on [dev]. *)
+
+  val get_neighbors : unit -> (string * Network_stats.lldp_neighbor) list
+  (** Query the agent for the LLDP neighbour received on each interface. *)
+
+  val get_enabled_interfaces : unit -> string list
+  (** The interfaces on which the agent currently has LLDP enabled (rx-and-tx). *)
 end
 
 let management_ip_address =
@@ -103,6 +170,10 @@ module Lldpd : AGENT = struct
   type error = Lldp_types.error
 
   let cli = "/usr/sbin/lldpcli"
+
+  let show_neighbors_args = ["-f"; "json0"; "show"; "neighbors"]
+
+  let show_interfaces_args = ["-f"; "json0"; "show"; "interfaces"]
 
   let systemctl = "/usr/bin/systemctl"
 
@@ -170,6 +241,24 @@ module Lldpd : AGENT = struct
 
   let disable dev =
     call_cli ["configure"; "ports"; dev; "lldp"; "status"; "disabled"]
+
+  let get_neighbors () =
+    match Network_utils.call_script cli show_neighbors_args with
+    | output ->
+        Lldp_parse.parse_neighbors output
+    | exception e ->
+        debug "%s: could not query LLDP neighbours: %s" __FUNCTION__
+          (Printexc.to_string e) ;
+        []
+
+  let get_enabled_interfaces () =
+    match Network_utils.call_script cli show_interfaces_args with
+    | output ->
+        Lldp_parse.parse_enabled_interfaces output
+    | exception e ->
+        debug "%s: could not query LLDP interfaces: %s" __FUNCTION__
+          (Printexc.to_string e) ;
+        []
 
   let string_of_multicast_address = function
     | I.Nearest_bridge ->
@@ -430,3 +519,9 @@ let stop = Lldp_agent.stop
 
 let set_tlv_management_address () =
   management_ip_address ~force:true () |> Lldp_agent.set_tlv_management_address
+
+let get_neighbors = Lldpd.get_neighbors
+
+let get_enabled_interfaces = Lldpd.get_enabled_interfaces
+
+let is_blocked dev = Blocklist.mem dev

--- a/ocaml/networkd/lib/lldp.mli
+++ b/ocaml/networkd/lib/lldp.mli
@@ -22,3 +22,15 @@ val stop : unit -> unit
 val set_tlv_management_address : unit -> unit
 (** [set_tlv_management_address ()] retrieves the management IP address(es) of
     the host and configure them in the LLDP management address TLV for advertising. *)
+
+val get_neighbors : unit -> (string * Network_stats.lldp_neighbor) list
+(** [get_neighbors ()] queries the LLDP agent and returns, per interface, the
+    received neighbour information (system name, port id, port description). *)
+
+val get_enabled_interfaces : unit -> string list
+(** [get_enabled_interfaces ()] queries the LLDP agent and returns the
+    interfaces on which LLDP is enabled (rx-and-tx). *)
+
+val is_blocked : string -> bool
+(** [is_blocked dev] returns true if the interface [dev] is blocked from
+    receiving LLDP packets. *)

--- a/ocaml/networkd/lib/lldp.mli
+++ b/ocaml/networkd/lib/lldp.mli
@@ -31,6 +31,15 @@ val get_enabled_interfaces : unit -> string list
 (** [get_enabled_interfaces ()] queries the LLDP agent and returns the
     interfaces on which LLDP is enabled (rx-and-tx). *)
 
+val parse_neighbors : string -> (string * Network_stats.lldp_neighbor) list
+(** [parse_neighbors output] parses the JSON produced by
+    [lldpcli -f json0 show neighbors]. Exposed for testing. *)
+
+val parse_enabled_interfaces : string -> string list
+(** [parse_enabled_interfaces output] parses the JSON produced by
+    [lldpcli -f json0 show interfaces], returning the rx-and-tx interfaces.
+    Exposed for testing. *)
+
 val is_blocked : string -> bool
 (** [is_blocked dev] returns true if the interface [dev] is blocked from
     receiving LLDP packets. *)

--- a/ocaml/networkd/test/test_lldp.ml
+++ b/ocaml/networkd/test/test_lldp.ml
@@ -1,0 +1,139 @@
+(*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+(* Tests for Lldp.parse_neighbors: parsing the JSON emitted by
+   [lldpcli -f json0 show neighbors]. *)
+let neighbor_testable =
+  Alcotest.testable
+    (fun ppf (n : Network_stats.lldp_neighbor) ->
+      Fmt.pf ppf "{system_name=%a; port_id=%a; port_description=%a}"
+        Fmt.(option string)
+        n.system_name
+        Fmt.(option string)
+        n.port_id
+        Fmt.(option string)
+        n.port_description
+    )
+    ( = )
+
+let result_testable = Alcotest.(list (pair string neighbor_testable))
+
+let rx ?system_name ?port_id ?port_description () =
+  Network_stats.{system_name; port_id; port_description}
+
+(* One interface with one neighbour (a Cisco Nexus switch). *)
+let single_json =
+  {|
+  { "lldp": [ { "interface": [
+    { "name": "eno8303",
+      "chassis": [ { "name": [ { "value": "NKG-ESWA07-2.eng.citrite.net" } ] } ],
+      "port": [ { "id": [ { "value": "Ethernet1/28" } ],
+                 "descr": [ { "value": "nkg-dt16/idrac" } ] } ] }
+  ] } ] }
+  |}
+
+(* One interface with two neighbours (wider multicast scope / repeater). *)
+let multi_json =
+  {|
+  { "lldp": [ { "interface": [
+    { "name": "eno8303",
+      "chassis": [ { "name": [ { "value": "TOR-A-01" } ] } ],
+      "port": [ { "id": [ { "value": "Eth1/8/3" } ],
+                 "descr": [ { "value": "rack7-a" } ] } ] },
+    { "name": "eno8303",
+      "chassis": [ { "name": [ { "value": "TOR-B-02" } ] } ],
+      "port": [ { "id": [ { "value": "Eth2/8/3" } ],
+                 "descr": [ { "value": "rack7-b" } ] } ] }
+  ] } ] }
+  |}
+
+let empty_json = {| { "lldp": [ { "interface": [] } ] } |}
+
+let test_single () =
+  Alcotest.check result_testable "single neighbour"
+    [
+      ( "eno8303"
+      , rx ~system_name:"NKG-ESWA07-2.eng.citrite.net" ~port_id:"Ethernet1/28"
+          ~port_description:"nkg-dt16/idrac" ()
+      )
+    ]
+    (Lldp.parse_neighbors single_json)
+
+let test_multi () =
+  (* The parser returns all neighbours; picking one is done by the caller. *)
+  Alcotest.check result_testable "two neighbours on one interface"
+    [
+      ( "eno8303"
+      , rx ~system_name:"TOR-A-01" ~port_id:"Eth1/8/3"
+          ~port_description:"rack7-a" ()
+      )
+    ; ( "eno8303"
+      , rx ~system_name:"TOR-B-02" ~port_id:"Eth2/8/3"
+          ~port_description:"rack7-b" ()
+      )
+    ]
+    (Lldp.parse_neighbors multi_json)
+
+let test_empty () =
+  Alcotest.check result_testable "no neighbours" []
+    (Lldp.parse_neighbors empty_json)
+
+let test_malformed () =
+  Alcotest.check result_testable "malformed JSON yields empty" []
+    (Lldp.parse_neighbors "not json {")
+
+let interfaces_json =
+  {|
+  { "lldp": [ { "interface": [
+    { "name": "eno0", "status": [ { "value": "RX and TX" } ] },
+    { "name": "eno1", "status": [ { "value": "disabled" } ] },
+    { "name": "ovs-system", "status": [ { "value": "disabled" } ] }
+  ] } ] }
+  |}
+
+let test_parse_enabled () =
+  Alcotest.check
+    Alcotest.(list string)
+    "only rx-and-tx interfaces" ["eno0"]
+    (Lldp.parse_enabled_interfaces interfaces_json)
+
+let test_parse_enabled_empty () =
+  Alcotest.check
+    Alcotest.(list string)
+    "no interfaces" []
+    (Lldp.parse_enabled_interfaces {| { "lldp": { "interface": [] } } |})
+
+let test_parse_enabled_malformed () =
+  Alcotest.check
+    Alcotest.(list string)
+    "malformed JSON yields empty" []
+    (Lldp.parse_enabled_interfaces "not json {")
+
+let tests =
+  [
+    ( "lldp_parse_neighbors"
+    , [
+        ("single", `Quick, test_single)
+      ; ("multi", `Quick, test_multi)
+      ; ("empty", `Quick, test_empty)
+      ; ("malformed", `Quick, test_malformed)
+      ]
+    )
+  ; ( "lldp_parse_enabled_interfaces"
+    , [
+        ("enabled", `Quick, test_parse_enabled)
+      ; ("empty", `Quick, test_parse_enabled_empty)
+      ; ("malformed", `Quick, test_parse_enabled_malformed)
+      ]
+    )
+  ]

--- a/ocaml/networkd/test/test_lldp.mli
+++ b/ocaml/networkd/test/test_lldp.mli
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2006-2013 Citrix Systems Inc.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -12,12 +12,4 @@
  * GNU Lesser General Public License for more details.
  *)
 
-let () =
-  Debug.log_to_stdout () ;
-  Alcotest.run "base_suite"
-    (Network_test_lacp_properties.suite
-    @ Test_jsonrpc_client.tests
-    @ Test_network_device_order_inherited.tests
-    @ Test_network_device_order.tests
-    @ Test_lldp.tests
-    )
+val tests : unit Alcotest.test list

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -741,6 +741,18 @@ let pif_record rpc session_id pif =
             Record_util.pif_lldp_mode_to_string (x ()).API.pIF_lldp_mode
           )
           ()
+      ; make_field ~name:"lldp-neighbor"
+          ~get:(fun () ->
+            Option.fold ~none:nid
+              ~some:(fun m -> get_from_map m.API.pIF_metrics_lldp_neighbor)
+              (xm ())
+          )
+          ~get_map:(fun () ->
+            Option.fold ~none:[]
+              ~some:(fun m -> m.API.pIF_metrics_lldp_neighbor)
+              (xm ())
+          )
+          ()
       ]
   }
 

--- a/ocaml/xapi-idl/network/network_stats.ml
+++ b/ocaml/xapi-idl/network/network_stats.ml
@@ -34,6 +34,35 @@ let checksum_bytes = 32
 
 let length_bytes = 8
 
+type lldp_state = Enabled | Disabled | Blocked
+[@@default Disabled] [@@deriving rpcty]
+
+let string_of_lldp_state = function
+  | Enabled ->
+      "enabled"
+  | Disabled ->
+      "disabled"
+  | Blocked ->
+      "blocked"
+
+type lldp_neighbor = {
+    system_name: string option
+  ; port_id: string option
+  ; port_description: string option
+}
+[@@deriving rpcty]
+
+let string_of_lldp_neighbor {system_name; port_id; port_description} =
+  let wrap = Option.value ~default:"<unknown>" in
+  let system_name = wrap system_name in
+  let port_id = wrap port_id in
+  let port_description = wrap port_description in
+  Printf.sprintf "system_name=%s, port_id=%s, port_description=%s" system_name
+    port_id port_description
+
+type lldp_rx = {state: lldp_state; neighbor: lldp_neighbor option}
+[@@deriving rpcty]
+
 type iface_stats = {
     carrier: bool
   ; speed: int
@@ -44,6 +73,7 @@ type iface_stats = {
   ; nb_links: int
   ; links_up: int
   ; interfaces: iface list
+  ; lldp_rx: lldp_rx option
 }
 [@@deriving rpcty]
 
@@ -58,6 +88,7 @@ let default_stats =
   ; nb_links= 0
   ; links_up= 0
   ; interfaces= []
+  ; lldp_rx= None
   }
 
 type stats_t = (iface * iface_stats) list [@@deriving rpcty]

--- a/ocaml/xapi/monitor_dbcalls.ml
+++ b/ocaml/xapi/monitor_dbcalls.ml
@@ -22,6 +22,22 @@ module D = Debug.Make (struct let name = "monitor_dbcalls" end)
 
 open D
 
+let lldp_map_of_rx (rx : Network_stats.lldp_rx) : (string * string) list =
+  ("state", Network_stats.string_of_lldp_state rx.Network_stats.state)
+  ::
+  ( match rx.Network_stats.neighbor with
+  | None ->
+      []
+  | Some n ->
+      List.filter_map
+        (fun (k, v) -> Option.map (fun x -> (k, x)) v)
+        [
+          ("system_name", n.Network_stats.system_name)
+        ; ("port_id", n.Network_stats.port_id)
+        ; ("port_description", n.Network_stats.port_description)
+        ]
+  )
+
 let get_pif_and_bond_changes () =
   (* Read fresh PIF information from networkd. *)
   let open Network_stats in
@@ -40,6 +56,13 @@ let get_pif_and_bond_changes () =
           ; pif_pci_bus_path= stat.pci_bus_path
           ; pif_vendor_id= stat.vendor_id
           ; pif_device_id= stat.device_id
+          ; pif_lldp_neighbor=
+              ( match stat.lldp_rx with
+              | Some rx ->
+                  lldp_map_of_rx rx
+              | None ->
+                  []
+              )
           }
         in
         Hashtbl.add pifs_tmp pif.pif_name pif

--- a/ocaml/xapi/monitor_master.ml
+++ b/ocaml/xapi/monitor_master.ml
@@ -50,7 +50,7 @@ let get_pciids vendor device =
   )
 
 let set_pif_metrics ~__context ~self ~vendor ~device ~carrier ~speed ~duplex
-    ~pcibuspath pmr =
+    ~pcibuspath ~lldp_neighbor pmr =
   (* don't update & and reread pciids if db already contains same value *)
   if
     pmr.API.pIF_metrics_vendor_id <> vendor
@@ -70,6 +70,12 @@ let set_pif_metrics ~__context ~self ~vendor ~device ~carrier ~speed ~duplex
     Db.PIF_metrics.set_duplex ~__context ~self ~value:duplex ;
   if pmr.API.pIF_metrics_pci_bus_path <> pcibuspath then
     Db.PIF_metrics.set_pci_bus_path ~__context ~self ~value:pcibuspath ;
+  ( match lldp_neighbor with
+  | Some v when pmr.API.pIF_metrics_lldp_neighbor <> v ->
+      Db.PIF_metrics.set_lldp_neighbor ~__context ~self ~value:v
+  | _ ->
+      ()
+  ) ;
   Db.PIF_metrics.set_last_updated ~__context ~self ~value:(Date.now ())
 
 (* Note that the following function is actually called on the slave most of the
@@ -113,6 +119,14 @@ let update_pifs ~__context host pifs =
             let vendor = pif_stats.pif_vendor_id in
             let device = pif_stats.pif_device_id in
             let pcibuspath = pif_stats.pif_pci_bus_path in
+            (* LLDP is scoped to managed physical NICs; do not write it for
+               bond masters or non-managed PIFs. *)
+            let lldp_neighbor =
+              if pifrec.API.pIF_physical && pifrec.API.pIF_managed then
+                Some pif_stats.pif_lldp_neighbor
+              else
+                None
+            in
             (* 1. Update corresponding VIF carrier flags *)
             if !Xapi_globs.pass_through_pif_carrier then (
               try
@@ -195,7 +209,7 @@ let update_pifs ~__context host pifs =
             in
             let pmr = Db.PIF_metrics.get_record ~__context ~self:metrics in
             set_pif_metrics ~__context ~self:metrics ~vendor ~device ~carrier
-              ~speed ~duplex ~pcibuspath pmr
+              ~speed ~duplex ~pcibuspath ~lldp_neighbor pmr
           with Not_found -> ()
         )
         db_pifs

--- a/ocaml/xapi/monitor_master.ml
+++ b/ocaml/xapi/monitor_master.ml
@@ -189,7 +189,7 @@ let update_pifs ~__context host pifs =
                   ~carrier:false ~device_name:"" ~vendor_name:"" ~device_id:""
                   ~vendor_id:"" ~speed:0L ~duplex:false ~pci_bus_path:""
                   ~io_read_kbs:0. ~io_write_kbs:0. ~last_updated:Date.epoch
-                  ~other_config:[] ;
+                  ~other_config:[] ~lldp_neighbor:[] ;
                 Db.PIF.set_metrics ~__context ~self:pifdev ~value:ref ;
                 ref
             in

--- a/ocaml/xapi/monitor_types.ml
+++ b/ocaml/xapi/monitor_types.ml
@@ -23,6 +23,7 @@ type pif = {
   ; pif_pci_bus_path: string
   ; pif_vendor_id: string
   ; pif_device_id: string
+  ; pif_lldp_neighbor: (string * string) list
 }
 
 let vif_device_of_string x =

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -478,7 +478,7 @@ let make_pif_metrics ~__context =
     Db.PIF_metrics.create ~__context ~ref:metrics ~uuid:metrics_uuid
       ~carrier:false ~device_name:"" ~vendor_name:"" ~device_id:"" ~vendor_id:""
       ~speed:0L ~duplex:false ~pci_bus_path:"" ~io_read_kbs:0. ~io_write_kbs:0.
-      ~last_updated:Date.epoch ~other_config:[]
+      ~last_updated:Date.epoch ~other_config:[] ~lldp_neighbor:[]
   in
   metrics
 


### PR DESCRIPTION
PIF_metrics.lldp_neighbor, Map (String, String), the received LLDP TLVs from the corresponding PIF

Example:
“state”: “enabled”, “system_name”: “EU1-ESWA04-7”, “port_id”: “ifname Eth1/8/3”, “port_description”: “genuk-37-13-nap/eth2_(nsec)”