### PR TITLE
 CP-27919: process xenopsd events in per-VM worker threads

### DIFF
--- a/ocaml/libs/xapi-work-queues/xapi_work_queues.ml
+++ b/ocaml/libs/xapi-work-queues/xapi_work_queues.ml
@@ -198,6 +198,8 @@ module type S = sig
 
     val start : int -> unit
 
+    val start_default : int -> unit
+
     val set_size : int -> unit
   end
 end
@@ -546,6 +548,11 @@ module Make (W : Work) = struct
         incr Redirector.parallel_queues ;
         incr Redirector.nested_parallel_queues ;
         incr Redirector.receive_memory_queues
+      done
+
+    let start_default size =
+      for _i = 1 to size do
+        incr Redirector.default
       done
 
     let set_size size =

--- a/ocaml/libs/xapi-work-queues/xapi_work_queues.mli
+++ b/ocaml/libs/xapi-work-queues/xapi_work_queues.mli
@@ -90,7 +90,13 @@ module type S = sig
     module Dump : Dump
 
     val start : int -> unit
-    (** [start n] Launches [n] additional worker threads *)
+    (** [start n] Launches [n] additional worker threads on every queue *)
+
+    val start_default : int -> unit
+    (** [start_default n] Launches [n] additional worker threads serving the
+        default queue only. Use this instead of [start] when the caller never
+        pushes to [parallel_queues], [nested_parallel_queues] or
+        [receive_memory_queues], to avoid creating idle threads for them. *)
 
     val set_size : int -> unit
     (** [set_size n] sets the worker pool size to [n]. *)

--- a/ocaml/tests/common/mock_rpc.ml
+++ b/ocaml/tests/common/mock_rpc.ml
@@ -34,6 +34,19 @@ let rpc __context call =
       let self = ref_VM_of_rpc self_rpc in
       Xapi_vm_lifecycle.update_allowed_operations ~__context ~self ;
       Rpc.{success= true; contents= Rpc.String ""; is_notification= false}
+  | "Async.VM.update_allowed_operations", [session_id_rpc; self_rpc] ->
+      (* Done synchronously here so that tests stay deterministic; the caller
+         discards the task reference. *)
+      let open API in
+      let _session_id = ref_session_of_rpc session_id_rpc in
+      let self = ref_VM_of_rpc self_rpc in
+      Xapi_vm_lifecycle.update_allowed_operations ~__context ~self ;
+      Rpc.
+        {
+          success= true
+        ; contents= API.rpc_of_ref_task Ref.null
+        ; is_notification= false
+        }
   | "VM.atomic_set_resident_on", [session_id_rpc; vm_rpc; host_rpc] ->
       let open API in
       let _session_id = ref_session_of_rpc session_id_rpc in

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -246,6 +246,7 @@
   xapi-tracing
   xapi-tracing-export
   xapi_version
+  xapi-work-queues
   xapi_xenopsd
   xenstore_transport.unix
   xml-light2

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -764,6 +764,11 @@ let vm_call_plugin_interval = ref 10.
 (** The maximum number of SR scans allowed concurrently *)
 let max_active_sr_scans = ref 32
 
+(** Number of threads processing xenopsd events. Events for one VM are always
+    processed in order by a single thread; this bounds how many VMs can be
+    updated concurrently. *)
+let xenopsd_event_workers = ref 16
+
 let nowatchdog = ref false
 
 let log_getter = ref false
@@ -1274,6 +1279,7 @@ let xapi_globs_spec =
   ; ("vm_call_plugin_interval", Float vm_call_plugin_interval)
   ; ("xapi_clusterd_port", Int xapi_clusterd_port)
   ; ("max_active_sr_scans", Int max_active_sr_scans)
+  ; ("xenopsd_event_workers", Int xenopsd_event_workers)
   ; ("winbind_debug_level", Int winbind_debug_level)
   ; ("winbind_cache_time", Int winbind_cache_time)
   ; ("winbind_machine_pwd_timeout", Float winbind_machine_pwd_timeout)

