### PR TITLE
python3/usb_scan: Read policy rules from drop-in directory

### DIFF
--- a/python3/libexec/usb_scan.py
+++ b/python3/libexec/usb_scan.py
@@ -26,8 +26,10 @@
 
 import abc
 import argparse
+import glob
 import json
 import logging
+import os
 import re
 import sys
 
@@ -341,6 +343,7 @@ class Policy:
     """
 
     _PATH = "/etc/xensource/usb-policy.conf"
+    _DROPIN_DIR = "/etc/xensource/usb-policy.conf.d"
 
     _CLASS = "class"
     _SUBCLASS = "subclass"
@@ -376,20 +379,30 @@ class Policy:
         Note: hubs are never allowed to pass through
         """
         self.rule_list = []
-        try:
-            with open(self._PATH, encoding="utf-8", errors="backslashreplace") as f:
-                log.debug("=== policy file begin")
-                for line in f:
-                    log.debug(line[0:-1])
-                    self.parse_line(line)
-                log.debug("=== policy file end")
-        except OSError as e:
-            # without policy file, no device will be allowed to passed through
-            log_exit("Caught error {}, policy file error".format(str(e)))
+
+        # drop-in files are optionals and read first, so a rule in one of them
+        # can override a rule in the main file below.
+        if os.path.isdir(self._DROPIN_DIR):
+            for path in sorted(glob.glob(os.path.join(self._DROPIN_DIR, "*.conf"))):
+                self._parse_file(path)
+
+        self._parse_file(self._PATH)
 
         log.debug("=== rule list begin")
         log_list(self.rule_list)
         log.debug("=== rule list end")
+
+    def _parse_file(self, path):
+        try:
+            with open(path, encoding="utf-8", errors="backslashreplace") as f:
+                log.debug("=== policy file begin: " + path)
+                for line in f:
+                    log.debug(line[0:-1])
+                    self.parse_line(line)
+                log.debug("=== policy file end: " + path)
+        except OSError as e:
+            # without policy file, no device will be allowed to passed through
+            log_exit("Caught error {}, policy file error".format(str(e)))
 
     def check_hex_length(self, name, value):
         if name in [self._CLASS, self._SUBCLASS, self._PROTOCOL]:

--- a/python3/tests/test_usb_scan.py
+++ b/python3/tests/test_usb_scan.py
@@ -86,10 +86,13 @@ class MocContext():
         raise AssertionError(f"unexpected {dev_type}")  # pragma: no cover
 
 
-def mock_setup(mod, devices, interfaces, path):
+def mock_setup(mod, devices, interfaces, path, dropin_dir):
     mod.log.error = verify_log
     mod.log.debug = verify_log
     mod.Policy._PATH = path
+    # point at a path that don't exist by default, so tests that don't care
+    # about drop-in files keep today's behaviour.
+    mod.Policy._DROPIN_DIR = dropin_dir or "/nonexistent/usb-policy.conf.d"
     mod.pyudev.Context = MagicMock(
             return_value=MocContext(devices, interfaces))
 
@@ -110,10 +113,11 @@ class TestUsbScan(unittest.TestCase):
         moc_interfaces,
         moc_results,
         # Use relative path to allow tests to be started in subdirectories
-        path = os.path.dirname(__file__) + "/../../scripts/usb-policy.conf"
+        path = os.path.dirname(__file__) + "/../../scripts/usb-policy.conf",
+        dropin_dir=None,
     ):
 
-        mock_setup(usb_scan, moc_devices, moc_interfaces, path)
+        mock_setup(usb_scan, moc_devices, moc_interfaces, path, dropin_dir)
 
         devices, interfaces = usb_scan.get_usb_info()
 
@@ -137,6 +141,110 @@ class TestUsbScan(unittest.TestCase):
             # looks like "duplicated tag'vid' found,
             # malformed line ALLOW:vid=056a vid=0314 class=03"
             self.assertIn(msg, cast(str, cm.exception.code))  # code is a str
