### PR TITLE
CP-314128: Reduce unnecessary allocations and complexity across xapi

### DIFF
--- a/ocaml/networkd/lib/network_utils.ml
+++ b/ocaml/networkd/lib/network_utils.ml
@@ -1969,6 +1969,8 @@ end
 module Modprobe = struct
   let getpath driver = Printf.sprintf "/etc/modprobe.d/%s.conf" driver
 
+  let whitespace_re = Re.Perl.compile_pat "[ \\t]+"
+
   let write_conf_file driver content =
     try
       Unixext.write_string_to_file (getpath driver) (String.concat "\n" content) ;
@@ -2067,6 +2069,7 @@ module Modprobe = struct
     >>= fun option ->
     let need_rebuild_initrd = ref false in
     let has_probe_conf = ref false in
+    let driver_options_re = Re.Perl.compile_pat ("options[ \\t]+" ^ driver) in
     let parse_single_line s =
       let parse_driver_options s =
         match Astring.String.cut ~sep:"=" s with
@@ -2086,11 +2089,8 @@ module Modprobe = struct
             s
       in
       let trimed_s = String.trim s in
-      if Re.execp (Re.Perl.compile_pat ("options[ \\t]+" ^ driver)) trimed_s
-      then
-        let driver_options =
-          Re.split (Re.Perl.compile_pat "[ \\t]+") trimed_s
-        in
+      if Re.execp driver_options_re trimed_s then
+        let driver_options = Re.split whitespace_re trimed_s in
         List.map parse_driver_options driver_options |> String.concat " "
       else
         trimed_s

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -748,6 +748,8 @@ module YumUpgradeOutput = struct
 
   let is_white = Astring.Char.Ascii.is_white
 
+  let replacing_pattern = Re.Str.regexp "^[ ]+replacing .+$"
+
   let rec line ~section ~section_acc ~acc =
     let rec line_after_txn_summary sections =
       at_end_of_input >>= function
@@ -800,34 +802,33 @@ module YumUpgradeOutput = struct
               line_after_txn_summary acc
         )
         | l -> (
-            let pattern = Re.Str.regexp "^[ ]+replacing .+$" in
-            match
-              ( section
-              , Re.Str.string_match pattern l 0
-              , String.starts_with ~prefix:"Error: " l
-              )
-            with
-            | Some s, true, false ->
-                (* in a section, but starting with 'replacing', ignoring the line.
-                 * https://github.com/rpm-software-management/yum/blob/master/output.py#L1622
-                 * https://github.com/rpm-software-management/dnf5/blob/main/libdnf5-cli/output/transaction_table.cpp#L373
-                 *)
-                line ~section:(Some s) ~section_acc ~acc
-            | Some s, false, false ->
-                (* in a section, append to the section's list *)
-                line ~section:(Some s) ~section_acc:(l :: section_acc) ~acc
-            | None, false, true ->
-                (* error reported from yum upgrade *)
-                fail l
-            | None, false, false ->
-                (* not in any section, ignoring the line *)
-                line ~section:None ~section_acc:[] ~acc
-            | _ ->
-                fail
-                  (Printf.sprintf
-                     "Unexpected output from yum upgrade (dry run): %s" l
-                  )
-          )
+          match
+            ( section
+            , Re.Str.string_match replacing_pattern l 0
+            , String.starts_with ~prefix:"Error: " l
+            )
+          with
+          | Some s, true, false ->
+              (* in a section, but starting with 'replacing', ignoring the line.
+               * https://github.com/rpm-software-management/yum/blob/master/output.py#L1622
+               * https://github.com/rpm-software-management/dnf5/blob/main/libdnf5-cli/output/transaction_table.cpp#L373
+               *)
+              line ~section:(Some s) ~section_acc ~acc
+          | Some s, false, false ->
+              (* in a section, append to the section's list *)
+              line ~section:(Some s) ~section_acc:(l :: section_acc) ~acc
+          | None, false, true ->
+              (* error reported from yum upgrade *)
+              fail l
+          | None, false, false ->
+              (* not in any section, ignoring the line *)
+              line ~section:None ~section_acc:[] ~acc
+          | _ ->
+              fail
+                (Printf.sprintf
+                   "Unexpected output from yum upgrade (dry run): %s" l
+                )
+        )
       )
     | true ->
         return ([], None)

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -22,6 +22,12 @@ open Updateinfo
 module LivePatchSet = Set.Make (LivePatch)
 module RpmFullNameSet = Set.Make (String)
 
