### PR TITLE
CP-314129: Optimise event.from with valid_ref_count cache

### DIFF
--- a/ocaml/database/db_cache_impl.ml
+++ b/ocaml/database/db_cache_impl.ml
@@ -535,16 +535,6 @@ let make t connections default_schema =
   update_database t (fun _ -> db) ;
   spawn_db_flush_threads ()
 
-(** Return an association list of table name * record count *)
-let stats t =
-  TableSet.fold
-    (fun name _ tbl acc ->
-      let size = Table.fold (fun _ _ _ acc -> acc + 1) tbl 0 in
-      (name, size) :: acc
-    )
-    (Database.tableset (get_database t))
-    []
-
 module Compat = struct
   type field_in = string
 

--- a/ocaml/database/db_cache_impl.mli
+++ b/ocaml/database/db_cache_impl.mli
@@ -10,9 +10,6 @@ val flush_and_exit : Parse_db_conf.db_connection -> int -> unit
 val sync : Parse_db_conf.db_connection list -> Db_cache_types.Database.t -> unit
 (** [sync db] forcibly flushes the database to disk *)
 
-val stats : Db_ref.t -> (string * int) list
-(** [stats t] returns some stats data for logging *)
-
 val touch_row : Db_ref.t -> string -> string -> unit
 (** [touch_row context tbl ref] bumps the generation count on [tbl], [ref] and
     generates a RefreshRow event *)

--- a/ocaml/database/db_cache_test.ml
+++ b/ocaml/database/db_cache_test.ml
@@ -83,6 +83,87 @@ let check_many_to_many () =
       ) ;
   ()
 
