### PR TITLE
xapi-cli-server: Fix default params display for snapshots

### DIFF
--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1032,8 +1032,8 @@ let gen_cmds rpc session_id =
             "name-label"
           ; "name-description"
           ; "uuid"
-          ; "snapshot_of"
-          ; "snapshot_time"
+          ; "snapshot-of"
+          ; "snapshot-time"
           ; "is-vmss-snapshot"
           ]
           rpc session_id


### PR DESCRIPTION
`xe snapshot-list` is supposed to display `snapshot-of` and `snapshot-time` parameters, but these were mistakenly defined with underscores instead so were not shown.

Before this fix:

    $ xe snapshot-list
    uuid ( RO)                : 54861331-3033-6209-5b25-490cfa6cb9ae
              name-label ( RW): test
        name-description ( RW):
        is-vmss-snapshot ( RO): false

After:

    $ xe snapshot-list
    uuid ( RO)                : 54861331-3033-6209-5b25-490cfa6cb9ae
              name-label ( RW): test
        name-description ( RW):
             snapshot-of ( RO): 1e4ce1bc-f606-b2e0-b18b-48bdf3458bb7
           snapshot-time ( RO): 20260826T15:09:40Z
        is-vmss-snapshot ( RO): false