### PR TITLE
CP-314124: gc_VDIs linear scan and Event.from invariant rebuild

### DIFF
--- a/ocaml/tests/bench/bench_event_tables.ml
+++ b/ocaml/tests/bench/bench_event_tables.ml
@@ -1,0 +1,31 @@
+open Bechamel
+
+let event_tables_inline () =
+  let objs =
+    List.filter
+      (fun x -> x.Datamodel_types.gen_events)
+      (Dm_api.objects_of_api Datamodel.all_api)
+  in
+  let (_ : string list) =
+    Sys.opaque_identity (List.map (fun x -> x.Datamodel_types.name) objs)
+  in
+  ()
+
+let all_event_tables =
+  Dm_api.objects_of_api Datamodel.all_api
+  |> List.filter (fun x -> x.Datamodel_types.gen_events)
+  |> List.map (fun x -> x.Datamodel_types.name)
+
+let event_tables_hoisted () =
+  let (_ : string list) = Sys.opaque_identity all_event_tables in
+  ()
+
+let benchmarks =
+  [
+    Test.make ~name:"Event.from tables: inline (before)"
+      (Staged.stage event_tables_inline)
+  ; Test.make ~name:"Event.from tables: hoisted (after)"
+      (Staged.stage event_tables_hoisted)
+  ]
+
+let () = Bechamel_simple_cli.cli benchmarks

--- a/ocaml/tests/bench/bench_gc_vdis.ml
+++ b/ocaml/tests/bench/bench_gc_vdis.ml
@@ -1,0 +1,52 @@
+open Bechamel
+
+let num_srs = 100
+
+let num_vdis = 5000
+
+let () =
+  Suite_init.harness_init () ;
+  Debug.set_level Syslog.Info
+
+let allocate () =
+  let __context = Test_common.make_test_database () in
+  let (_ : API.ref_SM) = Test_common.make_sm ~__context () in
+  let srs = Array.init num_srs (fun _ -> Test_common.make_sr ~__context ()) in
+  let _vdis =
+    Array.init num_vdis (fun i ->
+        let sr = srs.(i mod num_srs) in
+        Test_common.make_vdi ~__context ~sR:sr ()
+    )
+  in
+  __context
+
+let gc_vdis_list_mem __context =
+  let all_srs = Db.SR.get_all ~__context in
+  List.iter
+    (fun vdi ->
+      let sr = Db.VDI.get_SR ~__context ~self:vdi in
+      let (_ : bool) = Sys.opaque_identity (List.mem sr all_srs) in
+      ()
+    )
+    (Db.VDI.get_all ~__context)
+
+let gc_vdis_valid_ref __context =
+  List.iter
+    (fun vdi ->
+      let sr = Db.VDI.get_SR ~__context ~self:vdi in
+      let (_ : bool) = Sys.opaque_identity (Db.is_valid_ref __context sr) in
+      ()
+    )
+    (Db.VDI.get_all ~__context)
+
+let benchmarks =
+  [
+    Test.make_with_resource ~name:"gc_VDIs: List.mem (before)" ~allocate
+      ~free:ignore Test.uniq
+      (Staged.stage gc_vdis_list_mem)
+  ; Test.make_with_resource ~name:"gc_VDIs: valid_ref (after)" ~allocate
+      ~free:ignore Test.uniq
+      (Staged.stage gc_vdis_valid_ref)
+  ]
+
+let () = Bechamel_simple_cli.cli benchmarks

--- a/ocaml/tests/bench/dune
+++ b/ocaml/tests/bench/dune
@@ -7,7 +7,9 @@
   bench_cached_reads
   bench_vdi_allowed_operations
   bench_backtrace
-  bench_pool_field)
+  bench_pool_field
+  bench_gc_vdis
+  bench_event_tables)
  (libraries
   dune-build-info
   tracing

--- a/ocaml/xapi/db_gc_util.ml
+++ b/ocaml/xapi/db_gc_util.ml
@@ -68,11 +68,10 @@ let gc_connector ~__context get_all valid_ref1 valid_ref2 delete_record =
 
 (* If the SR record is missing, delete the VDI record *)
 let gc_VDIs ~__context =
-  let all_srs = Db.SR.get_all ~__context in
   List.iter
     (fun vdi ->
       let sr = Db.VDI.get_SR ~__context ~self:vdi in
-      if not (List.mem sr all_srs) then (
+      if not (valid_ref __context sr) then (
         debug "GCed VDI %s" (Ref.string_of vdi) ;
         Db.VDI.destroy ~__context ~self:vdi
       )

--- a/ocaml/xapi/xapi_event.ml
+++ b/ocaml/xapi/xapi_event.ml
@@ -588,21 +588,18 @@ let collect_events (subs, tables, last_generation) acc table =
   |> Table.fold_over_recent last_generation prepend_recent table_value
   |> Table.fold_over_deleted last_generation prepend_deleted table_value
 
+let all_event_tables =
+  Dm_api.objects_of_api Datamodel.all_api
+  |> List.filter (fun x -> x.Datamodel_types.gen_events)
+  |> List.map (fun x -> x.Datamodel_types.name)
+
 let from_inner __context session subs from from_t timer batching =
   let open Xapi_database in
   let open From in
-  (* The database tables involved in our subscription *)
   let tables =
-    let all =
-      let objs =
-        List.filter
-          (fun x -> x.Datamodel_types.gen_events)
-          (Dm_api.objects_of_api Datamodel.all_api)
-      in
-      let objs = List.map (fun x -> x.Datamodel_types.name) objs in
-      objs
-    in
-    List.filter (fun table -> Subscription.table_matches subs table) all
+    List.filter
+      (fun table -> Subscription.table_matches subs table)
+      all_event_tables
   in
   let last_msg_gen = ref from_t in
   let grab_range ~since t =


### PR DESCRIPTION
- **gc_VDIs**: Replace O(n) `List.mem` scan against all SR refs with the
    O(1) `Db.is_valid_ref` check that every other `gc_*` function in the
    module already uses. This runs every 30s under the global DB lock.
 - **Event.from**: Move the static datamodel table list (which tables
    generate events) from per-poll recomputation inside `from_inner` to a
    module-level binding, matching the existing `generate_events_for`
    pattern.
 - Add Bechamel microbenchmarks for both changes.
 
 | Benchmark | Before | After | Speedup |
  |---|---|---|---|
  | gc_VDIs (100 SRs, 5000 VDIs) | 5.99 ms | 2.75 ms | 2.2x |
  | Event.from table list | 348 ns | 1.3 ns | ~260x |