--- a/ocaml/xapi/xapi_guest_agent.ml
+++ b/ocaml/xapi/xapi_guest_agent.ml
@@ -535,9 +535,12 @@ let all (lookup : string -> string option) (list : string -> string list)
       Db.VM_guest_metrics.set_services ~__context ~self:gm ~value:services ;
     if guest_metrics_cached.other <> other then (
       Db.VM_guest_metrics.set_other ~__context ~self:gm ~value:other ;
-      Helpers.call_api_functions ~__context (fun rpc session_id ->
-          Client.Client.VM.update_allowed_operations ~rpc ~session_id ~self
-      )
+      ignore
+        (Helpers.call_api_functions ~__context (fun rpc session_id ->
+             Client.Client.Async.VM.update_allowed_operations ~rpc ~session_id
+               ~self
+         )
+        )
     ) ;
     if guest_metrics_cached.can_use_hotplug_vbd <> can_use_hotplug_vbd then
       Db.VM_guest_metrics.set_can_use_hotplug_vbd ~__context ~self:gm
@@ -587,9 +590,12 @@ let all (lookup : string -> string option) (list : string -> string list)
       || guest_metrics_cached.can_use_hotplug_vbd <> can_use_hotplug_vbd
       || guest_metrics_cached.can_use_hotplug_vif <> can_use_hotplug_vif
     then
-      Helpers.call_api_functions ~__context (fun rpc session_id ->
-          Client.Client.VM.update_allowed_operations ~rpc ~session_id ~self
-      )
+      ignore
+        (Helpers.call_api_functions ~__context (fun rpc session_id ->
+             Client.Client.Async.VM.update_allowed_operations ~rpc ~session_id
+               ~self
+         )
+        )
   )
 
 (* else debug "Ignored spurious guest agent update" *)

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -945,20 +945,21 @@ let force_state_reset_keep_current_operations ~__context ~self ~value:state =
           Db.VM.remove_attached_PCIs ~__context ~self ~value:pci
     ) ;
     List.iter
-      (fun pci ->
+      (fun (pci_ref, pci) ->
         (* The following should not be necessary if many-to-many relations in the DB
          * work properly. People have reported issues that may indicate that this is
          * not the case, but we have not yet found the root cause. Therefore, the
          * following code is there "just to be sure".*)
-        if List.mem self (Db.PCI.get_attached_VMs ~__context ~self:pci) then
-          Db.PCI.remove_attached_VMs ~__context ~self:pci ~value:self ;
+        if List.mem self pci.Db_actions.pCI_attached_VMs then
+          Db.PCI.remove_attached_VMs ~__context ~self:pci_ref ~value:self ;
         (* Clear any PCI device reservations for this VM. *)
-        if Db.PCI.get_scheduled_to_be_attached_to ~__context ~self:pci = self
-        then
-          Db.PCI.set_scheduled_to_be_attached_to ~__context ~self:pci
+        if pci.Db_actions.pCI_scheduled_to_be_attached_to = self then
+          Db.PCI.set_scheduled_to_be_attached_to ~__context ~self:pci_ref
             ~value:Ref.null
       )
-      (Db.PCI.get_all ~__context)
+      (Db.PCI.get_internal_records_where ~__context
+         ~expr:Xapi_database.Db_filter_types.True
+      )
   ) ;
   update_allowed_operations ~__context ~self ;
   if old_state <> state && (old_state = `Running || state = `Running) then

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1865,6 +1865,19 @@ module Events_from_xenopsd = struct
 
   let active_m = Mutex.create ()
 
