### PR TITLE
xapi_sr_operations: Reorder checks on destroy

### DIFF
--- a/ocaml/xapi/xapi_sr_operations.ml
+++ b/ocaml/xapi/xapi_sr_operations.ml
@@ -254,9 +254,9 @@ let valid_operations ~__context ?op record _ref' : table =
   let relevant_functions =
     [
       (all_ops, check_sm_features)
-    ; ([`destroy; `forget], check_any_attached_pbds)
     ; ([`destroy], check_no_pbds)
     ; ([`destroy], check_any_managed_vdis)
+    ; ([`destroy; `forget], check_any_attached_pbds)
     ; (all_ops, check_parallel_ops)
     ; ([`plug], check_cluster_stack_compatible)
     ]


### PR DESCRIPTION
When destroying an SR that still has VDIs and a plugged-in PBD, xapi errors out with SR_HAS_PBD. After unplugging the PBD, xapi instead errors out with SR_NOT_EMPTY - but removing VDIs in turn requires the PBD to be plugged back in.

So re-order the checks to avoid directing users to do these operations in the wrong order: first check for VDIs, then for plugged-in PBDs.