+(* Check that the incrementally-maintained Table.count matches the number of
+   rows obtained by folding, across inserts, updates, deletes and re-inserts.
+   This is the invariant relied upon by Event.from's valid_ref_counts. *)
+let check_row_count () =
+  let fold_count table = Table.fold (fun _ _ _ n -> n + 1) table 0 in
+  let assert_counts db label =
+    TableSet.iter
+      (fun tblname table ->
+        let counted = Table.count table in
+        let folded = fold_count table in
+        if counted <> folded then
+          failwith
+            (Printf.sprintf
+               "check_row_count (%s): table %s Table.count=%d but fold=%d" label
+               tblname counted folded
+            )
+      )
+      (Database.tableset db)
+  in
+  let mk_bar r =
+    Row.add 0L Db_names.ref (Schema.Value.string r)
+      (Row.add 0L "foos" (Schema.Value.Set []) Row.empty)
+  in
+  let db = create_test_db () in
+  assert_counts db "empty" ;
+  (* insert two rows *)
+  let db = add_row "bar" "bar:1" (mk_bar "bar:1") db in
+  let db = add_row "bar" "bar:2" (mk_bar "bar:2") db in
+  assert_counts db "after-insert" ;
+  ( match Table.count (TableSet.find "bar" (Database.tableset db)) with
+  | 2 ->
+      ()
+  | n ->
+      failwith (Printf.sprintf "check_row_count: expected 2 bars, got %d" n)
+  ) ;
+  (* update an existing row: count must not change *)
+  let db = set_field "bar" "bar:1" "foos" (Schema.Value.set ["foo:1"]) db in
+  assert_counts db "after-update" ;
+  (* delete a row *)
+  let db = remove_row "bar" "bar:2" db in
+  assert_counts db "after-delete" ;
+  ( match Table.count (TableSet.find "bar" (Database.tableset db)) with
+  | 1 ->
+      ()
+  | n ->
+      failwith (Printf.sprintf "check_row_count: expected 1 bar, got %d" n)
+  ) ;
+  (* re-insert a previously-deleted ref *)
+  let db = add_row "bar" "bar:2" (mk_bar "bar:2") db in
+  assert_counts db "after-reinsert" ;
+  ( match Table.count (TableSet.find "bar" (Database.tableset db)) with
+  | 2 ->
+      ()
+  | n ->
+      failwith (Printf.sprintf "check_row_count: expected 2 bars, got %d" n)
+  ) ;
+  let bar_table = TableSet.find "bar" (Database.tableset db) in
+  let before = Table.count bar_table in
+  ( match Table.remove 0L "bar:does-not-exist" bar_table with
+  | exception Not_found ->
+      ()
+  | after_table ->
+      let counted = Table.count after_table in
+      let folded = fold_count after_table in
+      if counted <> folded || counted <> before then
+        failwith
+          (Printf.sprintf
+             "check_row_count: spurious remove drifted count: before=%d \
+              count=%d fold=%d"
+             before counted folded
+          )
+  ) ;
+  ()
+
 let () =
   Alcotest.run "Database cache"
-    [("db_cache", [("many_to_many", `Quick, check_many_to_many)])]
+    [
+      ( "db_cache"
+      , [
+          ("many_to_many", `Quick, check_many_to_many)
+        ; ("row_count", `Quick, check_row_count)
+        ]
+      )
+    ]

--- a/ocaml/database/db_cache_types.ml
+++ b/ocaml/database/db_cache_types.ml
@@ -219,14 +219,29 @@ module Table = struct
       rows: StringRowMap.map_t
     ; deleted_len: int
     ; deleted: (Time.t * Time.t * string) list
+    ; count: int  (** number of live rows, maintained incrementally *)
   }
 
   type value = Row.t
 
-  let add g key value t = {t with rows= StringRowMap.add g key value t.rows}
+  let add g key value t =
+    let count =
+      if StringRowMap.mem key t.rows then
+        t.count
+      else
+        t.count + 1
+    in
+    {t with rows= StringRowMap.add g key value t.rows; count}
 
   let empty =
-    {rows= StringRowMap.empty; deleted_len= 1; deleted= [(0L, 0L, "")]}
+    {
+      rows= StringRowMap.empty
+    ; deleted_len= 1
+    ; deleted= [(0L, 0L, "")]
+    ; count= 0
+    }
+
+  let count t = t.count
 
   let fold f t acc = StringRowMap.fold f t.rows acc
 
@@ -255,13 +270,26 @@ module Table = struct
       rows= StringRowMap.remove g key t.rows
     ; deleted_len= new_len
     ; deleted= new_deleted
+    ; count= t.count - 1
     }
 
   let touch g key default t =
-    {t with rows= StringRowMap.touch g key default t.rows}
+    let count =
+      if StringRowMap.mem key t.rows then
+        t.count
+      else
+        t.count + 1
+    in
+    {t with rows= StringRowMap.touch g key default t.rows; count}
 
   let update g key default f t =
-    {t with rows= StringRowMap.update g key default f t.rows}
+    let count =
+      if StringRowMap.mem key t.rows then
+        t.count
+      else
+        t.count + 1
+    in
+    {t with rows= StringRowMap.update g key default f t.rows; count}
 
   let fold_over_recent since f t acc =
     StringRowMap.fold_over_recent since f t.rows acc

--- a/ocaml/database/db_cache_types.mli
+++ b/ocaml/database/db_cache_types.mli
@@ -120,6 +120,10 @@ end
 module Table : sig
   include MAP with type value = Row.t
 
+  val count : t -> int
+  (** [count t] is the number of live rows in [t], maintained incrementally
+      by the insert/remove operations (O(1)). *)
+
   val fold_over_deleted :
     Time.t -> (string -> Stat.t -> 'b -> 'b) -> t -> 'b -> 'b
   (** [fold_over_deleted now f t initial] folds [f key stat acc] over the keys

--- a/ocaml/xapi/xapi_event.ml
+++ b/ocaml/xapi/xapi_event.ml
@@ -725,7 +725,7 @@ let from_inner __context session subs from from_t timer batching =
     Db_cache_types.TableSet.fold
       (fun tablename _ table acc ->
         ( String.lowercase_ascii tablename
-        , Db_cache_types.Table.fold (fun _ _ _ acc -> Int32.add 1l acc) table 0l
+        , Int32.of_int (Db_cache_types.Table.count table)
         )
         :: acc
       )


### PR DESCRIPTION
Currently, event.from determines the valid ref count with a fold over all database entries on every call. This commit optimises this by keeping a ref counter which updates on all db actions.