+module PkgSet = Set.Make (struct
+  type t = Pkg.t * string
+
+  let compare = Stdlib.compare
+end)
+
 let pool_update_ops_mutex = Mutex.create ()
 
 module Pkgs = (val Pkg_mgr.get_pkg_mgr)
@@ -550,9 +556,10 @@ let get_updates_from_updateinfo ~__context repositories =
     get_pkgs_from_yum_updateinfo_list Pkg_mgr.Updateinfo.Updates repositories
   in
   (* 'new_updates' are a list of RPM packages to be installed, rather than updated *)
+  let updates_set = PkgSet.of_list updates in
   let new_updates =
     get_pkgs_from_yum_updateinfo_list Pkg_mgr.Updateinfo.Available repositories
-    |> List.filter (fun x -> not (List.mem x updates))
+    |> List.filter (fun x -> not (PkgSet.mem x updates_set))
     |> List.filter (fun (pkg, _) -> not (is_obsoleted pkg.Pkg.name repositories))
   in
   new_updates @ updates
@@ -729,11 +736,12 @@ let get_updates_from_repoquery repositories =
   (* Use 'updates' to decrease the number of packages to apply 'is_obsoleted' *)
   let Pkg_mgr.{cmd; params} = Pkgs.repoquery_updates ~repositories in
   let updates = get_pkgs_from_repoquery cmd params in
+  let updates_set = PkgSet.of_list updates in
   (* 'new_updates' are a list of RPM packages to be installed, rather than updated *)
   let Pkg_mgr.{cmd; params} = Pkgs.repoquery_available ~repositories in
   let new_updates =
     get_pkgs_from_repoquery cmd params
-    |> List.filter (fun x -> not (List.mem x updates))
+    |> List.filter (fun x -> not (PkgSet.mem x updates_set))
     |> List.filter (fun (pkg, _) -> not (is_obsoleted pkg.Pkg.name repositories))
   in
   new_updates @ updates

--- a/ocaml/xapi/xapi_message.ml
+++ b/ocaml/xapi/xapi_message.ml
@@ -662,8 +662,8 @@ let get_since ~__context ~since =
 let get_since_for_events ~__context since =
   let cached_result =
     with_lock in_memory_cache_mutex (fun () ->
-        match List.rev !in_memory_cache with
-        | (oldest_in_memory, _, _) :: _ when oldest_in_memory <= since ->
+        match Listext.List.last !in_memory_cache with
+        | Some (oldest_in_memory, _, _) when oldest_in_memory <= since ->
             Some
               (List.filter_map
                  (fun (gen, _ref, msg) ->
@@ -674,13 +674,13 @@ let get_since_for_events ~__context since =
                  )
                  !in_memory_cache
               )
-        | (oldest_in_memory, _, _) :: _ ->
+        | Some (oldest_in_memory, _, _) ->
             debug
               "%s: cache (%Ld) might not contain all messages since the \
                requested time (%Ld): Using slow message lookup"
               __FUNCTION__ oldest_in_memory since ;
             None
-        | _ ->
+        | None ->
             debug "%s: empty cache; Using slow message lookup" __FUNCTION__ ;
             None
     )

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -296,10 +296,9 @@ let get_intersection ~__context subject_ids_in_db subject_identifier
   let reflexive_membership_closure =
     subject_identifier :: group_membership_closure
   in
-  let intersection =
-    Listext.List.intersect reflexive_membership_closure subject_ids_in_db
-  in
-  intersection
+  let module SSet = Set.Make (String) in
+  let db_set = SSet.of_list subject_ids_in_db in
+  List.filter (fun id -> SSet.mem id db_set) reflexive_membership_closure
 
 let get_subject_in_intersection ~__context subjects_in_db intersection =
   Context.with_tracing ~__context __FUNCTION__ @@ fun __context ->
@@ -313,31 +312,21 @@ let get_subject_in_intersection ~__context subjects_in_db intersection =
 
 let get_permissions ~__context ~subject_membership =
   Context.with_tracing ~__context __FUNCTION__ @@ fun __context ->
-  (* see also rbac.ml *)
-  let get_union_of_subsets ~get_subset_fn ~set =
-    Listext.List.setify
-      (List.fold_left (* efficiently compute unions of subsets in set *)
-         (fun accu elem -> List.rev_append (get_subset_fn elem) accu)
-         [] set
-      )
-  in
   let role_membership =
