### PR TITLE
[backport] Switch hvm-pirq default back to true

### DIFF
--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -146,7 +146,7 @@ module VmExtra = struct
       | HVM _ ->
           if
             Platform.is_true ~key:"hvm-pirq"
-              ~platformdata:vm.Xenops_interface.Vm.platformdata ~default:false
+              ~platformdata:vm.Xenops_interface.Vm.platformdata ~default:true
           then
             X86_EMU_USE_PIRQ :: emulation_flags_hvm
           else


### PR DESCRIPTION
hvm-pirq is required for vGPU to function correctly. As a result, we cannot yet disable it on new boots by default.

Instead, set the default value to true if the setting is absent.

(cherry picked from commit b5d80a154c42fe3bd98476c5a35a1637439345ef)

Backport of https://github.com/xapi-project/xen-api/pull/7250.

This has already been tested in https://github.com/xapi-project/xen-api/pull/7235, but the behavior was later changed in order to disable hvm-pirq on new boots instead.