### PR TITLE
feature/lldp fix: CA-431204, CA-431221, CA-431224, CA-431350

### DIFF
--- a/doc/content/design/lldp.md
+++ b/doc/content/design/lldp.md
@@ -106,7 +106,7 @@ Behavior:
 
 - if `force=false` and `value = pool.lldp_enabled`, do nothing;
 - otherwise, set `pool.lldp_enabled` to `value`, apply LLDP configuration to every physical PIF in the pool by calling `PIF.plug` to each host;
-- return a map of failed PIFs and error strings.
+- every affected PIF is attempted; if any fail to re-plug, raise `LLDP_PIF_REPLUG_FAILED` with the list of PIFs that failed (so the caller learns which PIFs did not get the new setting).
 
 ### `PIF.set_lldp_mode`
 
@@ -119,7 +119,8 @@ Parameters:
 Behavior:
 
 - if `force=false` and `value= PIF.lldp_mode`, do nothing;
-- otherwise set `PIF.lldp_mode` to `value`, apply LLDP configuration to the physical NIC represented by the PIF by calling `PIF.plug` to the host.
+- otherwise set `PIF.lldp_mode` to `value`, apply LLDP configuration to the physical NIC represented by the PIF by calling `PIF.plug` to the host;
+- if the re-plug fails, raise `LLDP_PIF_REPLUG_FAILED` for the PIF.
 
 
 ## The networkd database

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1580,6 +1580,9 @@ let _ =
       "The IGMP Snooping setting cannot be applied for some of the host, \
        network(s)."
     () ;
+  error Api_errors.lldp_pif_replug_failed ["PIFs"]
+    ~doc:"Failed to re-plug one or more PIFs while applying the LLDP setting."
+    () ;
   error Api_errors.update_apply_failed ["output"]
     ~doc:"The update failed to apply. Please see attached output." () ;
   error Api_errors.update_already_applied ["update"]

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1206,11 +1206,6 @@ let set_lldp_enabled =
            value differs from pool.lldp_enabled."
         )
       ]
-    ~result:
-      ( Map (Ref _pif, String)
-      , "A map of the PIFs that failed to be reconfigured and the \
-         corresponding error message."
-      )
     ~allowed_roles:_R_POOL_OP ()
 
 let has_extension =

--- a/ocaml/networkd/lib/dune
+++ b/ocaml/networkd/lib/dune
@@ -16,6 +16,7 @@
   threads.posix
   unix
   uri
+  uutf
   xapi-stdext-pervasives
   xapi-stdext-std
   xapi-stdext-threads

--- a/ocaml/networkd/lib/lldp.ml
+++ b/ocaml/networkd/lib/lldp.ml
@@ -56,7 +56,7 @@ module Lldp_types = struct
 end
 
 module Lldp_parse = struct