-    get_union_of_subsets (*automatically removes duplicated roles*)
-      ~get_subset_fn:(fun subj -> Db.Subject.get_roles ~__context ~self:subj)
-      ~set:subject_membership
+    List.concat_map
+      (fun subj -> Db.Subject.get_roles ~__context ~self:subj)
+      subject_membership
+    |> List.sort_uniq Ref.compare
   in
-  let permission_membership =
-    get_union_of_subsets (*automatically removes duplicated perms*)
-      ~get_subset_fn:(fun role ->
-        try
-          Xapi_role.get_name_label ~__context ~self:role
-          :: Xapi_role.get_permissions_name_label ~__context ~self:role
-        with _ -> []
-        (* if the role disappeared, ignore it *)
-      )
-      ~set:role_membership
-  in
-  permission_membership
+  List.concat_map
+    (fun role ->
+      try
+        Xapi_role.get_name_label ~__context ~self:role
+        :: Xapi_role.get_permissions_name_label ~__context ~self:role
+      with _ -> []
+    )
+    role_membership
+  |> List.sort_uniq String.compare
 
 (* CP-827: finds out if the subject was suspended (ie. disabled,expired,locked-out) *)
 let is_subject_suspended ~__context ~cache subject_identifier =

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -1003,18 +1003,10 @@ let rank_hosts_by_best_vgpu ~__context vgpu visible_hosts =
 
 let host_to_vm_count_map ~__context group =
   let host_of_vm vm =
-    let vm_rec = Db.VM.get_record ~__context ~self:vm in
-    (* 1. When a VM starts migrating, it's 'scheduled_to_be_resident_on' will be set,
-          while its 'resident_on' is not cleared. In this case,
-          'scheduled_to_be_resident_on' should be treated as its running host.
-       2. For paused VM, its 'resident_on' has value, but it will not be considered
-          while computing the amount of VMs. *)
-    match
-      ( vm_rec.API.vM_scheduled_to_be_resident_on
-      , vm_rec.API.vM_resident_on
-      , vm_rec.API.vM_power_state
-      )
-    with
+    let scheduled = Db.VM.get_scheduled_to_be_resident_on ~__context ~self:vm in
+    let resident = Db.VM.get_resident_on ~__context ~self:vm in
+    let power_state = Db.VM.get_power_state ~__context ~self:vm in
+    match (scheduled, resident, power_state) with
     | sh, _, _ when sh <> Ref.null ->
         Some sh
     | _, h, `Running when h <> Ref.null ->

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -455,12 +455,9 @@ let check_operation_error ~__context ~ref =
     |> List.filter (Db.is_valid_ref __context)
   in
   let current_ops = vmr.Db_actions.vM_current_operations in
-  let metrics = Db.VM.get_metrics ~__context ~self:ref in
+  let metrics = vmr.Db_actions.vM_metrics in
   let is_nested_virt = nested_virt ~__context ref metrics in
-  let is_domain_zero =
-    Db.VM.get_by_uuid ~__context ~uuid:vmr.Db_actions.vM_uuid
-    |> Helpers.is_domain_zero ~__context
-  in
+  let is_domain_zero = Helpers.is_domain_zero ~__context ref in
   let vdis_reset_and_caching =
     List.filter_map
       (fun vdi ->

--- a/ocaml/xcp-rrdd/bin/rrdp-iostat/rrdp_iostat.ml
+++ b/ocaml/xcp-rrdd/bin/rrdp-iostat/rrdp_iostat.ml
@@ -627,11 +627,13 @@ module Stats_value = struct
     (* stats_blktap3 and stats won't both present at a time *)
     match (stats_blktap3, stats) with
     | None, Some stats ->
-        let stats_get = List.nth stats in
+        let stats = Array.of_list stats in
+        let last_stats = Option.map Array.of_list last_stats in
+        let stats_get n = stats.(n) in
         let stats_diff_get n =
           let stat = stats_get n in
           let last_stat =
-            match last_stats with None -> 0L | Some s -> List.nth s n
+            match last_stats with None -> 0L | Some s -> s.(n)
           in
           if stat >= last_stat then
             Int64.sub stat last_stat


### PR DESCRIPTION
- Replace O(n^2) list operations with Set/Hashtbl lookups in session auth and repository helpers
 - Move regex compilation out of per-line loops in network_utils and repository_helpers
 - Use array indexing instead of List.nth in rrdp_iostat
 - Avoid List.rev allocation on the event poll path in xapi_message
 - Remove redundant DB round-trips in xapi_vm_lifecycle
 - Fetch only needed fields instead of full VM record in xapi_vm_helpers

  Each commit is independent and targets a different module.