+  (* Maps barrier ID to the VM the barrier was injected for, so that the
+     wakeup can be queued on that VM's work queue. *)
+  let mapping = Hashtbl.create 25
+
+  let mapping_m = Mutex.create ()
+
+  let record_id id vm_id =
+    with_lock mapping_m (fun () -> Hashtbl.replace mapping id vm_id)
+
+  let lookup_id id = with_lock mapping_m (fun () -> Hashtbl.find_opt mapping id)
+
+  let forget_id id = with_lock mapping_m (fun () -> Hashtbl.remove mapping id)
+
   let register =
     let counter = ref 0 in
     fun t ->
@@ -1891,7 +1904,8 @@ module Events_from_xenopsd = struct
       ~dbg
     @@ fun di ->
     let dbg = Debug_info.to_string di in
-    debug "Client.UPDATES.inject_barrier %d" id ;
+    debug "Client.UPDATES.inject_barrier %d (vm_id = %s)" id vm_id ;
+    record_id id vm_id ;
     Client.UPDATES.inject_barrier dbg vm_id id ;
     with_lock t.m (fun () ->
         while not t.finished do
@@ -1913,6 +1927,7 @@ module Events_from_xenopsd = struct
     let dbg = Debug_info.to_string di in
     let module Client = (val make_client queue_name : XENOPS) in
     Client.UPDATES.remove_barrier dbg id ;
+    forget_id id ;
     let t =
       with_lock active_m @@ fun () ->
       match Hashtbl.find_opt active id with
@@ -3033,7 +3048,48 @@ let update_task ~__context queue_name id =
   | e ->
       error "xenopsd event: Caught %s while updating task" (string_of_exn e)
 
+(* Xenopsd events are handed to a pool of worker threads keyed on the id of the
+   object's VM: events for one VM are processed in the order they arrived,
+   events for different VMs may be processed concurrently. Previously a single
+   thread processed every event on the host in sequence, so one slow update -
+   each of which makes several database calls, and on a supporter host those
+   are RPCs to the coordinator - delayed the events of every other VM,
+   including the barriers that VM.start waits on. *)
+module Xenops_event_work = struct
+  type t = {label: string; work: Context.t -> unit}
+
+  let describe_work t = t.label
+
+  let dump_task _ = Rpc.Null
+
+  (* Run each item under a fresh task rather than the event loop's context:
+     the loop completes its tracing span on every iteration, so a captured
+     context could be completed while an item is still using it. *)
+  let execute t =
+    Server_helpers.exec_with_new_task t.label (fun __context -> t.work __context)
+
+  let finally _ = ()
+
+  (* Never drop a queued item. Coalescing redundant updates for the same VM is
+     possible, but would have to keep each barrier ordered after the updates it
+     was injected behind. *)
+  let should_keep _ _ = true
+end
+
+module Xenops_event_worker = Xapi_work_queues.Make (Xenops_event_work)
+
+(* Shared by every queue's event thread, so start it once however many queues
+   are watched. events_watch is useless without it - the items it queues would
+   never run - so it is forced there rather than in any one caller. *)
+let start_event_workers =
+  lazy
+    (let n = !Xapi_globs.xenopsd_event_workers in
+     info "Starting %d xenopsd event worker threads" n ;
+     Xenops_event_worker.WorkerPool.start_default n
+    )
+
 let rec events_watch ~__context cancel queue_name from =
+  Lazy.force start_event_workers ;
   Context.complete_tracing __context ;
   let next =
     Context.with_tracing ~__context __FUNCTION__ (fun __context ->
@@ -3046,6 +3102,11 @@ let rec events_watch ~__context cancel queue_name from =
         let done_events = ref [] in
         let already_done x = List.mem x !done_events in
         let add_event x = done_events := x :: !done_events in
+        let enqueue tag label work =
+          Xenops_event_worker.Redirector.push
+            Xenops_event_worker.Redirector.default tag
+            {Xenops_event_work.label; work}
+        in
         let do_updates l =
           let open Dynamic in
           List.iter
@@ -3056,28 +3117,47 @@ let rec events_watch ~__context cancel queue_name from =
                 debug "Skipping (already processed this round)"
               else (
                 add_event ev ;
+                (* Tag on the VM's id so that all of a VM's events, and the
+                   barrier injected behind them, are processed in order. *)
                 match ev with
                 | Vm id ->
                     debug "xenops event on VM %s" id ;
-                    update_vm ~__context id
+                    enqueue id (Printf.sprintf "update_vm(%s)" id)
+                      (fun __context -> update_vm ~__context id
+                    )
                 | Vbd id ->
                     debug "xenops event on VBD %s.%s" (fst id) (snd id) ;
-                    update_vbd ~__context id
+                    enqueue (fst id)
+                      (Printf.sprintf "update_vbd(%s.%s)" (fst id) (snd id))
+                      (fun __context -> update_vbd ~__context id)
                 | Vif id ->
                     debug "xenops event on VIF %s.%s" (fst id) (snd id) ;
-                    update_vif ~__context id
+                    enqueue (fst id)
+                      (Printf.sprintf "update_vif(%s.%s)" (fst id) (snd id))
+                      (fun __context -> update_vif ~__context id)
                 | Pci id ->
                     debug "xenops event on PCI %s.%s" (fst id) (snd id) ;
-                    update_pci ~__context id
+                    enqueue (fst id)
+                      (Printf.sprintf "update_pci(%s.%s)" (fst id) (snd id))
+                      (fun __context -> update_pci ~__context id)
                 | Vgpu id ->
                     debug "xenops event on VGPU %s.%s" (fst id) (snd id) ;
-                    update_vgpu ~__context id
+                    enqueue (fst id)
+                      (Printf.sprintf "update_vgpu(%s.%s)" (fst id) (snd id))
+                      (fun __context -> update_vgpu ~__context id)
                 | Vusb id ->
                     debug "xenops event on VUSB %s.%s" (fst id) (snd id) ;
-                    update_vusb ~__context id
+                    enqueue (fst id)
+                      (Printf.sprintf "update_vusb(%s.%s)" (fst id) (snd id))
+                      (fun __context -> update_vusb ~__context id)
                 | Task id ->
+                    (* Tasks are not VM-scoped; tag on the task so that updates
+                       to one task stay ordered without serialising all of
+                       them behind each other. *)
                     debug "xenops event on Task %s" id ;
-                    update_task ~__context queue_name id
+                    enqueue id (Printf.sprintf "update_task(%s)" id)
+                      (fun __context -> update_task ~__context queue_name id
+                    )
               )
             )
             l
@@ -3086,7 +3166,21 @@ let rec events_watch ~__context cancel queue_name from =
           (fun (id, b_events) ->
             debug "Processing barrier %d" id ;
             do_updates b_events ;
-            Events_from_xenopsd.wakeup queue_name dbg id
+            let wake __context =
+              let dbg = Context.string_of_task_and_tracing __context in
+              Events_from_xenopsd.wakeup queue_name dbg id
+            in
+            match Events_from_xenopsd.lookup_id id with
+            | Some vm_id ->
+                (* Queue the wakeup behind that VM's updates, so a waiter is
+                   only released once the events it is waiting for have been
+                   applied. *)
+                enqueue vm_id (Printf.sprintf "barrier(%d)" id) wake
+            | None ->
+                (* No record of who injected this barrier: wake immediately
+                   rather than leave a caller blocked forever. *)
+                warn "Barrier %d has no recorded VM; waking inline" id ;
+                Events_from_xenopsd.wakeup queue_name dbg id
           )
           barriers ;
         do_updates events ;

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2530,9 +2530,11 @@ let update_vm_internal ~__context ~id ~self ~previous ~info ~localhost =
 
   Xenops_cache.update_vm id info ;
   if !should_update_allowed_operations then
-    Helpers.call_api_functions ~__context (fun rpc session_id ->
-        XenAPI.VM.update_allowed_operations ~rpc ~session_id ~self
-    )
+    ignore
+      (Helpers.call_api_functions ~__context (fun rpc session_id ->
+           XenAPI.Async.VM.update_allowed_operations ~rpc ~session_id ~self
+       )
+      )
 
 let update_vm ~__context id =
   let@ __context =


### PR DESCRIPTION
## Problem

A single thread per xenopsd queue applies every event on the host, one at a time
(`Events_from_xenopsd` / `events_watch` in `xapi_xenops.ml`). Each update makes
several database calls, and on a supporter host those are RPCs to the coordinator.
So one slow update delays the events of every other VM on the host — including the
barrier that `VM.start` blocks on, which is why xapi can report a VM as still
starting long after xenopsd has unpaused it.

This is CP-27919 (originally reported against a Win7 bootstorm: VMs stayed "yellow"
in XenCenter for minutes after they had finished booting, with their tasks pending
at progress 0.0).

## Approach

Hand each event to a pool of worker threads keyed on the id of the object's VM:
events for one VM are processed in the order they arrived, events for different VMs
may be processed concurrently. Barrier wakeups are queued on the same key as the
events the barrier was injected behind, so a waiter is still only released once
those events have been applied.

Based on @edwintorok's `ca-87377-refactored` branch.

## Behaviour changes worth reviewing

- **`allowed_operations` becomes eventually consistent.** A client that reads it
  immediately after a state change may see the previous value. Anything asserting on
  `allowed_operations` right after a lifecycle operation is now racy.
- **One extra task object per `update_allowed_operations`**, discarded by the caller,
  so it lives until the task GC collects it. Worth watching the task table at
  bootstorm scale.
- **Ordering guarantees are now per-VM, not per-host.** Task events are ordered only
  against themselves. Any code that relied on a Task update and a VM update being
  applied in the order xenopsd emitted them would need to say so.
- **`should_keep` is always true** — no coalescing of redundant updates for the same
  VM. That optimisation is possible but has to keep each barrier ordered after the
  updates it was injected behind, so it is deliberately left out of this change.
- **New config key** `xenopsd_event_workers` (default 16). Setting it to 1
  approximates the previous behaviour, which makes for a clean A/B.