-  let ( let* ) = Option.bind
+  let ( >>= ) = Option.bind
 
   (* Follow [keys] through a json0 doc. Object keys are consumed one at a time;
      arrays are transparently entered at their head without consuming a key
@@ -69,8 +69,7 @@ module Lldp_parse = struct
     | k :: ks as keys -> (
       match json0 with
       | `Assoc l ->
-          let* json' = List.assoc_opt k l in
-          json0_get json' ks
+          List.assoc_opt k l >>= Fun.flip json0_get ks
       | `List (json' :: _) ->
           json0_get json' keys
       | _ ->
@@ -79,6 +78,50 @@ module Lldp_parse = struct
 
   let json0_get_str json0 keys =
     match json0_get json0 keys with Some (`String s) -> Some s | _ -> None
+
+  let max_value_bytes = 256
+
+  (* control characters: C0 (<= U+001F), DEL and C1 (U+007F-009F). *)
+  let is_control u =
+    let c = Uchar.to_int u in
+    c <= 0x1f || (c >= 0x7f && c <= 0x9f)
+
+  (* U+FFFE and U+FFFF are valid UTF-8 but lie outside XML 1.0's Char
+     production, so xmlm can write them to the XML-backed database yet fails to
+     read them back. Drop them so a neighbour value cannot poison state.db. *)
+  let is_xml_illegal u =
+    let c = Uchar.to_int u in
+    c = 0xfffe || c = 0xffff
+
+  (* Sanitise a single LLDP tlv value.
+     - verify UTF-8 encoding: any malformed sequence discards the whole value;
+     - remove control characters and XML-illegal noncharacters;
+     - truncate to [max_value_bytes], stopping on a UTF-8 codepoint boundary so
+       the result stays valid UTF-8. *)
+  let sanitise s =
+    let buf = Buffer.create (min (String.length s) max_value_bytes) in
+    let exception Malformed in
+    let exception Full in
+    let add () _pos = function
+      | `Malformed _ ->
+          raise Malformed
+      | `Uchar u when is_control u || is_xml_illegal u ->
+          ()
+      | `Uchar u ->
+          let before = Buffer.length buf in
+          Buffer.add_utf_8_uchar buf u ;
+          if Buffer.length buf > max_value_bytes then (
+            (* This codepoint overflows the cap: drop it and stop, leaving a
+               whole-codepoint prefix. *)
+            Buffer.truncate buf before ;
+            raise Full
+          )
+    in
+    match Uutf.String.fold_utf_8 add () s with
+    | () | (exception Full) ->
+        Some (Buffer.contents buf)
+    | exception Malformed ->
+        None
 
   let interfaces (output : string) : Yojson.Safe.t list =
     match Yojson.Safe.from_string output with
@@ -98,10 +141,16 @@ module Lldp_parse = struct
       (string * Network_stats.lldp_neighbor) list =
     interfaces output
     |> List.filter_map (fun iface ->
-        let* dev = json0_get_str iface ["name"] in
-        let system_name = json0_get_str iface ["chassis"; "name"; "value"] in
-        let port_id = json0_get_str iface ["port"; "id"; "value"] in
-        let port_description = json0_get_str iface ["port"; "descr"; "value"] in
+        json0_get_str iface ["name"] >>= fun dev ->
+        let system_name =
+          json0_get_str iface ["chassis"; "name"; "value"] >>= sanitise
+        in
+        let port_id =
+          json0_get_str iface ["port"; "id"; "value"] >>= sanitise
+        in
+        let port_description =
+          json0_get_str iface ["port"; "descr"; "value"] >>= sanitise
+        in
         Some (dev, Network_stats.{system_name; port_id; port_description})
     )
 

--- a/ocaml/networkd/lib/lldp.ml
+++ b/ocaml/networkd/lib/lldp.ml
@@ -21,13 +21,18 @@ let string_of_addresses addresses =
   addresses |> List.map Unix.string_of_inet_addr |> String.concat ","
 
 module Lldp_types = struct
-  type error = Command_failed of string * string | Internal of string
+  type error =
+    | Command_failed of string * string
+    | Internal of string
+    | Service_not_running
 
   let string_of_error = function
     | Command_failed (cmd, msg) ->
         Printf.sprintf "command %S failed: %s" cmd msg
     | Internal msg ->
         Printf.sprintf "Internal error: %s" msg
+    | Service_not_running ->
+        "Service not running"
 
   type chassis_id = Local of string
 
@@ -191,6 +196,18 @@ module Lldpd : AGENT = struct
 
   let conf_path = Filename.concat conf_dir "00-networkd-default.conf"
 
+  let result_ignore = Result.map ignore
+
+  let service_running =
+    Atomic.make (try Fe_systemctl.is_active ~service with _ -> false)
+
+  let mark_service_running v f =
+    f ()
+    |> Result.map (fun x ->
+        Atomic.set service_running v ;
+        x
+    )
+
   let default_conf =
     String.concat "\n"
       [
@@ -200,19 +217,23 @@ module Lldpd : AGENT = struct
       ; ""
       ]
 
-  let run cmd args =
+  let run cmd ?(log = true) args =
     let cmdline = String.concat " " (cmd :: args) in
-    try
-      ignore (Network_utils.call_script ~log:true cmd args) ;
-      Ok ()
+    try Ok (Network_utils.call_script ~log cmd args)
     with e ->
       let err_msg = Printexc.to_string e in
       error "%s: %S failed: %s" __FUNCTION__ cmdline err_msg ;
       Error (Command_failed (cmdline, err_msg))
 
-  let call_cli args = run cli args
+  let call_cli ?(log = true) args =
+    if Atomic.get service_running then
+      run cli ~log args
+    else
+      Error Service_not_running
 
-  let call_systemctl args = run systemctl args
+  let call_cli_ignore ?(log = true) args = call_cli ~log args |> result_ignore
+
+  let call_systemctl args = run systemctl args |> result_ignore
 
   let advertising_confs dev (config : I.lldp) : conf list =
     [
@@ -228,6 +249,7 @@ module Lldpd : AGENT = struct
 
   let start () =
     try
+      mark_service_running true @@ fun () ->
       Xapi_stdext_unix.Unixext.write_string_to_file conf_path default_conf ;
       if Fe_systemctl.is_active ~service then
         Ok ()
@@ -237,6 +259,7 @@ module Lldpd : AGENT = struct
 
   let stop () =
     try
+      mark_service_running false @@ fun () ->
       if Fe_systemctl.is_active ~service then
         call_systemctl ["stop"; service]
       else
@@ -244,27 +267,23 @@ module Lldpd : AGENT = struct
     with e -> Error (Internal (Printexc.to_string e))
 
   let enable dev =
-    call_cli ["configure"; "ports"; dev; "lldp"; "status"; "rx-and-tx"]
+    call_cli_ignore ["configure"; "ports"; dev; "lldp"; "status"; "rx-and-tx"]
 
   let disable dev =
-    call_cli ["configure"; "ports"; dev; "lldp"; "status"; "disabled"]
+    call_cli_ignore ["configure"; "ports"; dev; "lldp"; "status"; "disabled"]
 
   let get_neighbors () =
-    match Network_utils.call_script ~log:false cli show_neighbors_args with
-    | output ->
+    match call_cli ~log:false show_neighbors_args with
+    | Ok output ->
         Lldp_parse.parse_neighbors output
-    | exception e ->
-        debug "%s: could not query LLDP neighbours: %s" __FUNCTION__
-          (Printexc.to_string e) ;
+    | Error _ ->
         []
 
   let get_enabled_interfaces () =
-    match Network_utils.call_script ~log:false cli show_interfaces_args with
-    | output ->
+    match call_cli ~log:false show_interfaces_args with
+    | Ok output ->
         Lldp_parse.parse_enabled_interfaces output
-    | exception e ->
-        debug "%s: could not query LLDP interfaces: %s" __FUNCTION__
-          (Printexc.to_string e) ;
+    | Error _ ->
         []
 
   let string_of_multicast_address = function
@@ -278,7 +297,7 @@ module Lldpd : AGENT = struct
   let set_advertising_conf' conf =
     match conf with
     | Chassis_id (Local chassis_id) ->
-        call_cli ["configure"; "system"; "chassisid"; chassis_id]
+        call_cli_ignore ["configure"; "system"; "chassisid"; chassis_id]
     | Port_id (_dev, Default) ->
         (* MAC address *)
         Ok ()
@@ -286,9 +305,9 @@ module Lldpd : AGENT = struct
         (* Interface name *)
         Ok ()
     | System_name sys_name ->
-        call_cli ["configure"; "system"; "hostname"; sys_name]
+        call_cli_ignore ["configure"; "system"; "hostname"; sys_name]
     | System_description sys_desc ->
-        call_cli ["configure"; "system"; "description"; sys_desc]
+        call_cli_ignore ["configure"; "system"; "description"; sys_desc]
     | System_capability _ ->
         (* In default conf *)
         Ok ()
@@ -303,12 +322,12 @@ module Lldpd : AGENT = struct
             )
           |> string_of_multicast_address
         in
-        call_cli ["configure"; "lldp"; "agent-type"; addr_str]
+        call_cli_ignore ["configure"; "lldp"; "agent-type"; addr_str]
     | Management_address addrs ->
         let addrs_str =
           match addrs with [] -> {|""|} | _ :: _ -> string_of_addresses addrs
         in
-        call_cli
+        call_cli_ignore
           ["configure"; "system"; "ip"; "management"; "pattern"; addrs_str]
 
   module Cache = struct

--- a/ocaml/networkd/lib/lldp.ml
+++ b/ocaml/networkd/lib/lldp.ml
@@ -145,9 +145,16 @@ let management_ip_address =
     match (force, Atomic.get cache) with
     | true, seen | false, ([] as seen) -> (
         let addrs =
-          let iface = Inventory.lookup Inventory._management_interface in
-          let open Network_utils in
-          Ip.get_ipv4 iface @ Ip.get_ipv6 iface |> List.map fst
+          Inventory.reread_inventory () ;
+          match Inventory.lookup Inventory._management_interface with
+          | "" ->
+              (* Management is disabled: there is no interface to read from.
+                 [Ip.get_ipv4 ""] would raise; an empty list maps to an empty
+                 advertising pattern, matching the disabled state. *)
+              []
+          | iface ->
+              let open Network_utils in
+              Ip.get_ipv4 iface @ Ip.get_ipv6 iface |> List.map fst
         in
         match Atomic.compare_and_set cache seen addrs with
         | true ->

--- a/ocaml/networkd/test/test_lldp.ml
+++ b/ocaml/networkd/test/test_lldp.ml
@@ -92,6 +92,93 @@ let test_malformed () =
   Alcotest.check result_testable "malformed JSON yields empty" []
     (Lldp.parse_neighbors "not json {")
 
+(* Each LLDP value is sanitised before being surfaced -- UTF-8 verified
+   (malformed -> dropped), control characters removed, and truncated to 256
+   bytes on a UTF-8 codepoint boundary. *)
+let neighbour_json sys pid descr =
+  Printf.sprintf
+    {|{ "lldp": [ { "interface": [
+      { "name": "eno0",
+        "chassis": [ { "name": [ { "value": "%s" } ] } ],
+        "port": [ { "id": [ { "value": "%s" } ],
+                   "descr": [ { "value": "%s" } ] } ] }
+    ] } ] }|}
+    sys pid descr
+
+let parse_one json : Network_stats.lldp_neighbor =
+  match Lldp.parse_neighbors json with
+  | [(_, n)] ->
+      n
+  | _ ->
+      Alcotest.fail "expected exactly one neighbour"
+
+let a n = String.make n 'A'
+
+let test_cap_over_length () =
+  let n = parse_one (neighbour_json (a 300) (a 257) (a 255)) in
+  Alcotest.(check (option string))
+    "system_name 300B capped to 256"
+    (Some (a 256))
+    n.system_name ;
+  Alcotest.(check (option string))
+    "port_id 257B capped to 256"
+    (Some (a 256))
+    n.port_id ;
+  Alcotest.(check (option string))
+    "port_description 255B unchanged"
+    (Some (a 255))
+    n.port_description
+
+let test_cap_exact_256 () =
+  let n = parse_one (neighbour_json (a 256) (a 256) (a 256)) in
+  Alcotest.(check (option string))
+    "exactly 256B unchanged"
+    (Some (a 256))
+    n.system_name
+
+let test_cap_utf8_no_split () =
+  (* 255 ASCII bytes + one 2-byte codepoint = 257 bytes: capping at 256 must
+     drop the whole codepoint, not split it, leaving 255 valid bytes. *)
+  let n = parse_one (neighbour_json (a 255 ^ "\xc3\xa9") "p" "d") in
+  Alcotest.(check (option string))
+    "codepoint not split at boundary"
+    (Some (a 255))
+    n.system_name
+
+let test_cap_utf8_fits () =
+  (* 254 ASCII bytes + one 2-byte codepoint = 256 bytes: fits exactly. *)
+  let v = a 254 ^ "\xc3\xa9" in
+  let n = parse_one (neighbour_json v "p" "d") in
+  Alcotest.(check (option string))
+    "256B multibyte value unchanged" (Some v) n.system_name
+
+let test_reject_invalid_utf8 () =
+  (* Raw invalid UTF-8 bytes (lone 0xff): Yojson passes them through, so Uutf
+     must reject the value and it is dropped to None. *)
+  let n = parse_one (neighbour_json "AB\xffCD" "p" "d") in
+  Alcotest.(check (option string)) "invalid UTF-8 dropped" None n.system_name ;
+  Alcotest.(check (option string)) "port_id kept" (Some "p") n.port_id
+
+let test_strip_control_chars () =
+  (* C0 controls (incl. tab/newline) and DEL are removed, printable kept. *)
+  let n = parse_one (neighbour_json "A\x01B\tC\x7fD\nE" "p" "d") in
+  Alcotest.(check (option string))
+    "control characters removed" (Some "ABCDE") n.system_name
+
+let test_strip_all_control_is_empty () =
+  (* A value that is only control characters sanitises to the empty string,
+     not None -- it was valid UTF-8, just had nothing printable. *)
+  let n = parse_one (neighbour_json "\x01\x02\x03" "p" "d") in
+  Alcotest.(check (option string))
+    "all-control value becomes empty" (Some "") n.system_name
+
+let test_strip_xml_noncharacters () =
+  (* U+FFFE (\xef\xbf\xbe) and U+FFFF (\xef\xbf\xbf) are valid UTF-8 but illegal
+     in XML; they are removed so they cannot poison the XML-backed database. *)
+  let n = parse_one (neighbour_json "A\xef\xbf\xbeB\xef\xbf\xbfC" "p" "d") in
+  Alcotest.(check (option string))
+    "XML-illegal noncharacters removed" (Some "ABC") n.system_name
+
 let interfaces_json =
   {|
   { "lldp": [ { "interface": [
@@ -127,6 +214,14 @@ let tests =
       ; ("multi", `Quick, test_multi)
       ; ("empty", `Quick, test_empty)
       ; ("malformed", `Quick, test_malformed)
+      ; ("cap_over_length", `Quick, test_cap_over_length)
+      ; ("cap_exact_256", `Quick, test_cap_exact_256)
+      ; ("cap_utf8_no_split", `Quick, test_cap_utf8_no_split)
+      ; ("cap_utf8_fits", `Quick, test_cap_utf8_fits)
+      ; ("reject_invalid_utf8", `Quick, test_reject_invalid_utf8)
+      ; ("strip_control_chars", `Quick, test_strip_control_chars)
+      ; ("strip_all_control_is_empty", `Quick, test_strip_all_control_is_empty)
+      ; ("strip_xml_noncharacters", `Quick, test_strip_xml_noncharacters)
       ]
     )
   ; ( "lldp_parse_enabled_interfaces"

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1945,19 +1945,11 @@ let pool_disable_client_certificate_auth _printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
   Client.Pool.disable_client_certificate_auth ~rpc ~session_id ~self:pool
 
-let pool_set_lldp_enabled printer rpc session_id params =
+let pool_set_lldp_enabled _printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
   let value = bool_of_string "value" (List.assoc "value" params) in
   let force = get_bool_param params "force" in
-  let failures =
-    Client.Pool.set_lldp_enabled ~rpc ~session_id ~self:pool ~value ~force
-  in
-  let table =
-    List.map
-      (fun (pif, msg) -> (Client.PIF.get_uuid ~rpc ~session_id ~self:pif, msg))
-      failures
-  in
-  printer (Cli_printer.PTable [table])
+  Client.Pool.set_lldp_enabled ~rpc ~session_id ~self:pool ~value ~force
 
 let pool_sync_updates printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in

--- a/ocaml/xapi-cli-server/cli_util.ml
+++ b/ocaml/xapi-cli-server/cli_util.ml
@@ -295,10 +295,13 @@ let get_server_error code params =
      datamodel.ml and those in the exception but this is unchecked and
      false in some cases, defined here. *)
   let required =
-    if code = Api_errors.vms_failed_to_cooperate then
-      List.map (fun _ -> "VM") params
-    else
-      error.Datamodel_types.err_params
+    match code with
+    | c when c = Api_errors.vms_failed_to_cooperate ->
+        List.map (fun _ -> "VM") params
+    | c when c = Api_errors.lldp_pif_replug_failed ->
+        List.map (fun _ -> "PIF") params
+    | _ ->
+        error.Datamodel_types.err_params
   in
   (* For the rest we attempt to pretty-print the list even when it's short/long *)
   let rec pp_params = function

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -851,6 +851,8 @@ let update_pool_apply_failed = add_error "UPDATE_POOL_APPLY_FAILED"
 let could_not_update_igmp_snooping_everywhere =
   add_error "COULD_NOT_UPDATE_IGMP_SNOOPING_EVERYWHERE"
 
+let lldp_pif_replug_failed = add_error "LLDP_PIF_REPLUG_FAILED"
+
 let update_apply_failed = add_error "UPDATE_APPLY_FAILED"
 
 let update_precheck_failed_unknown_error =

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -995,7 +995,19 @@ let set_lldp_mode ~__context ~self ~value ~force =
     let to_plug = pif_to_plug_for_lldp ~__context ~self in
     if Db.PIF.get_currently_attached ~__context ~self:to_plug then
       Helpers.call_api_functions ~__context (fun rpc session_id ->
-          Client.Client.PIF.plug ~rpc ~session_id ~self:to_plug
+          (* The LLDP configuration itself is applied best-effort inside
+             networkd (a failure there is swallowed so it cannot block the
+             plug); only a genuine re-plug failure can be reported here. Raise
+             it as an error so the UI shows which PIF was not reconfigured. *)
+          try Client.Client.PIF.plug ~rpc ~session_id ~self:to_plug
+          with e ->
+            let pif_str = Ref.string_of to_plug in
+            error "%s: PIF.plug failed on %s: %s" __FUNCTION__ pif_str
+              (ExnHelper.string_of_exn e) ;
+            raise
+              (Api_errors.Server_error
+                 (Api_errors.lldp_pif_replug_failed, [pif_str])
+              )
       )
   )
 

--- a/ocaml/xapi/xapi_pif.mli
+++ b/ocaml/xapi/xapi_pif.mli
@@ -141,7 +141,10 @@ val set_lldp_mode :
   -> value:[`disabled | `enabled | `inherited]
   -> force:bool
   -> unit
-(** Set the LLDP mode of a managed physical PIF and apply the change *)
+(** Set the LLDP mode of a managed physical PIF and apply the change by
+    re-plugging it. If the re-plug fails, raises [LLDP_PIF_REPLUG_FAILED] with
+    the PIF; the LLDP configuration itself is best-effort, so a successful
+    re-plug does not guarantee LLDP was applied. *)
 
 val set_default_properties : __context:Context.t -> self:API.ref_PIF -> unit
 (** Set the default properties of a PIF *)

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3882,17 +3882,38 @@ let set_lldp_enabled ~__context ~self ~value ~force =
       |> List.map fst
     in
     Helpers.call_api_functions ~__context (fun rpc session_id ->
-        List.filter_map
-          (fun pif ->
-            try
-              Client.PIF.plug ~rpc ~session_id ~self:pif ;
-              None
-            with e -> Some (pif, ExnHelper.string_of_exn e)
-          )
-          pifs
+        (* Re-plug every affected PIF, collecting those whose re-plug fails so
+           that one bad PIF does not prevent the rest from being reconfigured.
+           If any failed, raise once with the list of failed PIFs.
+
+           Note the re-plug is the only failure we can report here: the LLDP
+           configuration itself is applied best-effort inside networkd (a
+           failure there is logged and swallowed so it cannot block PIF.plug),
+           so a successful re-plug does not guarantee LLDP was applied. What we
+           do guarantee is that the caller learns which PIFs failed to re-plug
+           and therefore certainly did not get the new LLDP setting. *)
+        let failed_pifs =
+          List.filter_map
+            (fun pif ->
+              try
+                Client.PIF.plug ~rpc ~session_id ~self:pif ;
+                None
+              with e ->
+                let pif_str = Ref.string_of pif in
+                let exnstr = ExnHelper.string_of_exn e in
+                error "%s: PIF.plug failed on %s: %s" __FUNCTION__ pif_str
+                  exnstr ;
+                Some pif_str
+            )
+            pifs
+        in
+        if failed_pifs <> [] then
+          raise
+            (Api_errors.Server_error
+               (Api_errors.lldp_pif_replug_failed, failed_pifs)
+            )
     )
-  ) else
-    []
+  )
 
 let has_extension ~__context ~self:_ ~name =
   let hosts = Db.Host.get_all ~__context in

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -325,13 +325,12 @@ val set_igmp_snooping_enabled :
 (** Set on/off for IGMP Snooping *)
 
 val set_lldp_enabled :
-     __context:Context.t
-  -> self:API.ref_pool
-  -> value:bool
-  -> force:bool
-  -> (API.ref_PIF * string) list
-(** Enable or disable LLDP on every managed physical PIF in the pool, returning
-    a map of the PIFs that failed and the corresponding error message. *)
+  __context:Context.t -> self:API.ref_pool -> value:bool -> force:bool -> unit
+(** Enable or disable LLDP on every managed physical PIF in the pool, re-plugging
+    the affected PIFs. Every PIF is attempted; if any fail to re-plug, raises
+    [LLDP_PIF_REPLUG_FAILED] with the list of PIFs that failed. The LLDP
+    configuration itself is best-effort inside networkd, so a successful re-plug
+    does not guarantee LLDP was applied; only re-plug failures are reported. *)
 
 val has_extension :
   __context:Context.t -> self:API.ref_pool -> name:string -> bool


### PR DESCRIPTION
Four independent follow-up fixes on the LLDP feature branch (details in each commit):

- CA-431204: re-read inventory so the management-address TLV uses the current management interface, not a stale cache.
- CA-431221: short-circuit `lldpcli` while `lldpd` isn't running, avoiding periodic error-log spam when LLDP is off.
- CA-431224: report LLDP re-plug failures as `LLDP_PIF_REPLUG_FAILED` instead of a result map; `pool.set_lldp_enabled` returns void.
- CA-431350: sanitise untrusted LLDP neighbour TLVs (UTF-8, control chars, length).