+
+    def _hid_keyboard_device(self, vid=b"413c", pid=b"2113"):
+        devices = [
+            {
+                "name": "1-2",
+                "props": {"ID_VENDOR_FROM_DATABASE": "Generic Vendor Inc."},
+                "attrs": {
+                    "idVendor": vid,
+                    "bNumInterfaces": b" 1",
+                    "bConfigurationValue": b"1",
+                    "bcdDevice": b"0110",
+                    "version": b" 2.00",
+                    "idProduct": pid,
+                    "bDeviceClass": b"00",
+                    "speed": b"480",
+                },
+            }
+        ]
+        interfaces = [
+            {
+                "name": "1-2:1.0",
+                "attrs": {
+                    "bInterfaceClass": b"03",
+                    "bInterfaceSubClass": b"01",
+                    "bInterfaceProtocol": b"01",
+                    "bInterfaceNumber": b"00",
+                },
+            }
+        ]
+        return devices, interfaces
+
+    def test_usb_dropin_overrides_main_file(self):
+        # The main policy file denies HID boot keyboards; a drop-in rule for this
+        # exact vendor/product must override that
+        devices, interfaces = self._hid_keyboard_device()
+
+        dropin_dir = os.path.join(self.work_dir, "usb-policy.conf.d")
+        os.mkdir(dropin_dir)
+        with open(os.path.join(dropin_dir, "10-custom.conf"), "w", encoding="utf-8") as f:
+            f.write("ALLOW: vid=413c pid=2113 # allow this keyboard\n")
+
+        results = [
+            {
+                "product-desc": "",
+                "product-id": "2113",
+                "description": "Generic Vendor Inc.",
+                "vendor-desc": "Generic Vendor Inc.",
+                "version": "2.00",
+                "vendor-id": "413c",
+                "path": "1-2",
+                "serial": "",
+                "speed": "480",
+            }
+        ]
+
+        self.verify_usb_common(devices, interfaces, results, dropin_dir=dropin_dir)
+
+    def test_usb_dropin_files_read_in_alphabetical_order(self):
+        # two drop-in files disagree on the same device, the one that sorts first
+        # must win
+        devices, interfaces = self._hid_keyboard_device()
+
+        dropin_dir = os.path.join(self.work_dir, "usb-policy.conf.d")
+        os.mkdir(dropin_dir)
+
+        with open(os.path.join(dropin_dir, "10-allow.conf"), "w", encoding="utf-8") as f:
+            f.write("ALLOW: vid=413c pid=2113 # allow this keyboard\n")
+        with open(os.path.join(dropin_dir, "20-deny.conf"), "w", encoding="utf-8") as f:
+            f.write("DENY: vid=413c pid=2113 # deny this keyboard\n")
+
+        results = [
+            {
+                "product-desc": "",
+                "product-id": "2113",
+                "description": "Generic Vendor Inc.",
+                "vendor-desc": "Generic Vendor Inc.",
+                "version": "2.00",
+                "vendor-id": "413c",
+                "path": "1-2",
+                "serial": "",
+                "speed": "480",
+            }
+        ]
+
+        self.verify_usb_common(devices, interfaces, results, dropin_dir=dropin_dir)
+
+    def test_usb_dropin_files_read_in_alphabetical_order_flipped(self):
+        # This time we set DENY with higher priority
+        devices, interfaces = self._hid_keyboard_device()
+
+        dropin_dir = os.path.join(self.work_dir, "usb-policy.conf.d")
+        os.mkdir(dropin_dir)
+
+        with open(os.path.join(dropin_dir, "30-allow.conf"), "w", encoding="utf-8") as f:
+            f.write("ALLOW: vid=413c pid=2113 # allow this keyboard\n")
+        with open(os.path.join(dropin_dir, "20-deny.conf"), "w", encoding="utf-8") as f:
+            f.write("DENY: vid=413c pid=2113 # deny this keyboard\n")
+
+        self.verify_usb_common(devices, interfaces, [], dropin_dir=dropin_dir)
+
+    def test_usb_dropin_dir_missing_is_not_error(self):
+        # no drop-in directory at all: behavior must be unchanged
+        devices, interfaces = self._hid_keyboard_device()
+        self.verify_usb_common(devices, interfaces, [])
 
     def test_usb_dongle(self):
         devices = [
@@ -248,7 +356,7 @@ class TestUsbScan(unittest.TestCase):
         devices = [
             {
                 "name": "1-2",
-                "props": {"ID_VENDOR_FROM_DATABASE": "Dell Computer Corp."},
+                "props": {"ID_VENDOR_FROM_DATABASE": "Generic Vendor Inc."},
                 "attrs": {
                     "idVendor": b"413c",
                     "bNumInterfaces": b" 2",

--- a/scripts/usb-policy.conf
+++ b/scripts/usb-policy.conf
@@ -1,3 +1,8 @@
+# WARNING: any changes made to this file may be overwritten by future
+# updates of the xapi-core RPM.
+# You may want to create a file in the /etc/xensource/usb-policy.conf.d/
+# directory instead.
+#
 # When you change this file, run 'xe pusb-scan' to confirm
 # the file can be parsed correctly.
 # You can also run '/opt/xensource/libexec/usb_scan.py -d' to see


### PR DESCRIPTION
/etc/xensource/usb-policy.conf is owned by the RPM manager. A customer who edits it to allow/deny some USB devices loses their changes on the next RPM uprade.

usb_scan.py now also reads any *.conf files found in /etc/xensource/usb-policy.conf.d, in alphabetical order before it reads the main policy file. Since the first match wins the user rule always override the main file rule. If the drop-in dir doesn't exist, behaviour is unchanged.

Tracking-reference: XCPNG-2952