### PR TITLE
CP-314126: Replace O(V²) list lookups with Map/Set in compute_restart_plan

### DIFF
--- a/ocaml/tests/bench/bench_ha_vm_failover.ml
+++ b/ocaml/tests/bench/bench_ha_vm_failover.ml
@@ -1,0 +1,113 @@
+(*
+ * Copyright (C) Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Bechamel
+
+let () =
+  Suite_init.harness_init () ;
+  Debug.set_level Syslog.Warning
+
+let gib x = Int64.mul x (Int64.mul 1073741824L 1L)
+
+let make_pool ~__context ~num_hosts ~num_vms =
+  let open Test_common in
+  let shared_sr = make_sr ~__context ~shared:true () in
+  let shared_net = make_network ~__context ~bridge:"xenbr0" () in
+  List.iter
+    (fun host -> Db.Host.destroy ~__context ~self:host)
+    (Db.Host.get_all ~__context) ;
+  let hosts =
+    Array.init num_hosts (fun i ->
+        let local_sr = make_sr ~__context ~shared:false () in
+        let local_net = make_network ~__context ~bridge:"xapi0" () in
+        let host_ref =
+          make_host ~__context ~name_label:(Printf.sprintf "host%d" i) ()
+        in
+        Db.Host.set_enabled ~__context ~self:host_ref ~value:true ;
+        let metrics = Db.Host.get_metrics ~__context ~self:host_ref in
+        Db.Host_metrics.set_live ~__context ~self:metrics ~value:true ;
+        Db.Host_metrics.set_memory_total ~__context ~self:metrics
+          ~value:(gib 256L) ;
+        let (_ : API.ref_PBD) =
+          make_pbd ~__context ~host:host_ref ~sR:local_sr ()
+        in
+        let (_ : API.ref_PBD) =
+          make_pbd ~__context ~host:host_ref ~sR:shared_sr ()
+        in
+        let (_ : API.ref_PIF) =
+          make_pif ~__context ~host:host_ref ~network:local_net ()
+        in
+        let (_ : API.ref_PIF) =
+          make_pif ~__context ~host:host_ref ~network:shared_net ()
+        in
+        host_ref
+    )
+  in
+  for i = 0 to num_vms - 1 do
+    let host_ref = hosts.(i mod num_hosts) in
+    let vm_ref =
+      make_vm ~__context ~ha_always_run:true ~ha_restart_priority:"restart"
+        ~memory_static_min:(gib 1L) ~memory_dynamic_min:(gib 1L)
+        ~memory_dynamic_max:(gib 1L) ~memory_static_max:(gib 1L)
+        ~name_label:(Printf.sprintf "vm%d" i) ()
+    in
+    Db.VM.set_power_state ~__context ~self:vm_ref ~value:`Running ;
+    Db.VM.set_resident_on ~__context ~self:vm_ref ~value:host_ref ;
+    let vdi_ref = make_vdi ~__context ~sR:shared_sr () in
+    let (_ : API.ref_VBD) = make_vbd ~__context ~vM:vm_ref ~vDI:vdi_ref () in
+    let (_ : API.ref_VIF) =
+      make_vif ~__context ~vM:vm_ref ~network:shared_net
+        ~device:(string_of_int i) ()
+    in
+    ()
+  done ;
+  let pool = Helpers.get_pool ~__context in
+  let master_ref = hosts.(0) in
+  Db.Pool.set_master ~__context ~self:pool ~value:master_ref ;
+  Db.Pool.set_ha_enabled ~__context ~self:pool ~value:true ;
+  Db.Pool.set_ha_host_failures_to_tolerate ~__context ~self:pool ~value:1L ;
+  Db.Pool.set_ha_plan_exists_for ~__context ~self:pool ~value:1L
+
+let allocate ~num_hosts ~num_vms () =
+  let __context = Test_common.make_test_database () in
+  make_pool ~__context ~num_hosts ~num_vms ;
+  __context
+
+let run_plan_for_n_failures __context =
+  let all_protected_vms = Xapi_ha_vm_failover.all_protected_vms ~__context in
+  let (_ : Xapi_ha_vm_failover.plan_status) =
+    Xapi_ha_vm_failover.plan_for_n_failures ~__context ~all_protected_vms 1
+  in
+  ()
+
+let benchmarks =
+  let make ~num_hosts ~num_vms =
+    let name =
+      Printf.sprintf "plan_for_n_failures (%d hosts, %d VMs)" num_hosts num_vms
+    in
+    Test.make_with_resource ~name
+      ~allocate:(allocate ~num_hosts ~num_vms)
+      ~free:ignore Test.uniq
+      (Staged.stage run_plan_for_n_failures)
+  in
+  [
+    make ~num_hosts:3 ~num_vms:10
+  ; make ~num_hosts:3 ~num_vms:50
+  ; make ~num_hosts:3 ~num_vms:100
+  ; make ~num_hosts:3 ~num_vms:500
+  ; make ~num_hosts:8 ~num_vms:100
+  ; make ~num_hosts:8 ~num_vms:500
+  ]
+
+let () = Bechamel_simple_cli.cli benchmarks

--- a/ocaml/tests/bench/dune
+++ b/ocaml/tests/bench/dune
@@ -1,5 +1,6 @@
 (executables
  (names
+  bench_ha_vm_failover
   bench_tracing
   bench_uuid
   bench_throttle2

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -978,8 +978,11 @@ let compute_restart_plan ~__context ~all_protected_vms ~live_set
     Binpack.account hosts_and_memory vms_and_memory non_agile_restart_plan
   in
   (* Now that we've considered the overhead of the non-agile (pinned) VMs, we can perform some binpacking of the agile VMs. *)
+  let vms_and_memory_map =
+    List.fold_left (fun m (k, v) -> VMMap.add k v m) VMMap.empty vms_and_memory
+  in
   let agile_vms_and_memory =
-    List.map (fun (vm, _) -> (vm, List.assoc vm vms_and_memory)) agile_vms
+    List.map (fun (vm, _) -> (vm, VMMap.find vm vms_and_memory_map)) agile_vms
   in
   (* Compute the current placement for all agile VMs. VMs which are powered off currently are placed nowhere *)
   let agile_vm_accounted_to_host =

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -889,10 +889,11 @@ let compute_restart_plan ~__context ~all_protected_vms ~live_set
          p
       )
   in
-  debug "Protected VMs: [ %s ]"
-    (String.concat "; "
-       (List.map (fun (vm, _) -> string_of_vm vm) vms_to_ensure_running)
-    ) ;
+  if not (Debug.is_disabled "xapi_ha_vm_failover" Syslog.Debug) then
+    debug "Protected VMs: [ %s ]"
+      (String.concat "; "
+         (List.map (fun (vm, _) -> string_of_vm vm) vms_to_ensure_running)
+      ) ;
   (* Current free memory on all hosts (does not include any for *offline* protected VMs ie those for which (vm_accounted_to_host vm)
      	   returns None) Also apply the supplied counterfactual-reasoning changes (if any) *)
   let hosts_and_memory =

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -850,12 +850,17 @@ let compute_restart_plan ~__context ~all_protected_vms ~live_set
       (fun (_, a) (_, b) -> compare a.API.vM_uuid b.API.vM_uuid)
       vms_to_ensure_running
   in
+  let vms_map =
+    List.fold_left
+      (fun m (k, v) -> VMMap.add k v m)
+      VMMap.empty vms_to_ensure_running
+  in
   let agile_vms, not_agile_vms =
     Agility.partition_vm_ps_by_agile ~__context vms_to_ensure_running
   in
   (* If a VM is marked as resident on a live_host then it will already be accounted for in the host's current free memory. *)
   let vm_accounted_to_host vm =
-    let vm_t = List.assoc vm vms_to_ensure_running in
+    let vm_t = VMMap.find vm vms_map in
     if HostSet.mem vm_t.API.vM_resident_on live_hosts_set then
       Some vm_t.API.vM_resident_on
     else
@@ -869,7 +874,7 @@ let compute_restart_plan ~__context ~all_protected_vms ~live_set
   in
   let string_of_vm vm =
     Printf.sprintf "%s (%s)" (Ref.short_string_of vm)
-      (List.assoc vm vms_to_ensure_running).API.vM_name_label
+      (VMMap.find vm vms_map).API.vM_name_label
   in
   let string_of_host host =
     let name = (HostMap.find host hosts_map).API.host_name_label in

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -843,6 +843,7 @@ let compute_restart_plan ~__context ~all_protected_vms ~live_set
     List.map fst live_hosts_and_snapshots
     (* and dead_hosts = List.map fst dead_hosts_and_snapshots *)
   in
+  let live_hosts_set = HostSet.of_list live_hosts in
   (* Any deterministic ordering is fine here: *)
   let vms_to_ensure_running =
     List.sort
@@ -855,13 +856,13 @@ let compute_restart_plan ~__context ~all_protected_vms ~live_set
   (* If a VM is marked as resident on a live_host then it will already be accounted for in the host's current free memory. *)
   let vm_accounted_to_host vm =
     let vm_t = List.assoc vm vms_to_ensure_running in
-    if List.mem vm_t.API.vM_resident_on live_hosts then
+    if HostSet.mem vm_t.API.vM_resident_on live_hosts_set then
       Some vm_t.API.vM_resident_on
     else
       let scheduled =
         Db.VM.get_scheduled_to_be_resident_on ~__context ~self:vm
       in
-      if List.mem scheduled live_hosts then
+      if HostSet.mem scheduled live_hosts_set then
         Some scheduled
       else
         None

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -821,6 +821,11 @@ let compute_restart_plan ~__context ~all_protected_vms ~live_set
       (fun (_, a) (_, b) -> compare a.API.host_uuid b.API.host_uuid)
       all_hosts_and_snapshots
   in
+  let hosts_map =
+    List.fold_left
+      (fun m (k, v) -> HostMap.add k v m)
+      HostMap.empty all_hosts_and_snapshots
+  in
   let is_alive (rf, r) =
     (* We exclude: (i) online disabled hosts; (ii) online proposed disabled hosts; and (iii) offline hosts *)
     true
@@ -866,7 +871,7 @@ let compute_restart_plan ~__context ~all_protected_vms ~live_set
       (List.assoc vm vms_to_ensure_running).API.vM_name_label
   in
   let string_of_host host =
-    let name = (List.assoc host all_hosts_and_snapshots).API.host_name_label in
+    let name = (HostMap.find host hosts_map).API.host_name_label in
     Printf.sprintf "%s (%s)" (Ref.short_string_of host) name
   in
   let string_of_plan p =

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -215,6 +215,18 @@ module HostKey = struct
   let compare = Ref.compare
 end
 
+module HostMap = Map.Make (HostKey)
+module HostSet = Set.Make (HostKey)
+
+module VMRefOrd = struct
+  type t = [`VM] Ref.t
+
+  let compare = Ref.compare
+end
+
+module VMRefSet = Set.Make (VMRefOrd)
+module VMMap = Map.Make (VMRefOrd)
+
 (* For a VM anti-affinity group, the state of a host which determines
    evacuation planning for anti-affinity VMs in that group:
    1. vm_cnt: the number of running VMs in that group resident on the host
@@ -1273,14 +1285,6 @@ let restart_failed : (API.ref_VM, unit) Hashtbl.t = Hashtbl.create 10
 
 (* We also limit the rate we attempt to retry starting the VM. *)
 let last_start_attempt : (API.ref_VM, float) Hashtbl.t = Hashtbl.create 10
-
-module VMRefOrd = struct
-  type t = [`VM] Ref.t
-
-  let compare = Ref.compare
-end
-
-module VMMap = Map.Make (VMRefOrd)
 
 (* When a host is up, it will be added in the HA live set. But it may be still
    in disabled state so that starting best-effort VMs on it would fail.

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -1024,13 +1024,17 @@ let compute_restart_plan ~__context ~all_protected_vms ~live_set
   let agile_restart_plan = h.Binpack.get_specific_plan config agile_vm_failed in
   debug "Restart plan for agile offline VMs: [ %s ]"
     (string_of_plan agile_restart_plan) ;
-  let vms_restarted = List.map fst agile_restart_plan in
+  let vms_restarted =
+    List.fold_left
+      (fun s (vm, _) -> VMRefSet.add vm s)
+      VMRefSet.empty agile_restart_plan
+  in
   (* List the protected VMs which are not already running and weren't in the restart plan *)
   let vms_not_restarted =
     List.map fst
       (List.filter
          (fun (vm, _) ->
-           vm_accounted_to_host vm = None && not (List.mem vm vms_restarted)
+           vm_accounted_to_host vm = None && not (VMRefSet.mem vm vms_restarted)
          )
          vms_to_ensure_running
       )


### PR DESCRIPTION
compute_restart_plan used List.assoc and List.mem over association lists in inner loops, making the HA plan recomputation O(V²) where V is the number of protected VMs. This replaces
  those linear scans with immutable Map and Set structures for O(V log V) overall.

  - Build HostMap / HostSet for host record lookups and live-host membership tests
  - Build VMMap / VMRefSet for VM record lookups, memory lookups, and restarted-VM membership tests
  - Guard an eager O(V) debug formatting call with Debug.is_disabled
  - Add a Bechamel benchmark for plan_for_n_failures across pool sizes (10–500 VMs, 3–8 hosts)

  Benchmark results:

  │     Scenario           │ Before (ns/run) │ After (ns/run) │ Speedup │
  │ 3 hosts, 10 VMs   │ 312,064             │ 316,296          │ ~1.0x      │
  │ 3 hosts, 50 VMs   │ 1,830,234          │ 1,609,937       │ 1.14x       │
  │ 3 hosts, 100 VMs │ 4,389,669          │ 3,702,982       │ 1.19x       │
  │ 3 hosts, 500 VMs │ 52,277,926        │ 34,665,446     │ 1.51x       │
  │ 8 hosts, 100 VMs │ 4,696,515          │ 3,968,948       │ 1.18x       │
  │ 8 hosts, 500 VMs │ 54,391,061        │ 34,974,569     │ 1.56x       │

Easier to review commit by commit.