### PR TITLE
Make `xe` warn about ignored command-line parameters

### DIFF
--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -72,4 +72,5 @@ let () =
     @ Test_extauth_plugin_ADwinbind.tests
     @ Test_rfb_client_msgtype_parser.tests
     @ Test_tracked_user_agents.tests
+    @ Test_cli_args.tests
     )

--- a/ocaml/tests/test_cli_args.ml
+++ b/ocaml/tests/test_cli_args.ml
@@ -1,0 +1,167 @@
+(*
+ * Copyright (C) 2026 Vates.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Cli_args
+
+let strings = Alcotest.(list string)
+
+let t_of = from_pairs
+
+let check_unused msg expected t = Alcotest.check strings msg expected (unused t)
+
+let test_map_contents_preserves_order_and_dups () =
+  let t = t_of [("a", "1"); ("b", "2"); ("a", "3")] in
+  Alcotest.check strings "map_contents keeps command-line order and duplicates"
+    ["1"; "2"; "3"]
+    (List.map snd (map_contents t)) ;
+  check_unused "and consumes every entry" [] t
+
+let test_assoc_default_ci () =
+  let t = t_of [("IP", "1.2.3.4"); ("x", "1")] in
+  Alcotest.check Alcotest.string "case-insensitive hit" "1.2.3.4"
+    (assoc_default_ci "ip" t) ;
+  Alcotest.check Alcotest.string "absent falls back to empty" ""
+    (assoc_default_ci "dns" t) ;
+  check_unused "marks only the matched key" ["x"] t
+
+let test_get_marks () =
+  let t = t_of [("a", "1"); ("b", "2"); ("c", "3")] in
+  check_unused "nothing read yet" ["a"; "b"; "c"] t ;
+  Alcotest.check Alcotest.string "get value" "1" (get "a" t) ;
+  ignore (get_opt "b" t) ;
+  check_unused "a and b now read" ["c"] t
+
+let test_absent_lookup_marks_nothing () =
+  let t = t_of [("a", "1")] in
+  ignore (get_opt "zzz" t) ;
+  Alcotest.check Alcotest.string "get_default falls back" "d"
+    (get_default "zzz" t "d") ;
+  check_unused "absent lookups mark nothing" ["a"] t
+
+let test_exists_marks () =
+  let t = t_of [("force", "true"); ("x", "1")] in
+  Alcotest.check Alcotest.bool "exists" true (exists "force" t) ;
+  Alcotest.check Alcotest.bool "exists absent" false (exists "nope" t) ;
+  check_unused "exists marks the present key only" ["x"] t
+
+let test_get_all_marks_every_occurrence () =
+  let t = t_of [("vm-uuid", "a"); ("other", "z"); ("vm-uuid", "b")] in
+  Alcotest.check strings "get_all in command-line order" ["a"; "b"]
+    (get_all "vm-uuid" t) ;
+  check_unused "both occurrences marked" ["other"] t
+
+let test_view_strips_prefix_and_marks_root () =
+  let t =
+    t_of [("other-config:a", "1"); ("other-config:b", "2"); ("scalar", "s")]
+  in
+  let oc = view "other-config" t in
+  Alcotest.check strings "view keys are prefix-stripped" ["a"; "b"] (keys oc) ;
+  ignore (get "a" oc) ;
+  check_unused "reading through the view marks the root entry"
+    ["other-config:b"; "scalar"]
+    t
+
+let test_view_accepts_legacy_dash_separator () =
+  let t = t_of [("device-config-target", "/dev/x"); ("z", "1")] in
+  let dc = view "device-config" t in
+  Alcotest.check
+    (Alcotest.option Alcotest.string)
+    "dash-separated key is visible through the view" (Some "/dev/x")
+    (get_opt "target" dc) ;
+  check_unused "and marked on the root" ["z"] t
+
+let test_consume_marks_all_visible () =
+  let t = t_of [("a", "1"); ("b", "2")] in
+  ignore (consume t) ;
+  check_unused "consume marks everything" [] t
+
+let test_consume_on_view_respects_scope () =
+  let t = t_of [("m:a", "1"); ("m:b", "2"); ("outside", "x")] in
+  ignore (consume (view "m" t)) ;
+  check_unused "consume on a view leaves entries outside its scope" ["outside"]
+    t
+
+let test_mark_used_without_reading () =
+  let t = t_of [("a", "1"); ("b", "2")] in
+  mark_used "a" t ;
+  mark_used "absent" t ;
+  check_unused "mark_used marks a, absent is a no-op" ["b"] t
+
+let test_add_entry_starts_unused () =
+  let t = add "b" "2" (t_of [("a", "1")]) in
+  check_unused "the added entry is not marked" ["b"; "a"] t
+
+let test_remove_first_occurrence_only () =
+  let t = remove "k" (t_of [("k", "1"); ("k", "2"); ("k", "3")]) in
+  Alcotest.check strings "remove drops only the first" ["2"; "3"] (get_all "k" t)
+
+let test_rename_key_in_place () =
+  let t = t_of [("host-uuid", "H"); ("x", "1")] in
+  rename_key ~from_:"host-uuid" ~to_:"host" t ;
+  check_unused "the key is renamed, still unread" ["host"; "x"] t ;
+  Alcotest.check Alcotest.string "value survives the rename" "H" (get "host" t) ;
+  check_unused "reading the renamed key marks it" ["x"] t
+
+let test_rename_key_seen_through_shared_records () =
+  let t = t_of [("a", "1"); ("b", "2")] in
+  let derived = filter (fun _ -> true) t in
+  rename_key ~from_:"a" ~to_:"z" t ;
+  Alcotest.check strings "a structure derived before the rename sees it"
+    ["z"; "b"] (keys derived) ;
+  ignore (get "z" derived) ;
+  check_unused "and marking through it reaches the original" ["b"] t
+
+let tests =
+  [
+    ( "Cli_args"
+    , [
+        ( "map_contents keeps order and duplicates"
+        , `Quick
+        , test_map_contents_preserves_order_and_dups
+        )
+      ; ("assoc_default_ci", `Quick, test_assoc_default_ci)
+      ; ("get / get_opt mark", `Quick, test_get_marks)
+      ; ("absent lookups mark nothing", `Quick, test_absent_lookup_marks_nothing)
+      ; ("exists marks", `Quick, test_exists_marks)
+      ; ( "get_all marks every occurrence"
+        , `Quick
+        , test_get_all_marks_every_occurrence
+        )
+      ; ( "view strips prefix, marks root"
+        , `Quick
+        , test_view_strips_prefix_and_marks_root
+        )
+      ; ( "view accepts legacy dash"
+        , `Quick
+        , test_view_accepts_legacy_dash_separator
+        )
+      ; ("consume marks all visible", `Quick, test_consume_marks_all_visible)
+      ; ( "consume on view respects scope"
+        , `Quick
+        , test_consume_on_view_respects_scope
+        )
+      ; ("mark_used without reading", `Quick, test_mark_used_without_reading)
+      ; ("add entry starts unused", `Quick, test_add_entry_starts_unused)
+      ; ( "remove first occurrence only"
+        , `Quick
+        , test_remove_first_occurrence_only
+        )
+      ; ("rename_key in place", `Quick, test_rename_key_in_place)
+      ; ( "rename_key via shared records"
+        , `Quick
+        , test_rename_key_seen_through_shared_records
+        )
+      ]
+    )
+  ]

--- a/ocaml/tests/test_cli_args.ml
+++ b/ocaml/tests/test_cli_args.ml
@@ -81,6 +81,23 @@ let test_view_accepts_legacy_dash_separator () =
     (get_opt "target" dc) ;
   check_unused "and marked on the root" ["z"] t
 
+let test_view_requires_a_separator () =
+  let t =
+    t_of
+      [
+        ("other-config:real", "1")
+      ; ("other-configuration", "2")
+      ; ("other-configx", "3")
+      ]
+  in
+  let oc = view "other-config" t in
+  Alcotest.check strings "only prefix + separator + key is in scope" ["real"]
+    (keys oc) ;
+  ignore (consume oc) ;
+  check_unused "keys sharing the prefix without a separator stay untouched"
+    ["other-configuration"; "other-configx"]
+    t
+
 let test_consume_marks_all_visible () =
   let t = t_of [("a", "1"); ("b", "2")] in
   ignore (consume t) ;
@@ -146,6 +163,7 @@ let tests =
         , `Quick
         , test_view_accepts_legacy_dash_separator
         )
+      ; ("view requires a separator", `Quick, test_view_requires_a_separator)
       ; ("consume marks all visible", `Quick, test_consume_marks_all_visible)
       ; ( "consume on view respects scope"
         , `Quick

--- a/ocaml/xapi-cli-server/cli_args.ml
+++ b/ocaml/xapi-cli-server/cli_args.ml
@@ -1,0 +1,52 @@
+(*
+ * Copyright (C) 2026 Vates.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+type 'a t = (string * 'a) list
+
+let from_pairs args = args
+
+let to_pairs args = args
+
+let reserved = ["server"; "username"; "password"; "port"; "minimal"; "all"]
+
+let is_reserved arg = List.mem arg reserved
+
+let get = List.assoc
+
+let get_opt = List.assoc_opt
+
+let get_default key args default =
+  match List.assoc_opt key args with None -> default | Some v -> v
+
+let get_all key args =
+  List.filter_map
+    (fun (k, v) ->
+      if k = key then
+        Some v
+      else
+        None
+    )
+    args
+
+let exists = List.mem_assoc
+
+let add key value args = (key, value) :: args
+
+let filter pred = List.filter (fun (k, _) -> pred k)
+
+let filter_out pred = List.filter (fun (k, _) -> not (pred k))
+
+let remove = List.remove_assoc
+
+let keys args = List.map fst args

--- a/ocaml/xapi-cli-server/cli_args.ml
+++ b/ocaml/xapi-cli-server/cli_args.ml
@@ -12,24 +12,48 @@
  * GNU Lesser General Public License for more details.
  *)
 
-type 'a t = (string * 'a) list
+(* [scope = Some prefix] restricts the visible entries to those whose key is
+   [prefix] followed by at least one more character (any separator, matching the
+   historical map-parameter parsing); their keys are seen with that prefix and
+   its separator removed. [pairs] is shared with the unscoped structure the view
+   was taken from. *)
+type 'a t = {pairs: (string * 'a) list; scope: string option}
 
-let from_pairs args = args
+(* The entries visible through [t], with the scope prefix stripped from keys. *)
+let visible t =
+  match t.scope with
+  | None ->
+      t.pairs
+  | Some prefix ->
+      let plen = String.length prefix in
+      let len = plen + 1 in
+      List.filter_map
+        (fun (k, v) ->
+          if String.length k > len && String.sub k 0 plen = prefix then
+            Some (String.sub k len (String.length k - len), v)
+          else
+            None
+        )
+        t.pairs
 
-let to_pairs args = args
+let from_pairs pairs = {pairs; scope= None}
+
+let to_pairs = visible
+
+let view prefix t = {t with scope= Some prefix}
 
 let reserved = ["server"; "username"; "password"; "port"; "minimal"; "all"]
 
 let is_reserved arg = List.mem arg reserved
 
-let get = List.assoc
+let get key t = List.assoc key (visible t)
 
-let get_opt = List.assoc_opt
+let get_opt key t = List.assoc_opt key (visible t)
 
-let get_default key args default =
-  match List.assoc_opt key args with None -> default | Some v -> v
+let get_default key t default =
+  match List.assoc_opt key (visible t) with None -> default | Some v -> v
 
-let get_all key args =
+let get_all key t =
   List.filter_map
     (fun (k, v) ->
       if k = key then
@@ -37,16 +61,19 @@ let get_all key args =
       else
         None
     )
-    args
+    (visible t)
 
-let exists = List.mem_assoc
+let exists key t = List.mem_assoc key (visible t)
 
-let add key value args = (key, value) :: args
+let keys t = List.map fst (visible t)
 
-let filter pred = List.filter (fun (k, _) -> pred k)
+(* The mutating helpers below are only ever used on an unscoped structure. *)
 
-let filter_out pred = List.filter (fun (k, _) -> not (pred k))
+let add key value t = {t with pairs= (key, value) :: t.pairs}
 
-let remove = List.remove_assoc
+let remove key t = {t with pairs= List.remove_assoc key t.pairs}
 
-let keys args = List.map fst args
+let filter pred t = {t with pairs= List.filter (fun (k, _) -> pred k) t.pairs}
+
+let filter_out pred t =
+  {t with pairs= List.filter (fun (k, _) -> not (pred k)) t.pairs}

--- a/ocaml/xapi-cli-server/cli_args.ml
+++ b/ocaml/xapi-cli-server/cli_args.ml
@@ -19,10 +19,10 @@
 type 'a entry = {mutable key: string; value: 'a; mutable used: bool}
 
 (* [scope = Some prefix] restricts the visible entries to those whose key is
-   [prefix] followed by at least one more character (any separator, matching the
-   historical map-parameter parsing); their keys are seen with that prefix and
-   its separator removed. [entries] is shared with the structure the view was
-   taken from. *)
+   [prefix], then a [:] or [-] separator, then at least one more character (the
+   [prefix:key=value] map/set syntax and the legacy [prefix-key=value] form);
+   their keys are seen with that prefix and separator removed. [entries] is
+   shared with the structure the view was taken from. *)
 type 'a t = {entries: 'a entry list; scope: string option}
 
 (* [bare t e] is [e]'s key as seen through [t] (scope prefix stripped), or [None]
@@ -34,7 +34,11 @@ let bare t e =
   | Some prefix ->
       let plen = String.length prefix in
       let len = plen + 1 in
-      if String.length e.key > len && String.sub e.key 0 plen = prefix then
+      if
+        String.length e.key > len
+        && String.sub e.key 0 plen = prefix
+        && (e.key.[plen] = ':' || e.key.[plen] = '-')
+      then
         Some (String.sub e.key len (String.length e.key - len))
       else
         None

--- a/ocaml/xapi-cli-server/cli_args.ml
+++ b/ocaml/xapi-cli-server/cli_args.ml
@@ -59,7 +59,16 @@ let to_pairs t = List.map (fun (k, e) -> (k, e.value)) (visible t)
 
 let view prefix t = {t with scope= Some prefix}
 
-let reserved = ["server"; "username"; "password"; "port"; "minimal"; "all"]
+let reserved =
+  [
+    "server"
+  ; "username"
+  ; "password"
+  ; "port"
+  ; "minimal"
+  ; "all"
+  ; "report-ignored-params"
+  ]
 
 let is_reserved arg = List.mem arg reserved
 

--- a/ocaml/xapi-cli-server/cli_args.ml
+++ b/ocaml/xapi-cli-server/cli_args.ml
@@ -12,33 +12,46 @@
  * GNU Lesser General Public License for more details.
  *)
 
+(* [used] records whether a command has read this parameter. It is mutable and
+   the entry records are shared between a structure and the views taken from it
+   ({!view}), so marking through a view is visible from the root. Nothing reads
+   [used] yet -- the report of ignored parameters is a later commit. *)
+type 'a entry = {mutable key: string; value: 'a; mutable used: bool}
+
 (* [scope = Some prefix] restricts the visible entries to those whose key is
    [prefix] followed by at least one more character (any separator, matching the
    historical map-parameter parsing); their keys are seen with that prefix and
-   its separator removed. [pairs] is shared with the unscoped structure the view
-   was taken from. *)
-type 'a t = {pairs: (string * 'a) list; scope: string option}
+   its separator removed. [entries] is shared with the structure the view was
+   taken from. *)
+type 'a t = {entries: 'a entry list; scope: string option}
 
-(* The entries visible through [t], with the scope prefix stripped from keys. *)
-let visible t =
+(* [bare t e] is [e]'s key as seen through [t] (scope prefix stripped), or [None]
+   when [e] is not visible through [t]. *)
+let bare t e =
   match t.scope with
   | None ->
-      t.pairs
+      Some e.key
   | Some prefix ->
       let plen = String.length prefix in
       let len = plen + 1 in
-      List.filter_map
-        (fun (k, v) ->
-          if String.length k > len && String.sub k 0 plen = prefix then
-            Some (String.sub k len (String.length k - len), v)
-          else
-            None
-        )
-        t.pairs
+      if String.length e.key > len && String.sub e.key 0 plen = prefix then
+        Some (String.sub e.key len (String.length e.key - len))
+      else
+        None
 
-let from_pairs pairs = {pairs; scope= None}
+(* The entries visible through [t], each paired with its bare key. *)
+let visible t =
+  List.filter_map (fun e -> Option.map (fun k -> (k, e)) (bare t e)) t.entries
 
-let to_pairs = visible
+let mark e = e.used <- true
+
+let from_pairs pairs =
+  {
+    entries= List.map (fun (key, value) -> {key; value; used= false}) pairs
+  ; scope= None
+  }
+
+let to_pairs t = List.map (fun (k, e) -> (k, e.value)) (visible t)
 
 let view prefix t = {t with scope= Some prefix}
 
@@ -46,34 +59,110 @@ let reserved = ["server"; "username"; "password"; "port"; "minimal"; "all"]
 
 let is_reserved arg = List.mem arg reserved
 
-let get key t = List.assoc key (visible t)
+let get_opt key t =
+  match List.find_opt (fun (k, _) -> k = key) (visible t) with
+  | Some (_, e) ->
+      mark e ; Some e.value
+  | None ->
+      None
 
-let get_opt key t = List.assoc_opt key (visible t)
+let get key t = match get_opt key t with Some v -> v | None -> raise Not_found
 
 let get_default key t default =
-  match List.assoc_opt key (visible t) with None -> default | Some v -> v
+  match get_opt key t with None -> default | Some v -> v
+
+(* Like [get_default key t ""] but matching [key] case-insensitively; marks the
+   matched entry as read. *)
+let assoc_default_ci key t =
+  let key = String.lowercase_ascii key in
+  match
+    List.find_opt (fun (k, _) -> String.lowercase_ascii k = key) (visible t)
+  with
+  | Some (_, e) ->
+      mark e ; e.value
+  | None ->
+      ""
 
 let get_all key t =
   List.filter_map
-    (fun (k, v) ->
-      if k = key then
-        Some v
-      else
+    (fun (k, e) ->
+      if k = key then (
+        mark e ; Some e.value
+      ) else
         None
     )
     (visible t)
 
-let exists key t = List.mem_assoc key (visible t)
+let exists key t = Option.is_some (get_opt key t)
 
 let keys t = List.map fst (visible t)
 
-(* The mutating helpers below are only ever used on an unscoped structure. *)
+(* Mark every visible entry of [t] as read, and return [t]. Underlies
+   {!map_contents}; also used directly with {!keys} to drain a set parameter. *)
+let consume t =
+  List.iter (fun (_, e) -> mark e) (visible t) ;
+  t
 
-let add key value t = {t with pairs= (key, value) :: t.pairs}
+(* The visible [(key, value)] pairs of [t], all marked as read -- for forwarding
+   a whole map/set parameter (or a filtered parameter list) wholesale to the
+   API. Reads the contents, so it consumes: never left un-consumed, or the
+   entries would be reported as ignored. *)
+let map_contents t = to_pairs (consume t)
 
-let remove key t = {t with pairs= List.remove_assoc key t.pairs}
+(* Render [t] as a "key=value key=value" line for a log, replacing the value of
+   every [key] for which [censor key] holds with "(omitted)". Does not mark
+   entries: this is diagnostic output, not the command reading its parameters. *)
+let log_args ~censor t =
+  to_pairs t
+  |> List.map (fun (k, v) ->
+      let v =
+        if censor k then
+          "(omitted)"
+        else
+          v
+      in
+      Printf.sprintf "%s=%s" k v
+  )
+  |> String.concat " "
 
-let filter pred t = {t with pairs= List.filter (fun (k, _) -> pred k) t.pairs}
+(* The bare keys of the entries visible through [t] that no command has read.
+   Not called yet -- the report of ignored parameters is a later commit. *)
+let unused t =
+  List.filter_map
+    (fun (k, e) ->
+      if e.used then
+        None
+      else
+        Some k
+    )
+    (visible t)
 
-let filter_out pred t =
-  {t with pairs= List.filter (fun (k, _) -> not (pred k)) t.pairs}
+(* Mark the entry for [key], if any, as read -- without reading its value. *)
+let mark_used key t = ignore (get_opt key t)
+
+(* The helpers below are only ever used on an unscoped structure. *)
+
+(* Rename every entry keyed [from_] to [to_], in place: the entry records are
+   shared with the views taken from [t], so the rename is seen everywhere,
+   including a report computed on the structure this one was derived from. *)
+let rename_key ~from_ ~to_ t =
+  List.iter (fun e -> if e.key = from_ then e.key <- to_) t.entries
+
+let add key value t = {t with entries= {key; value; used= false} :: t.entries}
+
+let remove key t =
+  let rec go = function
+    | [] ->
+        []
+    | e :: rest ->
+        if e.key = key then
+          rest
+        else
+          e :: go rest
+  in
+  {t with entries= go t.entries}
+
+let filter pred t =
+  {t with entries= List.filter (fun e -> pred e.key) t.entries}
+
+let filter_out pred t = filter (Fun.negate pred) t

--- a/ocaml/xapi-cli-server/cli_args.mli
+++ b/ocaml/xapi-cli-server/cli_args.mli
@@ -1,0 +1,62 @@
+(*
+ * Copyright (C) 2026 Vates.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** [Cli_args] holds the [key=value] parameters parsed from an [xe] command
+    line. It is a thin abstraction over an association list; the point of the
+    abstraction is to give a single place through which every parameter access
+    goes, so that later we can track which parameters a command actually
+    consumed and report the ones that were silently ignored. *)
+
+type 'a t
+
+val from_pairs : (string * string) list -> string t
+(** Build the structure from the parsed command-line [(key, value)] pairs. *)
+
+val to_pairs : 'a t -> (string * 'a) list
+(** The [(key, value)] pairs, in command-line order. *)
+
+val reserved : string list
+(** Parameter names reserved by the CLI framework; these cannot be used as
+    command names. *)
+
+val is_reserved : string -> bool
+
+val get : string -> 'a t -> 'a
+(** [get key t] is the value bound to [key]. Raises [Not_found] if absent. *)
+
+val get_opt : string -> 'a t -> 'a option
+
+val get_default : string -> 'a t -> 'a -> 'a
+(** [get_default key t default] is the value bound to [key], or [default]. *)
+
+val get_all : string -> 'a t -> 'a list
+(** Every value bound to [key], in command-line order (a key may legitimately
+    appear more than once). *)
+
+val exists : string -> 'a t -> bool
+
+val add : string -> 'a -> 'a t -> 'a t
+(** [add key value t] prepends [(key, value)], shadowing any existing binding
+    for [key] in subsequent {!get} / {!get_opt} lookups. *)
+
+val filter : (string -> bool) -> 'a t -> 'a t
+(** Keep only the pairs whose key satisfies the predicate. *)
+
+val filter_out : (string -> bool) -> 'a t -> 'a t
+(** Drop the pairs whose key satisfies the predicate. *)
+
+val remove : string -> 'a t -> 'a t
+(** Remove the first pair bound to [key] (mirrors [List.remove_assoc]). *)
+
+val keys : 'a t -> string list

--- a/ocaml/xapi-cli-server/cli_args.mli
+++ b/ocaml/xapi-cli-server/cli_args.mli
@@ -24,7 +24,16 @@ val from_pairs : (string * string) list -> string t
 (** Build the structure from the parsed command-line [(key, value)] pairs. *)
 
 val to_pairs : 'a t -> (string * 'a) list
-(** The [(key, value)] pairs, in command-line order. *)
+(** The [(key, value)] pairs, in command-line order. On a view (see {!view}),
+    only the entries under the view's prefix, with that prefix stripped. *)
+
+val view : string -> 'a t -> 'a t
+(** [view prefix t] is [t] restricted to the entries whose key is [prefix]
+    followed by a separator and at least one more character (the
+    [prefix:key=value] map/set syntax, and the legacy [prefix-key=value] form).
+    Every accessor then sees those keys with the [prefix] and separator removed,
+    e.g. [get "auto-scan" (view "other-config" t)] reads [other-config:auto-scan].
+    The underlying entries are shared with [t]. *)
 
 val reserved : string list
 (** Parameter names reserved by the CLI framework; these cannot be used as

--- a/ocaml/xapi-cli-server/cli_args.mli
+++ b/ocaml/xapi-cli-server/cli_args.mli
@@ -23,10 +23,6 @@ type 'a t
 val from_pairs : (string * string) list -> string t
 (** Build the structure from the parsed command-line [(key, value)] pairs. *)
 
-val to_pairs : 'a t -> (string * 'a) list
-(** The [(key, value)] pairs, in command-line order. On a view (see {!view}),
-    only the entries under the view's prefix, with that prefix stripped. *)
-
 val view : string -> 'a t -> 'a t
 (** [view prefix t] is [t] restricted to the entries whose key is [prefix]
     followed by a separator and at least one more character (the
@@ -49,11 +45,39 @@ val get_opt : string -> 'a t -> 'a option
 val get_default : string -> 'a t -> 'a -> 'a
 (** [get_default key t default] is the value bound to [key], or [default]. *)
 
+val assoc_default_ci : string -> string t -> string
+(** [assoc_default_ci key t] is the value bound to [key] matched
+    case-insensitively, or [""] if absent. Marks the matched entry as read. *)
+
 val get_all : string -> 'a t -> 'a list
 (** Every value bound to [key], in command-line order (a key may legitimately
     appear more than once). *)
 
 val exists : string -> 'a t -> bool
+
+val consume : 'a t -> 'a t
+(** Mark every entry visible through [t] as read, and return [t]. For call sites
+    that take a whole (view's) contents wholesale -- e.g. a set parameter read
+    with {!keys}; a map parameter goes through {!map_contents} instead. *)
+
+val map_contents : 'a t -> (string * 'a) list
+(** The visible [(key, value)] pairs of [t], all marked as read. For forwarding a
+    whole map parameter -- or a filtered parameter list -- to the API:
+    [Cli_maps.other_config params |> map_contents]. Marks as it reads, so the
+    entries cannot be left unconsumed and then wrongly reported as ignored --
+    which is why it, rather than a raw pair list, is what the interface exposes. *)
+
+val log_args : censor:(string -> bool) -> string t -> string
+(** [t] rendered as a ["key=value key=value"] line for a log, with the value of
+    every [key] for which [censor key] is [true] replaced by ["(omitted)"]. Does
+    not mark entries -- diagnostic output, not a command reading its arguments. *)
+
+val mark_used : string -> 'a t -> unit
+(** Mark the entry for [key], if any, as read, without reading its value. *)
+
+val unused : 'a t -> string list
+(** The keys of the entries no command has read through {!get} & co. Used to
+    report the parameters a command silently ignored. *)
 
 val add : string -> 'a -> 'a t -> 'a t
 (** [add key value t] prepends [(key, value)], shadowing any existing binding
@@ -67,5 +91,11 @@ val filter_out : (string -> bool) -> 'a t -> 'a t
 
 val remove : string -> 'a t -> 'a t
 (** Remove the first pair bound to [key] (mirrors [List.remove_assoc]). *)
+
+val rename_key : from_:string -> to_:string -> 'a t -> unit
+(** Rename every entry keyed [from_] to [to_], in place. The entry records are
+    shared with the views of [t] and with the structure it was derived from, so
+    the rename -- and any subsequent {!mark_used} -- is visible from all of
+    them. *)
 
 val keys : 'a t -> string list

--- a/ocaml/xapi-cli-server/cli_cmdtable.ml
+++ b/ocaml/xapi-cli-server/cli_cmdtable.ml
@@ -19,7 +19,7 @@ type op =
      Cli_printer.print_fn
   -> (Rpc.call -> Rpc.response)
   -> API.ref_session
-  -> (string * string) list
+  -> string Cli_args.t
   -> unit
 
 type imp =

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -4143,7 +4143,7 @@ let make_list l =
   in
   doline (indent ^ List.hd l) [] (List.tl l)
 
-let rio_help printer minimal cmd =
+let cmd_help printer minimal cmd =
   let docmd cmd =
     match Hashtbl.find_opt cmdtable cmd with
     | Some cmd_spec ->
@@ -4282,5 +4282,3 @@ Common command list
         printer (Cli_printer.PList [h]) ;
         printer (Cli_printer.PList (make_list cmds))
       )
-
-let cmd_help printer minimal cmd = rio_help printer minimal cmd

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -4113,14 +4113,13 @@ let rec parse_params_2 xs =
   | [] ->
       []
 
-let parse_commandline arg_list =
+let parse_commandline (argv0, arg_list) =
   try
-    let argv0 = List.hd arg_list in
-    let cmdname = List.hd (List.tl arg_list) in
+    let cmdname = List.hd arg_list in
     (* Detect the case when the command-name is missing *)
     if String.contains cmdname '=' then
       raise (ParseError "command name is missing") ;
-    let params = parse_params_2 (List.tl (List.tl arg_list)) in
+    let params = parse_params_2 (List.tl arg_list) in
     {cmdname; argv0; params}
   with e ->
     error "Rethrowing %s as ParseError \"\"" (Printexc.to_string e) ;

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -4065,25 +4065,17 @@ let convert_switch switch =
     error "Rethrowing Not_found as ParseError: Unknown switch: %s" switch ;
     Backtrace.reraise e (ParseError ("Unknown switch: " ^ switch))
 
-type token = Id of string | Eq
-
-type commandline = {
-    cmdname: string
-  ; argv0: string
-  ; params: (string * string) list
-}
+type commandline = {cmdname: string; argv0: string; params: string Cli_args.t}
 
 let get_params cmd = cmd.params
 
 let get_cmdname cmd = cmd.cmdname
 
 let get_reqd_param cmd p =
-  try List.assoc p cmd.params
+  try Cli_args.get p cmd.params
   with Not_found as e ->
     error "Rethrowing Not_found as ParamNotFound %s" p ;
     Backtrace.reraise e (ParamNotFound p)
-
-let string_of_token t = match t with Id s -> "Id(" ^ s ^ ")" | Eq -> "Eq"
 
 let starts_with s prefix =
   let s_len = String.length s in
@@ -4119,7 +4111,7 @@ let parse_commandline (argv0, arg_list) =
     (* Detect the case when the command-name is missing *)
     if String.contains cmdname '=' then
       raise (ParseError "command name is missing") ;
-    let params = parse_params_2 (List.tl arg_list) in
+    let params = Cli_args.from_pairs (parse_params_2 (List.tl arg_list)) in
     {cmdname; argv0; params}
   with e ->
     error "Rethrowing %s as ParseError \"\"" (Printexc.to_string e) ;
@@ -4196,17 +4188,11 @@ let cmd_help printer minimal cmd =
         printer (Cli_printer.PList ["Unknown command '" ^ cmd ^ "'"])
   in
   let cmds =
-    List.filter
-      (fun (x, _) ->
-        not
-          (List.mem x
-             ["server"; "username"; "password"; "port"; "minimal"; "all"]
-          )
-      )
-      cmd.params
+    let open Cli_args in
+    cmd.params |> filter_out is_reserved |> keys
   in
   if cmds <> [] then
-    List.iter docmd (List.map fst cmds)
+    List.iter docmd cmds
   else
     let cmds =
       Hashtbl.fold (fun name cmd list -> (name, cmd) :: list) cmdtable []
@@ -4217,6 +4203,13 @@ let cmd_help printer minimal cmd =
     (* Filter hidden commands from help *)
     let cmds =
       List.sort (fun (name1, _) (name2, _) -> compare name1 name2) cmds
+    in
+    let all_commands =
+      match Cli_args.get_opt "all" cmd.params with
+      | None ->
+          false
+      | Some s ->
+          s = "true"
     in
     let help =
       Printf.sprintf
@@ -4238,8 +4231,7 @@ To get help on a specific command:
 |}
         cmd.argv0 cmd.argv0
     in
-    if List.mem_assoc "all" cmd.params && List.assoc "all" cmd.params = "true"
-    then
+    if all_commands then
       let cmds = List.map fst cmds in
       let host_cmds, other =
         List.partition (fun n -> Astring.String.is_prefix ~affix:"host-" n) cmds

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -4223,6 +4223,8 @@ let cmd_help printer minimal cmd =
     [ --debug ]                Enable debug output
     [ --debug-on-fail ]        Enable debug output only on failure
     [ --traceparent <value> ]  Distributed tracing context
+    [ report-ignored-params=off|warn ]
+                               Report parameters the command ignored (on stderr)
     [ <other arguments> ... ]  Command-specific options
 
 To get help on a specific command:

--- a/ocaml/xapi-cli-server/cli_frontend.mli
+++ b/ocaml/xapi-cli-server/cli_frontend.mli
@@ -32,4 +32,4 @@ val populate_cmdtable : Cli_operations.rpc -> API.ref_session -> unit
 
 val cmd_help : (Cli_printer.printval -> unit) -> bool -> commandline -> unit
 
-val parse_commandline : string list -> commandline
+val parse_commandline : string * string list -> commandline

--- a/ocaml/xapi-cli-server/cli_frontend.mli
+++ b/ocaml/xapi-cli-server/cli_frontend.mli
@@ -20,7 +20,7 @@ exception ParamNotFound of string
 
 type commandline
 
-val get_params : commandline -> (string * string) list
+val get_params : commandline -> string Cli_args.t
 
 val get_cmdname : commandline -> string
 

--- a/ocaml/xapi-cli-server/cli_frontend.mli
+++ b/ocaml/xapi-cli-server/cli_frontend.mli
@@ -1,0 +1,35 @@
+(*
+ * Copyright (C) 2026 Vates.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** Interface of the Cli_frontend module *)
+
+exception ParseError of string
+
+exception ParamNotFound of string
+
+type commandline
+
+val get_params : commandline -> (string * string) list
+
+val get_cmdname : commandline -> string
+
+val get_reqd_param : commandline -> string -> string
+
+val cmdtable : (string, Cli_cmdtable.cmd_spec) Hashtbl.t
+
+val populate_cmdtable : Cli_operations.rpc -> API.ref_session -> unit
+
+val cmd_help : (Cli_printer.printval -> unit) -> bool -> commandline -> unit
+
+val parse_commandline : string list -> commandline

--- a/ocaml/xapi-cli-server/cli_maps.ml
+++ b/ocaml/xapi-cli-server/cli_maps.ml
@@ -1,0 +1,60 @@
+(*
+ * Copyright (C) 2026 Vates.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** Named views onto the map-valued parameters of an [xe] command line (the
+    [name:key=value] syntax), and the set-valued parameters -- which are maps
+    whose values are ignored, so read the result with {!Cli_args.keys} rather
+    than {!Cli_args.to_pairs}.
+
+    Each entry is [fun params -> Cli_args.view "name" params]: a lens onto the
+    [name:*] entries of [params], presenting their keys with the [name:] prefix
+    removed. This is the one place, in code, that lists which map/set parameter
+    names the CLI understands. *)
+
+let args params = Cli_args.view "args" params
+
+let config params = Cli_args.view "config" params
+
+let database params = Cli_args.view "database" params
+
+let device_config params = Cli_args.view "device-config" params
+
+let driver_params params = Cli_args.view "driver-params" params
+
+let ha_config params = Cli_args.view "ha-config" params
+
+let image_format params = Cli_args.view "image-format" params
+
+let other_config params = Cli_args.view "other-config" params
+
+let power_on_config params = Cli_args.view "power-on-config" params
+
+let properties params = Cli_args.view "properties" params
+
+let remote_config params = Cli_args.view "remote-config" params
+
+let schedule params = Cli_args.view "schedule" params
+
+let sm_config params = Cli_args.view "sm-config" params
+
+let vdi params = Cli_args.view "vdi" params
+
+let vgpu params = Cli_args.view "vgpu" params
+
+let vif params = Cli_args.view "vif" params
+
+let xenstore_data params = Cli_args.view "xenstore-data" params
+
+(* Set-valued: read with Cli_args.keys. *)
+let tags params = Cli_args.view "tags" params

--- a/ocaml/xapi-cli-server/cli_maps.ml
+++ b/ocaml/xapi-cli-server/cli_maps.ml
@@ -15,7 +15,7 @@
 (** Named views onto the map-valued parameters of an [xe] command line (the
     [name:key=value] syntax), and the set-valued parameters -- which are maps
     whose values are ignored, so read the result with {!Cli_args.keys} rather
-    than {!Cli_args.to_pairs}.
+    than {!Cli_args.map_contents}.
 
     Each entry is [fun params -> Cli_args.view "name" params]: a lens onto the
     [name:*] entries of [params], presenting their keys with the [name:] prefix

--- a/ocaml/xapi-cli-server/cli_maps.mli
+++ b/ocaml/xapi-cli-server/cli_maps.mli
@@ -1,0 +1,60 @@
+(*
+ * Copyright (C) 2026 Vates.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** Named views onto the map-valued parameters of an [xe] command line (the
+    [name:key=value] syntax), and the set-valued parameters -- which are maps
+    whose values are ignored, so read the result with {!Cli_args.keys} rather
+    than {!Cli_args.to_pairs}.
+
+    Each accessor is [fun params -> Cli_args.view "name" params]: a lens onto the
+    [name:*] entries of [params], presenting their keys with the [name:] prefix
+    removed. This is the one place, in code, that lists which map/set parameter
+    names the CLI understands. *)
+
+val args : 'a Cli_args.t -> 'a Cli_args.t
+
+val config : 'a Cli_args.t -> 'a Cli_args.t
+
+val database : 'a Cli_args.t -> 'a Cli_args.t
+
+val device_config : 'a Cli_args.t -> 'a Cli_args.t
+
+val driver_params : 'a Cli_args.t -> 'a Cli_args.t
+
+val ha_config : 'a Cli_args.t -> 'a Cli_args.t
+
+val image_format : 'a Cli_args.t -> 'a Cli_args.t
+
+val other_config : 'a Cli_args.t -> 'a Cli_args.t
+
+val power_on_config : 'a Cli_args.t -> 'a Cli_args.t
+
+val properties : 'a Cli_args.t -> 'a Cli_args.t
+
+val remote_config : 'a Cli_args.t -> 'a Cli_args.t
+
+val schedule : 'a Cli_args.t -> 'a Cli_args.t
+
+val sm_config : 'a Cli_args.t -> 'a Cli_args.t
+
+val vdi : 'a Cli_args.t -> 'a Cli_args.t
+
+val vgpu : 'a Cli_args.t -> 'a Cli_args.t
+
+val vif : 'a Cli_args.t -> 'a Cli_args.t
+
+val xenstore_data : 'a Cli_args.t -> 'a Cli_args.t
+
+val tags : 'a Cli_args.t -> 'a Cli_args.t
+(** Set-valued: read the result with {!Cli_args.keys}. *)

--- a/ocaml/xapi-cli-server/cli_maps.mli
+++ b/ocaml/xapi-cli-server/cli_maps.mli
@@ -15,7 +15,7 @@
 (** Named views onto the map-valued parameters of an [xe] command line (the
     [name:key=value] syntax), and the set-valued parameters -- which are maps
     whose values are ignored, so read the result with {!Cli_args.keys} rather
-    than {!Cli_args.to_pairs}.
+    than {!Cli_args.map_contents}.
 
     Each accessor is [fun params -> Cli_args.view "name" params]: a lens onto the
     [name:*] entries of [params], presenting their keys with the [name:] prefix

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -454,6 +454,12 @@ let stdparams =
   ; "trace"
   ]
 
+(* [params_except extra params] is [params] with the standard framework keys
+   and [extra] removed. Used by commands that treat every remaining key=value
+   pair as data (map/set contents, event filters, report query strings). *)
+let params_except extra params =
+  List.filter (fun (k, _) -> not (List.mem k (extra @ stdparams))) params
+
 (* This goes through the list of parameters, extracting any of the form map-name-key=value   *)
 (* where map-name is the name of a map in the class. These will be used to set the key-value *)
 (* pair in the map. Returns a list of params that didn't fit this form *)
@@ -565,11 +571,7 @@ let make_param_funs getallrecs getbyuuid record class_name def_filters
             all
         in
         (* Filter on everything on the cmd line except params=... *)
-        let filter_params =
-          List.filter
-            (fun (p, _) -> not (List.mem p ("params" :: stdparams)))
-            params
-        in
+        let filter_params = params_except ["params"] params in
         (* Filter out all params beginning with "database:" *)
         let filter_params =
           List.filter
@@ -646,9 +648,7 @@ let make_param_funs getallrecs getbyuuid record class_name def_filters
   in
   let p_set (_ : printer) rpc session_id params =
     let record = get_record rpc session_id (List.assoc "uuid" params) in
-    let set_params =
-      List.filter (fun (p, _) -> not (List.mem p ("uuid" :: stdparams))) params
-    in
+    let set_params = params_except ["uuid"] params in
     (* Hashtable set_map_table contains key as set_map function
        and associated value as list of (key, value) pairs to set a map field *)
     let set_map_table :
@@ -737,11 +737,7 @@ let make_param_funs getallrecs getbyuuid record class_name def_filters
     let record = get_record rpc session_id (List.assoc "uuid" params) in
     let param_name = List.assoc "param-name" params in
     let filter_params =
-      List.filter
-        (fun (p, _) ->
-          not (List.mem p ("uuid" :: "param-name" :: "param-key" :: stdparams))
-        )
-        params
+      params_except ["uuid"; "param-name"; "param-key"] params
     in
     match field_lookup record param_name with
     | {add_to_set= Some f; _} ->
@@ -3213,9 +3209,7 @@ let event_wait_gen rpc session_id classname record_matches =
 
 let event_wait _printer rpc session_id params =
   let classname = List.assoc "class" params in
-  let filter_params =
-    List.filter (fun (p, _) -> not (List.mem p ("class" :: stdparams))) params
-  in
+  let filter_params = params_except ["class"] params in
   (* Each filter_params is a key value pair:
      	   (key, value) if the user entered "key=value"
      	   (key, "/=" value) if the user entered "key=/=value"
@@ -5800,11 +5794,7 @@ let download_file_with_task fd rpc session_id filename uri query label task_name
 let pool_retrieve_wlb_report fd _printer rpc session_id params =
   let report = List.assoc "report" params in
   let filename = Listext.assoc_default "filename" params "" in
-  let other_params =
-    List.filter
-      (fun (k, _) -> not (List.mem k (["report"; "filename"] @ stdparams)))
-      params
-  in
+  let other_params = params_except ["report"; "filename"] params in
   download_file_with_task fd rpc session_id filename Constants.wlb_report_uri
     (Printf.sprintf "report=%s%s%s" (Http.urlencode report)
        ( if other_params = [] then

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -133,18 +133,12 @@ let waiter printer rpc session_id params task =
 (* Return the list of k=v pairs for maps.
    Works for key which is not follow by a ':',
    also match old syntax 'device-config-key' for backwards compatability *)
-let read_map_params name params =
-  (* [name:key=value] pairs (also the legacy [name-key=value] form), with the
-     [name:] / [name-] prefix stripped. The contents of a map-valued parameter
-     are plain data, not tracked CLI arguments. *)
-  let len = String.length name + 1 in
-  Cli_args.to_pairs params
-  |> List.filter (fun (p, _) ->
-      Astring.String.is_prefix ~affix:name p && String.length p > len
-  )
-  |> List.map (fun (p, v) -> (String.sub p len (String.length p - len), v))
+(* The [(key, value)] contents of a map-valued parameter [name:key=value], as a
+   plain list. For reading individual keys, use [Cli_args.view name params]
+   directly with the [Cli_args] accessors. *)
+let read_map_params name params = Cli_args.to_pairs (Cli_args.view name params)
 
-let read_set_params name params = List.map fst (read_map_params name params)
+let read_set_params name params = Cli_args.keys (Cli_args.view name params)
 
 let get_chunks fd =
   let buffer = Buffer.create 10240 in
@@ -536,20 +530,20 @@ type params = string Cli_args.t
 (* open the database on the specified VDI and use the resulting session_id. *)
 (* If the parameter is not present, use the original session_id. *)
 let with_specified_database rpc session_id params f =
-  let database_params = read_map_params "database" params in
-  let use_db_vdi = List.mem_assoc "vdi-uuid" database_params in
-  let use_db_file = List.mem_assoc "filename" database_params in
+  let database_params = Cli_args.view "database" params in
+  let use_db_vdi = Cli_args.exists "vdi-uuid" database_params in
+  let use_db_file = Cli_args.exists "filename" database_params in
   if use_db_vdi && use_db_file then
     failwith "xapi can query a DB vdi or a DB file, but not both." ;
   let session_id =
     if use_db_vdi then
-      let database_vdi_uuid = List.assoc "vdi-uuid" database_params in
+      let database_vdi_uuid = Cli_args.get "vdi-uuid" database_params in
       let database_vdi =
         Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:database_vdi_uuid
       in
       Client.VDI.open_database ~rpc ~session_id ~self:database_vdi
     else if use_db_file then
-      let database_file = List.assoc "filename" database_params in
+      let database_file = Cli_args.get "filename" database_params in
       Client.Session.create_from_db_file ~rpc ~session_id
         ~filename:database_file
     else
@@ -6273,10 +6267,10 @@ let vm_vif_list printer rpc session_id params =
 (* always list multiple vms *)
 
 let with_database_vdi rpc session_id params f =
-  let database_params = read_map_params "database" params in
+  let database_params = Cli_args.view "database" params in
   let database_uuid =
-    if List.mem_assoc "vdi-uuid" database_params then
-      List.assoc "vdi-uuid" database_params
+    if Cli_args.exists "vdi-uuid" database_params then
+      Cli_args.get "vdi-uuid" database_params
     else
       failwith
         "A parameter of the form 'database:vdi-uuid=<uuid>' must be specified \

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -464,6 +464,13 @@ let params_except extra params =
    user supplied for [key] (subsequent List.assoc lookups return [value]). *)
 let override_param key value params = (key, value) :: params
 
+(* [assoc_default_ci key params] looks up [key] in [params] ignoring the case of
+   the keys, defaulting to "". *)
+let assoc_default_ci key params =
+  let key = String.lowercase_ascii key in
+  let params = List.map (fun (k, v) -> (String.lowercase_ascii k, v)) params in
+  Listext.assoc_default key params ""
+
 (* This goes through the list of parameters, extracting any of the form map-name-key=value   *)
 (* where map-name is the name of a map in the class. These will be used to set the key-value *)
 (* pair in the map. Returns a list of params that didn't fit this form *)
@@ -6648,23 +6655,16 @@ module Network_sriov = struct
 end
 
 let pif_reconfigure_ip _printer rpc session_id params =
-  let read_optional_case_insensitive key =
-    let lower_case_params =
-      List.map (fun (k, v) -> (String.lowercase_ascii k, v)) params
-    in
-    let lower_case_key = String.lowercase_ascii key in
-    Listext.assoc_default lower_case_key lower_case_params ""
-  in
   let pif =
     Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
   in
   let mode =
     Record_util.ip_configuration_mode_of_string (List.assoc "mode" params)
   in
-  let iP = read_optional_case_insensitive "IP" in
+  let iP = assoc_default_ci "IP" params in
   let netmask = Listext.assoc_default "netmask" params "" in
   let gateway = Listext.assoc_default "gateway" params "" in
-  let dNS = read_optional_case_insensitive "DNS" in
+  let dNS = assoc_default_ci "DNS" params in
   let () =
     Client.PIF.reconfigure_ip ~rpc ~session_id ~self:pif ~mode ~iP ~netmask
       ~gateway ~dNS
@@ -6672,22 +6672,15 @@ let pif_reconfigure_ip _printer rpc session_id params =
   ()
 
 let pif_reconfigure_ipv6 _printer rpc session_id params =
-  let read_optional_case_insensitive key =
-    let lower_case_params =
-      List.map (fun (k, v) -> (String.lowercase_ascii k, v)) params
-    in
-    let lower_case_key = String.lowercase_ascii key in
-    Listext.assoc_default lower_case_key lower_case_params ""
-  in
   let pif =
     Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
   in
   let mode =
     Record_util.ipv6_configuration_mode_of_string (List.assoc "mode" params)
   in
-  let iPv6 = read_optional_case_insensitive "IPv6" in
+  let iPv6 = assoc_default_ci "IPv6" params in
   let gateway = Listext.assoc_default "gateway" params "" in
-  let dNS = read_optional_case_insensitive "DNS" in
+  let dNS = assoc_default_ci "DNS" params in
   let () =
     Client.PIF.reconfigure_ipv6 ~rpc ~session_id ~self:pif ~mode ~iPv6 ~gateway
       ~dNS

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -4735,7 +4735,6 @@ let vm_migrate_sxm_params =
   ]
 
 let vm_migrate printer rpc session_id params =
-  let comp2 f g a b = f (g a b) in
   (* Hack to match host-uuid and host-name for backwards compatibility *)
   let params =
     List.map
@@ -4755,11 +4754,15 @@ let vm_migrate printer rpc session_id params =
     match List.assoc_opt key params with Some v -> [(key, v)] | None -> []
   in
   let options =
-    Listext.map_assoc_with_key
-      (comp2 string_of_bool bool_of_string)
-      (Listext.restrict_with_default "false" ["force"; "live"; "copy"] params)
+    (* For each boolean option, take the value given on the command line or
+       default to "false", then validate it and canonicalise it to
+       "true"/"false". *)
+    let bool_option key =
+      let raw = Option.value ~default:"false" (List.assoc_opt key params) in
+      (key, string_of_bool (bool_of_string key raw))
+    in
+    compress @ List.map bool_option ["force"; "live"; "copy"]
   in
-  let options = List.concat [compress; options] in
   (* We assume the user wants to do Storage XenMotion if they supply any of the
      SXM-specific parameters, and then we use the new codepath. *)
   let use_sxm_migration =

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -460,6 +460,10 @@ let stdparams =
 let params_except extra params =
   List.filter (fun (k, _) -> not (List.mem k (extra @ stdparams))) params
 
+(* [override_param key value params] prepends [key=value], overriding whatever the
+   user supplied for [key] (subsequent List.assoc lookups return [value]). *)
+let override_param key value params = (key, value) :: params
+
 (* This goes through the list of parameters, extracting any of the form map-name-key=value   *)
 (* where map-name is the name of a map in the class. These will be used to set the key-value *)
 (* pair in the map. Returns a list of params that didn't fit this form *)
@@ -3256,13 +3260,13 @@ let select_vms ?(include_control_vms = false) ?(include_template_vms = false)
   (* Make sure we don't select a template or control domain by mistake *)
   let params =
     if not include_control_vms then
-      ("is-control-domain", "false") :: params
+      override_param "is-control-domain" "false" params
     else
       params
   in
   let params =
     if not include_template_vms then
-      ("is-a-template", "false") :: params
+      override_param "is-a-template" "false" params
     else
       params
   in
@@ -6277,7 +6281,7 @@ let vm_vif_list printer rpc session_id params =
   in
   ignore
     (do_vm_op printer rpc session_id op
-       (("multiple", "true") :: params)
+       (override_param "multiple" "true" params)
        ["params"]
     )
 

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -130,16 +130,6 @@ let waiter printer rpc session_id params task =
     )
     (fun () -> Client.Task.destroy ~rpc ~session_id ~self:task)
 
-(* Return the list of k=v pairs for maps.
-   Works for key which is not follow by a ':',
-   also match old syntax 'device-config-key' for backwards compatability *)
-(* The [(key, value)] contents of a map-valued parameter [name:key=value], as a
-   plain list. For reading individual keys, use [Cli_args.view name params]
-   directly with the [Cli_args] accessors. *)
-let read_map_params name params = Cli_args.to_pairs (Cli_args.view name params)
-
-let read_set_params name params = Cli_args.keys (Cli_args.view name params)
-
 let get_chunks fd =
   let buffer = Buffer.create 10240 in
   let rec f bytes_read =
@@ -530,7 +520,7 @@ type params = string Cli_args.t
 (* open the database on the specified VDI and use the resulting session_id. *)
 (* If the parameter is not present, use the original session_id. *)
 let with_specified_database rpc session_id params f =
-  let database_params = Cli_args.view "database" params in
+  let database_params = Cli_maps.database params in
   let use_db_vdi = Cli_args.exists "vdi-uuid" database_params in
   let use_db_file = Cli_args.exists "filename" database_params in
   if use_db_vdi && use_db_file then
@@ -1528,7 +1518,7 @@ let pool_disable_binary_storage (_ : printer) rpc session_id (_ : params) =
   Client.Pool.disable_binary_storage ~rpc ~session_id
 
 let pool_ha_enable (_ : printer) rpc session_id params =
-  let configuration = read_map_params "ha-config" params in
+  let configuration = Cli_args.to_pairs (Cli_maps.ha_config params) in
   let uuids =
     Option.fold ~none:[] ~some:(String.split_on_char ',')
       (Cli_args.get_opt "heartbeat-sr-uuids" params)
@@ -1826,7 +1816,7 @@ let pool_deconfigure_wlb (_ : printer) rpc session_id (_ : params) =
   Client.Pool.deconfigure_wlb ~rpc ~session_id
 
 let pool_send_wlb_configuration (_ : printer) rpc session_id params =
-  let config = read_map_params "config" params in
+  let config = Cli_args.to_pairs (Cli_maps.config params) in
   Client.Pool.send_wlb_configuration ~rpc ~session_id ~config
 
 let pool_retrieve_wlb_configuration printer rpc session_id _params =
@@ -2056,8 +2046,8 @@ let vdi_create printer rpc session_id params =
       `user
   in
   let sharable = get_bool_param params "sharable" in
-  let sm_config = read_map_params "sm-config" params in
-  let tags = read_set_params "tags" params in
+  let sm_config = Cli_args.to_pairs (Cli_maps.sm_config params) in
+  let tags = Cli_args.keys (Cli_maps.tags params) in
   let vdi =
     Client.VDI.create ~rpc ~session_id ~name_label ~name_description:"" ~sR
       ~virtual_size ~_type:ty ~sharable ~read_only:false ~xenstore_data:[]
@@ -2084,9 +2074,9 @@ let vdi_introduce printer rpc session_id params =
   let sharable = get_bool_param params "sharable" in
   let read_only = get_bool_param params "read-only" in
   (* NB call is new so backwards compat other-config- not required *)
-  let other_config = read_map_params "other-config" params in
-  let xenstore_data = read_map_params "xenstore-data" params in
-  let sm_config = read_map_params "sm-config" params in
+  let other_config = Cli_args.to_pairs (Cli_maps.other_config params) in
+  let xenstore_data = Cli_args.to_pairs (Cli_maps.xenstore_data params) in
+  let sm_config = Cli_args.to_pairs (Cli_maps.sm_config params) in
   let location = Cli_args.get "location" params in
   let managed = get_bool_param params "managed" in
   let virtual_size = 0L and physical_utilisation = 0L in
@@ -2185,7 +2175,7 @@ let vdi_clone printer rpc session_id params =
   let vdi =
     Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
-  let driver_params = read_map_params "driver-params" params in
+  let driver_params = Cli_args.to_pairs (Cli_maps.driver_params params) in
   let name_label = Cli_args.get_opt "new-name-label" params in
   let name_description = Cli_args.get_opt "new-name-description" params in
   let newvdi = Client.VDI.clone ~rpc ~session_id ~vdi ~driver_params in
@@ -2204,7 +2194,7 @@ let vdi_snapshot printer rpc session_id params =
   let vdi =
     Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
-  let driver_params = read_map_params "driver-params" params in
+  let driver_params = Cli_args.to_pairs (Cli_maps.driver_params params) in
   let newvdi = Client.VDI.snapshot ~rpc ~session_id ~vdi ~driver_params in
   let newuuid = Client.VDI.get_uuid ~rpc ~session_id ~self:newvdi in
   printer (Cli_printer.PList [newuuid])
@@ -2626,7 +2616,7 @@ let sr_create fd _printer rpc session_id params =
   in
   let _type = Cli_args.get "type" params in
   let content_type = Cli_args.get_default "content-type" params "" in
-  let device_config = read_map_params "device-config" params in
+  let device_config = Cli_args.to_pairs (Cli_maps.device_config params) in
   (* If the device-config parameter is of the form k-filename=v, then we assume the
      	   key is 'k' and the value is stored in a file named 'v' *)
   let suffix = "-filename" in
@@ -2647,7 +2637,7 @@ let sr_create fd _printer rpc session_id params =
       )
       device_config
   in
-  let sm_config = read_map_params "sm-config" params in
+  let sm_config = Cli_args.to_pairs (Cli_maps.sm_config params) in
   let sr =
     Client.SR.create ~rpc ~session_id ~host ~device_config ~name_label
       ~name_description ~physical_size ~_type ~content_type ~shared ~sm_config
@@ -2662,7 +2652,7 @@ let sr_introduce printer rpc session_id params =
   let content_type = Cli_args.get_default "content-type" params "" in
   let uuid = Cli_args.get "uuid" params in
   let shared = get_bool_param params "shared" in
-  let sm_config = read_map_params "sm-config" params in
+  let sm_config = Cli_args.to_pairs (Cli_maps.sm_config params) in
   let _ =
     Client.SR.introduce ~rpc ~session_id ~uuid ~name_label ~name_description
       ~_type ~content_type ~shared ~sm_config
@@ -2675,8 +2665,8 @@ type probe_result = Raw of string (* SMAPIv1 adapters return arbitrary data *)
 let sr_probe printer rpc session_id params =
   let host = parse_host_uuid rpc session_id params in
   let _type = Cli_args.get "type" params in
-  let device_config = read_map_params "device-config" params in
-  let sm_config = read_map_params "sm-config" params in
+  let device_config = Cli_args.to_pairs (Cli_maps.device_config params) in
+  let sm_config = Cli_args.to_pairs (Cli_maps.sm_config params) in
   let txt =
     Client.SR.probe ~rpc ~session_id ~host ~_type ~device_config ~sm_config
   in
@@ -2694,8 +2684,8 @@ let sr_probe printer rpc session_id params =
 let sr_probe_ext printer rpc session_id params =
   let host = parse_host_uuid rpc session_id params in
   let _type = Cli_args.get "type" params in
-  let device_config = read_map_params "device-config" params in
-  let sm_config = read_map_params "sm-config" params in
+  let device_config = Cli_args.to_pairs (Cli_maps.device_config params) in
+  let sm_config = Cli_args.to_pairs (Cli_maps.sm_config params) in
   let results =
     Client.SR.probe_ext ~rpc ~session_id ~host ~device_config ~_type ~sm_config
   in
@@ -2804,7 +2794,7 @@ let sr_disable_database_replication _printer rpc session_id params =
 let pbd_create printer rpc session_id params =
   let host_uuid = Cli_args.get "host-uuid" params in
   let sr_uuid = Cli_args.get "sr-uuid" params in
-  let device_config = read_map_params "device-config" params in
+  let device_config = Cli_args.to_pairs (Cli_maps.device_config params) in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
   let sR = Client.SR.get_by_uuid ~rpc ~session_id ~uuid:sr_uuid in
   let pbd =
@@ -3627,7 +3617,7 @@ let vm_call_plugin fd printer rpc session_id params =
   let vm = Client.VM.get_by_uuid ~rpc ~session_id ~uuid:vm_uuid in
   let plugin = Cli_args.get "plugin" params in
   let fn = Cli_args.get "fn" params in
-  let args = read_map_params "args" params in
+  let args = Cli_args.to_pairs (Cli_maps.args params) in
   let args = List.map (args_file fd) args in
   let result = Client.VM.call_plugin ~rpc ~session_id ~vm ~plugin ~fn ~args in
   printer (Cli_printer.PList [result])
@@ -3637,7 +3627,7 @@ let vm_call_host_plugin fd printer rpc session_id params =
   let vm = Client.VM.get_by_uuid ~rpc ~session_id ~uuid:vm_uuid in
   let plugin = Cli_args.get "plugin" params in
   let fn = Cli_args.get "fn" params in
-  let args = read_map_params "args" params in
+  let args = Cli_args.to_pairs (Cli_maps.args params) in
   let args = List.map (args_file fd) args in
   let result =
     Client.VM.call_host_plugin ~rpc ~session_id ~vm ~plugin ~fn ~args
@@ -4849,7 +4839,7 @@ let vm_migrate printer rpc session_id params =
               let net = remote Client.Network.get_by_uuid ~uuid:net_uuid in
               (vif, net)
             )
-            (read_map_params "vif" params)
+            (Cli_args.to_pairs (Cli_maps.vif params))
         in
         let vdi_map =
           List.map
@@ -4860,7 +4850,7 @@ let vm_migrate printer rpc session_id params =
               let sr = remote Client.SR.get_by_uuid ~uuid:sr_uuid in
               (vdi, sr)
             )
-            (read_map_params "vdi" params)
+            (Cli_args.to_pairs (Cli_maps.vdi params))
         in
         let vgpu_map =
           List.map
@@ -4873,7 +4863,7 @@ let vm_migrate printer rpc session_id params =
               in
               (vgpu, gpu_group)
             )
-            (read_map_params "vgpu" params)
+            (Cli_args.to_pairs (Cli_maps.vgpu params))
         in
         let preferred_sr =
           (* The preferred SR is determined to be as the SR that the
@@ -5043,7 +5033,7 @@ let vm_migrate printer rpc session_id params =
               in
               (vdi, vdi_fmt)
             )
-            (read_map_params "image-format" params)
+            (Cli_args.to_pairs (Cli_maps.image_format params))
         in
         let new_vm =
           do_vm_op ~include_control_vms:false ~include_template_vms:true printer
@@ -5820,7 +5810,7 @@ let vm_import fd _printer rpc session_id params =
   let vm_metadata_only = get_bool_param params "metadata" in
   let force = get_bool_param params "force" in
   let dry_run = get_bool_param params "dry-run" in
-  let vdi_map = read_map_params "vdi" params in
+  let vdi_map = Cli_args.to_pairs (Cli_maps.vdi params) in
   if Cli_args.exists "url" params && Cli_args.exists "filename" params then (
     marshal fd
       (Command
@@ -5834,7 +5824,7 @@ let vm_import fd _printer rpc session_id params =
   if Vpx_types.of_string _type <> Vpx_types.XenServer then
     let username = Cli_args.get "host-username" params in
     let password = Cli_args.get "host-password" params in
-    let remote_config = read_map_params "remote-config" params in
+    let remote_config = Cli_args.to_pairs (Cli_maps.remote_config params) in
     Client.VM.import_convert ~rpc ~session_id ~_type ~username ~password ~sr
       ~remote_config
   else if Cli_args.exists "url" params then
@@ -6267,7 +6257,7 @@ let vm_vif_list printer rpc session_id params =
 (* always list multiple vms *)
 
 let with_database_vdi rpc session_id params f =
-  let database_params = Cli_args.view "database" params in
+  let database_params = Cli_maps.database params in
   let database_uuid =
     if Cli_args.exists "vdi-uuid" database_params then
       Cli_args.get "vdi-uuid" database_params
@@ -6733,7 +6723,7 @@ let bond_create printer rpc session_id params =
   let mode =
     Record_util.bond_mode_of_string (Cli_args.get_default "mode" params "")
   in
-  let properties = read_map_params "properties" params in
+  let properties = Cli_args.to_pairs (Cli_maps.properties params) in
   let bond =
     Client.Bond.create ~rpc ~session_id ~network ~members:pifs ~mAC ~mode
       ~properties
@@ -6873,7 +6863,7 @@ let pool_apply_edition printer rpc session_id params =
 
 let host_set_power_on_mode _printer rpc session_id params =
   let power_on_mode = Cli_args.get "power-on-mode" params in
-  let power_on_config = read_map_params "power-on-config" params in
+  let power_on_config = Cli_args.to_pairs (Cli_maps.power_on_config params) in
   ignore
     (do_host_op rpc session_id
        (fun _ host ->
@@ -7003,13 +6993,13 @@ let pool_enable_external_auth _printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
   let auth_type = Cli_args.get "auth-type" params in
   let service_name = Cli_args.get "service-name" params in
-  let config = read_map_params "config" params in
+  let config = Cli_args.to_pairs (Cli_maps.config params) in
   Client.Pool.enable_external_auth ~rpc ~session_id ~pool ~config ~service_name
     ~auth_type
 
 let pool_disable_external_auth _printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
-  let config = read_map_params "config" params in
+  let config = Cli_args.to_pairs (Cli_maps.config params) in
   Client.Pool.disable_external_auth ~rpc ~session_id ~pool ~config
 
 let pool_external_auth_set_ldaps _printer rpc session_id params =
@@ -7164,7 +7154,7 @@ let host_call_plugin fd printer rpc session_id params =
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
   let plugin = Cli_args.get "plugin" params in
   let fn = Cli_args.get "fn" params in
-  let args = read_map_params "args" params in
+  let args = Cli_args.to_pairs (Cli_maps.args params) in
   let args = List.map (args_file fd) args in
   let result =
     Client.Host.call_plugin ~rpc ~session_id ~host ~plugin ~fn ~args
@@ -7180,7 +7170,7 @@ let host_enable_external_auth _printer rpc session_id params =
   let host_uuid = Cli_args.get "host-uuid" params in
   let auth_type = Cli_args.get "auth-type" params in
   let service_name = Cli_args.get "service-name" params in
-  let config = read_map_params "config" params in
+  let config = Cli_args.to_pairs (Cli_maps.config params) in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
   Client.Host.enable_external_auth ~rpc ~session_id ~host ~config ~service_name
     ~auth_type
@@ -7193,7 +7183,7 @@ let host_disable_external_auth _printer rpc session_id params =
        must be forced (use --force)." ;
   let host_uuid = Cli_args.get "host-uuid" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
-  let config = read_map_params "config" params in
+  let config = Cli_args.to_pairs (Cli_maps.config params) in
   Client.Host.disable_external_auth ~rpc ~session_id ~host ~config ~force:true
 
 let host_external_auth_set_ldaps _printer rpc session_id params =
@@ -7612,7 +7602,7 @@ let session_subject_identifier_logout_all _printer rpc session_id _params =
 
 let secret_create printer rpc session_id params =
   let value = Cli_args.get "value" params in
-  let other_config = read_map_params "other-config" params in
+  let other_config = Cli_args.to_pairs (Cli_maps.other_config params) in
   let ref = Client.Secret.create ~rpc ~session_id ~value ~other_config in
   let uuid = Client.Secret.get_uuid ~rpc ~session_id ~self:ref in
   printer (Cli_printer.PList [uuid])
@@ -7636,7 +7626,7 @@ let vmss_create printer rpc session_id params =
   let name_label = Cli_args.get "name-label" params in
   let ty = Record_util.vmss_type_of_string (get "type") in
   let frequency = Record_util.vmss_frequency_of_string (get "frequency") in
-  let schedule = read_map_params "schedule" params in
+  let schedule = Cli_args.to_pairs (Cli_maps.schedule params) in
   (* optional parameters with default values *)
   let name_description = get "name-description" ~default:"" in
   let enabled = get_bool_param ~default:true params "enabled" in
@@ -7772,7 +7762,7 @@ let vgpu_destroy _printer rpc session_id params =
 
 let dr_task_create printer rpc session_id params =
   let _type = Cli_args.get "type" params in
-  let device_config = read_map_params "device-config" params in
+  let device_config = Cli_args.to_pairs (Cli_maps.device_config params) in
   let whitelist =
     if Cli_args.exists "sr-whitelist" params then
       String.split_on_char ',' (Cli_args.get "sr-whitelist" params)

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -460,9 +460,9 @@ let assoc_default_ci key params =
 (* where map-name is the name of a map in the class. These will be used to set the key-value *)
 (* pair in the map. Returns a list of params that didn't fit this form *)
 
-let choose_params params defaults =
-  if Cli_args.exists "params" params then
-    let ps = Cli_args.get "params" params in
+let choose_params ?(key = "params") params defaults =
+  if Cli_args.exists key params then
+    let ps = Cli_args.get key params in
     if ps = "all" then
       []
     else
@@ -470,8 +470,8 @@ let choose_params params defaults =
   else
     defaults
 
-let select_fields params records default_params =
-  let params = choose_params params default_params in
+let select_fields ?(key = "params") params records default_params =
+  let params = choose_params ~key params default_params in
   if params = [] then
     List.map (fun record -> record.fields) records
   else
@@ -5100,34 +5100,13 @@ let vm_disk_list_aux vm is_cd_list printer rpc session_id params =
       )
       vbds
   in
-  (* Hack - convert 'vbd-params' to 'params' *)
-  let params' =
-    Cli_args.to_pairs params
-    |> List.map (fun (a, b) ->
-        if a = "vbd-params" then
-          ("params", b)
-        else
-          (a, b)
-    )
-    |> Cli_args.from_pairs
-  in
   let selectedvbd =
-    select_fields params' vbdrecords
+    select_fields ~key:"vbd-params" params vbdrecords
       ( if is_cd_list then
           ["uuid"; "vm-name-label"; "userdevice"; "empty"]
         else
           ["uuid"; "vm-name-label"; "userdevice"]
       )
-  in
-  let params' =
-    Cli_args.to_pairs params
-    |> List.map (fun (a, b) ->
-        if a = "vdi-params" then
-          ("params", b)
-        else
-          (a, b)
-    )
-    |> Cli_args.from_pairs
   in
   let rec doit vbds vdis n =
     match (vbds, vdis) with
@@ -5149,7 +5128,7 @@ let vm_disk_list_aux vm is_cd_list printer rpc session_id params =
         | Some vdi ->
             let selectedvdi =
               List.hd
-                (select_fields params' [vdi]
+                (select_fields ~key:"vdi-params" params [vdi]
                    ["uuid"; "name-label"; "virtual-size"; "sr-name-label"]
                 )
             in

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -40,20 +40,20 @@ let bool_of_string param string =
     raise (Record_util.Record_failure msg)
 
 let get_bool_param params ?(default = false) param =
-  List.assoc_opt param params
+  Cli_args.get_opt param params
   |> Option.map (bool_of_string param)
   |> Option.value ~default
 
 let get_float_param params param ~default =
-  List.assoc_opt param params
+  Cli_args.get_opt param params
   |> Fun.flip Option.bind float_of_string_opt
   |> Option.value ~default
 
 let get_param params param ~default =
-  Option.value ~default (List.assoc_opt param params)
+  Option.value ~default (Cli_args.get_opt param params)
 
 let get_set_param params ?(default = []) param =
-  List.assoc_opt param params
+  Cli_args.get_opt param params
   |> Option.map (String.split_on_char ',')
   |> Option.value ~default
 
@@ -68,17 +68,17 @@ let get_map_param params ?(default = []) param =
             None
     )
   in
-  List.assoc_opt param params |> Option.map get_map |> Option.value ~default
+  Cli_args.get_opt param params |> Option.map get_map |> Option.value ~default
 
 (** [get_unique_param param params] is intended to replace [List.assoc_opt] in
     the cases where a parameter can only exist once, as repeating it might
     force the CLI to make choices the user didn't foresee. In those cases
     raises an exception to warn the user to input it only once *)
 let get_unique_param param params =
-  match List.find_all (fun (n, _) -> n = param) params with
+  match Cli_args.get_all param params with
   | [] ->
       None
-  | [(_, value)] ->
+  | [value] ->
       Some value
   | _ :: _ :: _ ->
       failwith
@@ -121,7 +121,7 @@ let wait _printer rpc session_id task =
 let waiter printer rpc session_id params task =
   finally
     (fun () ->
-      ( if List.mem_assoc "progress" params then
+      ( if Cli_args.exists "progress" params then
           wait_with_progress_bar
         else
           wait
@@ -134,18 +134,15 @@ let waiter printer rpc session_id params task =
    Works for key which is not follow by a ':',
    also match old syntax 'device-config-key' for backwards compatability *)
 let read_map_params name params =
+  (* [name:key=value] pairs (also the legacy [name-key=value] form), with the
+     [name:] / [name-] prefix stripped. The contents of a map-valued parameter
+     are plain data, not tracked CLI arguments. *)
   let len = String.length name + 1 in
-  (* include ':' *)
-  let filter_params =
-    List.filter
-      (fun (p, _) ->
-        Astring.String.is_prefix ~affix:name p && String.length p > len
-      )
-      params
-  in
-  List.map
-    (fun (k, v) -> (String.sub k len (String.length k - len), v))
-    filter_params
+  Cli_args.to_pairs params
+  |> List.filter (fun (p, _) ->
+      Astring.String.is_prefix ~affix:name p && String.length p > len
+  )
+  |> List.map (fun (p, v) -> (String.sub p len (String.length p - len), v))
 
 let read_set_params name params = List.map fst (read_map_params name params)
 
@@ -268,9 +265,9 @@ let create_owner_vbd_and_plug rpc session_id vm vdi device_name bootable rw cd
    --------------------------------------------------------------------- *)
 
 let user_password_change _ rpc session_id params =
-  let old_pwd = Listext.assoc_default "old" params ""
+  let old_pwd = Cli_args.get_default "old" params ""
   (* "new" must be in params here, since it is a required parameter. *)
-  and new_pwd = List.assoc "new" params in
+  and new_pwd = Cli_args.get "new" params in
   Client.Session.change_password ~rpc ~session_id ~old_pwd ~new_pwd
 
 (** Low level CLI interface **)
@@ -454,30 +451,34 @@ let stdparams =
   ; "trace"
   ]
 
-(* [params_except extra params] is [params] with the standard framework keys
-   and [extra] removed. Used by commands that treat every remaining key=value
-   pair as data (map/set contents, event filters, report query strings). *)
+(* [params_except extra params] is the [(key, value)] pairs of [params] with the
+   standard framework keys and [extra] removed. Used by commands that treat every
+   remaining pair as data (map/set contents, event filters, report query
+   strings); it is the boundary past which the command line is plain data rather
+   than tracked CLI arguments. *)
 let params_except extra params =
-  List.filter (fun (k, _) -> not (List.mem k (extra @ stdparams))) params
+  Cli_args.to_pairs params
+  |> List.filter (fun (k, _) -> not (List.mem k (extra @ stdparams)))
 
 (* [override_param key value params] prepends [key=value], overriding whatever the
-   user supplied for [key] (subsequent List.assoc lookups return [value]). *)
-let override_param key value params = (key, value) :: params
+   user supplied for [key] (subsequent lookups return [value]). *)
+let override_param = Cli_args.add
 
 (* [assoc_default_ci key params] looks up [key] in [params] ignoring the case of
    the keys, defaulting to "". *)
 let assoc_default_ci key params =
   let key = String.lowercase_ascii key in
-  let params = List.map (fun (k, v) -> (String.lowercase_ascii k, v)) params in
-  Listext.assoc_default key params ""
+  Cli_args.to_pairs params
+  |> List.map (fun (k, v) -> (String.lowercase_ascii k, v))
+  |> fun params -> Listext.assoc_default key params ""
 
 (* This goes through the list of parameters, extracting any of the form map-name-key=value   *)
 (* where map-name is the name of a map in the class. These will be used to set the key-value *)
 (* pair in the map. Returns a list of params that didn't fit this form *)
 
 let choose_params params defaults =
-  if List.mem_assoc "params" params then
-    let ps = List.assoc "params" params in
+  if Cli_args.exists "params" params then
+    let ps = Cli_args.get "params" params in
     if ps = "all" then
       []
     else
@@ -529,7 +530,7 @@ type printer = Cli_printer.print_fn
 
 type rpc = Rpc.call -> Rpc.response
 
-type params = (string * string) list
+type params = string Cli_args.t
 
 (* Check the params for "database:vdi-uuid=" - if this parameter is present, *)
 (* open the database on the specified VDI and use the resulting session_id. *)
@@ -630,19 +631,19 @@ let make_param_funs getallrecs getbyuuid record class_name def_filters
   in
   let p_list printer rpc session_id params : unit =
     with_specified_database rpc session_id params (fun session_id ->
-        let record = get_record rpc session_id (List.assoc "uuid" params) in
+        let record = get_record rpc session_id (Cli_args.get "uuid" params) in
         let record = List.filter (fun field -> not field.hidden) record in
         printer (Cli_printer.PTable [List.map print_field record])
     )
   in
   let p_get printer rpc session_id params : unit =
     with_specified_database rpc session_id params (fun session_id ->
-        let record = get_record rpc session_id (List.assoc "uuid" params) in
-        let param = List.assoc "param-name" params in
+        let record = get_record rpc session_id (Cli_args.get "uuid" params) in
+        let param = Cli_args.get "param-name" params in
         let x = field_lookup record param in
         let std () = printer (Cli_printer.PList [safe_get_field x]) in
-        if List.mem_assoc "param-key" params then
-          let key = List.assoc "param-key" params in
+        if Cli_args.exists "param-key" params then
+          let key = Cli_args.get "param-key" params in
           match x.get_map with
           | Some f ->
               let result =
@@ -658,7 +659,7 @@ let make_param_funs getallrecs getbyuuid record class_name def_filters
     )
   in
   let p_set (_ : printer) rpc session_id params =
-    let record = get_record rpc session_id (List.assoc "uuid" params) in
+    let record = get_record rpc session_id (Cli_args.get "uuid" params) in
     let set_params = params_except ["uuid"] params in
     (* Hashtable set_map_table contains key as set_map function
        and associated value as list of (key, value) pairs to set a map field *)
@@ -745,15 +746,15 @@ let make_param_funs getallrecs getbyuuid record class_name def_filters
     Hashtbl.iter (fun func params -> func params) set_map_table
   in
   let p_add (_ : printer) rpc session_id params =
-    let record = get_record rpc session_id (List.assoc "uuid" params) in
-    let param_name = List.assoc "param-name" params in
+    let record = get_record rpc session_id (Cli_args.get "uuid" params) in
+    let param_name = Cli_args.get "param-name" params in
     let filter_params =
       params_except ["uuid"; "param-name"; "param-key"] params
     in
     match field_lookup record param_name with
     | {add_to_set= Some f; _} ->
-        if List.mem_assoc "param-key" params then
-          let key = List.assoc "param-key" params in
+        if Cli_args.exists "param-key" params then
+          let key = Cli_args.get "param-key" params in
           f key
         else
           failwith
@@ -768,9 +769,9 @@ let make_param_funs getallrecs getbyuuid record class_name def_filters
         failwith "Can only add to parameters of type Set or Map"
   in
   let p_remove (_ : printer) rpc session_id params =
-    let record = get_record rpc session_id (List.assoc "uuid" params) in
-    let param_name = List.assoc "param-name" params in
-    let param_key = List.assoc "param-key" params in
+    let record = get_record rpc session_id (Cli_args.get "uuid" params) in
+    let param_name = Cli_args.get "param-name" params in
+    let param_key = Cli_args.get "param-key" params in
     match field_lookup record param_name with
     | {get_set= Some g; remove_from_set= Some f; _} ->
         if List.mem param_key (g ()) then
@@ -789,8 +790,8 @@ let make_param_funs getallrecs getbyuuid record class_name def_filters
         failwith "Can only remove from parameters of type Set or Map"
   in
   let p_clear (_ : printer) rpc session_id params =
-    let record = get_record rpc session_id (List.assoc "uuid" params) in
-    let param_name = List.assoc "param-name" params in
+    let record = get_record rpc session_id (Cli_args.get "uuid" params) in
+    let param_name = Cli_args.get "param-name" params in
     match field_lookup record param_name with
     | {get_set= Some f; remove_from_set= Some g; _} ->
         List.iter g (f ())
@@ -1439,21 +1440,21 @@ let gen_cmds rpc session_id =
     ]
 
 let message_create (_ : printer) rpc session_id params =
-  let body = List.assoc "body" params in
+  let body = Cli_args.get "body" params in
   let priority =
-    try Int64.of_string (List.assoc "priority" params)
+    try Int64.of_string (Cli_args.get "priority" params)
     with _ -> failwith "Priority field should be an integer"
   in
-  let name = List.assoc "name" params in
+  let name = Cli_args.get "name" params in
   let obj_uuid, cls =
-    if List.mem_assoc "vm-uuid" params then
-      (List.assoc "vm-uuid" params, `VM)
-    else if List.mem_assoc "pool-uuid" params then
-      (List.assoc "pool-uuid" params, `Pool)
-    else if List.mem_assoc "sr-uuid" params then
-      (List.assoc "sr-uuid" params, `SR)
-    else if List.mem_assoc "host-uuid" params then
-      (List.assoc "host-uuid" params, `Host)
+    if Cli_args.exists "vm-uuid" params then
+      (Cli_args.get "vm-uuid" params, `VM)
+    else if Cli_args.exists "pool-uuid" params then
+      (Cli_args.get "pool-uuid" params, `Pool)
+    else if Cli_args.exists "sr-uuid" params then
+      (Cli_args.get "sr-uuid" params, `SR)
+    else if Cli_args.exists "host-uuid" params then
+      (Cli_args.get "host-uuid" params, `Host)
     else
       raise
         (Cli_util.Cli_failure
@@ -1465,8 +1466,8 @@ let message_create (_ : printer) rpc session_id params =
 
 let message_destroy (_ : printer) rpc session_id params =
   let fail msg = raise (Cli_util.Cli_failure msg) in
-  let uuid = List.assoc_opt "uuid" params in
-  let uuids = List.assoc_opt "uuids" params in
+  let uuid = Cli_args.get_opt "uuid" params in
+  let uuids = Cli_args.get_opt "uuids" params in
   let uuids =
     match (uuid, uuids) with
     | Some uuid, None ->
@@ -1486,9 +1487,9 @@ let message_destroy (_ : printer) rpc session_id params =
 
 let message_destroy_all (_ : printer) rpc session_id params =
   let fail msg = raise (Cli_util.Cli_failure msg) in
-  let before_str = List.assoc_opt "before" params in
-  let after_str = List.assoc_opt "after" params in
-  let priority_str = List.assoc_opt "priority" params in
+  let before_str = Cli_args.get_opt "before" params in
+  let after_str = Cli_args.get_opt "after" params in
+  let priority_str = Cli_args.get_opt "priority" params in
   let before =
     try Option.map Date.of_iso8601 before_str
     with _ ->
@@ -1520,8 +1521,8 @@ let message_destroy_all (_ : printer) rpc session_id params =
 (* Pool operations *)
 
 let get_pool_with_default rpc session_id params key =
-  if List.mem_assoc key params then (* User provided a pool uuid. *)
-    let pool_uuid = List.assoc key params in
+  if Cli_args.exists key params then (* User provided a pool uuid. *)
+    let pool_uuid = Cli_args.get key params in
     Client.Pool.get_by_uuid ~rpc ~session_id ~uuid:pool_uuid
   else (* User didn't provide a pool uuid: let's fetch the default pool. *)
     List.hd (Client.Pool.get_all ~rpc ~session_id)
@@ -1536,7 +1537,7 @@ let pool_ha_enable (_ : printer) rpc session_id params =
   let configuration = read_map_params "ha-config" params in
   let uuids =
     Option.fold ~none:[] ~some:(String.split_on_char ',')
-      (List.assoc_opt "heartbeat-sr-uuids" params)
+      (Cli_args.get_opt "heartbeat-sr-uuids" params)
   in
   let srs =
     List.map (fun uuid -> Client.SR.get_by_uuid ~rpc ~session_id ~uuid) uuids
@@ -1547,7 +1548,7 @@ let pool_ha_disable (_ : printer) rpc session_id (_ : params) =
   Client.Pool.disable_ha ~rpc ~session_id
 
 let pool_ha_prevent_restarts_for (_ : printer) rpc session_id params =
-  let seconds = Int64.of_string (List.assoc "seconds" params) in
+  let seconds = Int64.of_string (Cli_args.get "seconds" params) in
   Client.Pool.ha_prevent_restarts_for ~rpc ~session_id ~seconds
 
 let pool_ha_compute_max_host_failures_to_tolerate printer rpc session_id
@@ -1560,10 +1561,8 @@ let pool_ha_compute_max_host_failures_to_tolerate printer rpc session_id
 let pool_ha_compute_hypothetical_max_host_failures_to_tolerate printer rpc
     session_id params =
   (* Walk through the params in order constructing a VM -> restart_priority map *)
-  let vms = List.map snd (List.filter (fun (k, _) -> k = "vm-uuid") params)
-  and pri =
-    List.map snd (List.filter (fun (k, _) -> k = "restart-priority") params)
-  in
+  let vms = Cli_args.get_all "vm-uuid" params
+  and pri = Cli_args.get_all "restart-priority" params in
   if List.length vms <> List.length pri then
     failwith
       "Call requires an equal number of vm-uuid and restart-priority arguments" ;
@@ -1577,7 +1576,9 @@ let pool_ha_compute_hypothetical_max_host_failures_to_tolerate printer rpc
   printer (Cli_printer.PList [Int64.to_string n])
 
 let pool_ha_compute_vm_failover_plan printer rpc session_id params =
-  let host_uuids = String.split_on_char ',' (List.assoc "host-uuids" params) in
+  let host_uuids =
+    String.split_on_char ',' (Cli_args.get "host-uuids" params)
+  in
   let hosts =
     List.map
       (fun uuid -> Client.Host.get_by_uuid ~rpc ~session_id ~uuid)
@@ -1644,23 +1645,23 @@ let pool_sync_database (_ : printer) rpc session_id (_ : params) =
   Client.Pool.sync_database ~rpc ~session_id
 
 let pool_designate_new_master (_ : printer) rpc session_id params =
-  let uuid = List.assoc "host-uuid" params in
+  let uuid = Cli_args.get "host-uuid" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid in
   Client.Pool.designate_new_master ~rpc ~session_id ~host
 
 let pool_management_reconfigure (_ : printer) rpc session_id params =
   let network =
     Client.Network.get_by_uuid ~rpc ~session_id
-      ~uuid:(List.assoc "network-uuid" params)
+      ~uuid:(Cli_args.get "network-uuid" params)
   in
   Client.Pool.management_reconfigure ~rpc ~session_id ~network
 
 let pool_join printer rpc session_id params =
   try
     let force = get_bool_param params "force" in
-    let master_address = List.assoc "master-address" params in
-    let master_username = List.assoc "master-username" params in
-    let master_password = List.assoc "master-password" params in
+    let master_address = Cli_args.get "master-address" params in
+    let master_username = Cli_args.get "master-username" params in
+    let master_password = Cli_args.get "master-password" params in
     if force then
       Client.Pool.join_force ~rpc ~session_id ~master_address ~master_username
         ~master_password
@@ -1689,7 +1690,7 @@ let pool_join printer rpc session_id params =
       )
 
 let pool_eject fd printer rpc session_id params =
-  let uuid = List.assoc "host-uuid" params in
+  let uuid = Cli_args.get "host-uuid" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid in
   let force = get_bool_param params "force" in
   let go () =
@@ -1775,7 +1776,7 @@ let pool_eject fd printer rpc session_id params =
     if user_says_yes fd then go ()
 
 let pool_emergency_reset_master printer rpc session_id params =
-  let master_address = List.assoc "master-address" params in
+  let master_address = Cli_args.get "master-address" params in
   Client.Pool.emergency_reset_master ~rpc ~session_id ~master_address ;
   printer
     (Cli_printer.PList
@@ -1819,11 +1820,11 @@ let pool_recover_slaves printer rpc session_id (_ : params) =
   printer (Cli_printer.PList host_uuids)
 
 let pool_initialize_wlb (_ : printer) rpc session_id params =
-  let wlb_url = List.assoc "wlb_url" params in
-  let wlb_username = List.assoc "wlb_username" params in
-  let wlb_password = List.assoc "wlb_password" params in
-  let xenserver_username = List.assoc "xenserver_username" params in
-  let xenserver_password = List.assoc "xenserver_password" params in
+  let wlb_url = Cli_args.get "wlb_url" params in
+  let wlb_username = Cli_args.get "wlb_username" params in
+  let wlb_password = Cli_args.get "wlb_password" params in
+  let xenserver_username = Cli_args.get "xenserver_username" params in
+  let xenserver_password = Cli_args.get "xenserver_password" params in
   Client.Pool.initialize_wlb ~rpc ~session_id ~wlb_url ~wlb_username
     ~wlb_password ~xenserver_username ~xenserver_password
 
@@ -1831,19 +1832,7 @@ let pool_deconfigure_wlb (_ : printer) rpc session_id (_ : params) =
   Client.Pool.deconfigure_wlb ~rpc ~session_id
 
 let pool_send_wlb_configuration (_ : printer) rpc session_id params =
-  let len = String.length "config:" in
-  let filter_params =
-    List.filter
-      (fun (p, _) ->
-        Astring.String.is_prefix ~affix:"config" p && String.length p > len
-      )
-      params
-  in
-  let config =
-    List.map
-      (fun (k, v) -> (String.sub k len (String.length k - len), v))
-      filter_params
-  in
+  let config = read_map_params "config" params in
   Client.Pool.send_wlb_configuration ~rpc ~session_id ~config
 
 let pool_retrieve_wlb_configuration printer rpc session_id _params =
@@ -1873,16 +1862,16 @@ let pool_retrieve_wlb_recommendations printer rpc session_id _params =
     )
 
 let pool_send_test_post printer rpc session_id params =
-  let host = List.assoc "dest-host" params in
-  let port = Int64.of_string (List.assoc "dest-port" params) in
-  let body = List.assoc "body" params in
+  let host = Cli_args.get "dest-host" params in
+  let port = Int64.of_string (Cli_args.get "dest-port" params) in
+  let body = Cli_args.get "body" params in
   printer
     (Cli_printer.PMsg
        (Client.Pool.send_test_post ~rpc ~session_id ~host ~port ~body)
     )
 
 let pool_install_ca_certificate fd _printer rpc session_id params =
-  let filename = List.assoc "filename" params in
+  let filename = Cli_args.get "filename" params in
   match get_client_file fd filename with
   | Some cert ->
       Client.Pool.install_ca_certificate ~rpc ~session_id
@@ -1893,7 +1882,7 @@ let pool_install_ca_certificate fd _printer rpc session_id params =
       raise (ExitWithError 1)
 
 let pool_uninstall_ca_certificate _printer rpc session_id params =
-  let name = List.assoc "name" params in
+  let name = Cli_args.get "name" params in
   let force = get_bool_param params "force" in
   Client.Pool.uninstall_ca_certificate ~rpc ~session_id ~name ~force
 
@@ -1901,7 +1890,7 @@ let pool_certificate_list printer rpc session_id _params =
   printer (Cli_printer.PList (Client.Pool.certificate_list ~rpc ~session_id))
 
 let pool_crl_install fd _printer rpc session_id params =
-  let filename = List.assoc "filename" params in
+  let filename = Cli_args.get "filename" params in
   match get_client_file fd filename with
   | Some cert ->
       Client.Pool.crl_install ~rpc ~session_id
@@ -1912,7 +1901,7 @@ let pool_crl_install fd _printer rpc session_id params =
       raise (ExitWithError 1)
 
 let pool_crl_uninstall _printer rpc session_id params =
-  let name = List.assoc "name" params in
+  let name = Cli_args.get "name" params in
   Client.Pool.crl_uninstall ~rpc ~session_id ~name
 
 let pool_crl_list printer rpc session_id _params =
@@ -1923,7 +1912,7 @@ let pool_certificate_sync _printer rpc session_id _params =
 
 let pool_enable_redo_log _printer rpc session_id params =
   let sr =
-    Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "sr-uuid" params)
+    Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "sr-uuid" params)
   in
   Client.Pool.enable_redo_log ~rpc ~session_id ~sr
 
@@ -1931,7 +1920,7 @@ let pool_disable_redo_log _printer rpc session_id _params =
   Client.Pool.disable_redo_log ~rpc ~session_id
 
 let pool_set_vswitch_controller _printer rpc session_id params =
-  let address = List.assoc "address" params in
+  let address = Cli_args.get "address" params in
   Client.Pool.set_vswitch_controller ~rpc ~session_id ~address
 
 let pool_disable_ssl_legacy _printer _rpc _session_id _params =
@@ -1945,7 +1934,7 @@ let pool_enable_tls_verification _printer rpc session_id _params =
 
 let pool_enable_client_certificate_auth _printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
-  let name = List.assoc "name" params in
+  let name = Cli_args.get "name" params in
   Client.Pool.enable_client_certificate_auth ~rpc ~session_id ~self:pool ~name
 
 let pool_disable_client_certificate_auth _printer rpc session_id params =
@@ -1967,7 +1956,7 @@ let pool_sync_updates printer rpc session_id params =
 
 let pool_configure_repository_proxy _printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
-  let url = List.assoc "proxy-url" params in
+  let url = Cli_args.get "proxy-url" params in
   let username = get_param params "proxy-username" ~default:"" in
   let password = get_param params "proxy-password" ~default:"" in
   Client.Pool.configure_repository_proxy ~rpc ~session_id ~self:pool ~url
@@ -1985,9 +1974,9 @@ let pool_configure_update_sync _printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
   let update_sync_frequency =
     Record_util.update_sync_frequency_of_string
-      (List.assoc "update-sync-frequency" params)
+      (Cli_args.get "update-sync-frequency" params)
   in
-  let day = List.assoc_opt "update-sync-day" params in
+  let day = Cli_args.get_opt "update-sync-day" params in
   let update_sync_day =
     match (update_sync_frequency, day) with
     | `daily, _ ->
@@ -2015,10 +2004,10 @@ let pool_set_update_sync_enabled _printer rpc session_id params =
 
 let pool_install_trusted_certificate fd _printer rpc session_id params =
   let self = get_pool_with_default rpc session_id params "uuid" in
-  let filename = List.assoc "filename" params in
+  let filename = Cli_args.get "filename" params in
   let ca = get_bool_param params ~default:true "ca" in
   let purpose =
-    List.assoc_opt "purpose" params
+    Cli_args.get_opt "purpose" params
     |> Option.map (fun ss ->
         String.split_on_char ',' ss
         |> List.map Record_util.certificate_purpose_of_string
@@ -2039,7 +2028,7 @@ let pool_install_trusted_certificate fd _printer rpc session_id params =
 
 let pool_uninstall_trusted_certificate _printer rpc session_id params =
   let self = get_pool_with_default rpc session_id params "uuid" in
-  let cert_uuid = List.assoc "certificate-uuid" params in
+  let cert_uuid = Cli_args.get "certificate-uuid" params in
   let certificate =
     Client.Certificate.get_by_uuid ~rpc ~session_id ~uuid:cert_uuid
   in
@@ -2059,15 +2048,16 @@ let vdi_type_of_string = function
 
 let vdi_create printer rpc session_id params =
   let sR =
-    Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "sr-uuid" params)
+    Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "sr-uuid" params)
   in
-  let name_label = List.assoc "name-label" params in
+  let name_label = Cli_args.get "name-label" params in
   let virtual_size =
-    Record_util.bytes_of_string "virtual-size" (List.assoc "virtual-size" params)
+    Record_util.bytes_of_string "virtual-size"
+      (Cli_args.get "virtual-size" params)
   in
   let ty =
-    if List.mem_assoc "type" params then
-      vdi_type_of_string (List.assoc "type" params)
+    if Cli_args.exists "type" params then
+      vdi_type_of_string (Cli_args.get "type" params)
     else
       `user
   in
@@ -2083,27 +2073,27 @@ let vdi_create printer rpc session_id params =
   printer (Cli_printer.PList [vdi_uuid])
 
 let vdi_introduce printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let sR =
-    Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "sr-uuid" params)
+    Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "sr-uuid" params)
   in
   (* CA-13140: Some of the backends set their own name-labels, and the VDI introduce will
      	   not override them if we pass in the empty string. *)
-  let name_label = try List.assoc "name-label" params with _ -> "" in
+  let name_label = try Cli_args.get "name-label" params with _ -> "" in
   let name_description =
-    if List.mem_assoc "name-description" params then
-      List.assoc "name-description" params
+    if Cli_args.exists "name-description" params then
+      Cli_args.get "name-description" params
     else
       ""
   in
-  let _type = vdi_type_of_string (List.assoc "type" params) in
+  let _type = vdi_type_of_string (Cli_args.get "type" params) in
   let sharable = get_bool_param params "sharable" in
   let read_only = get_bool_param params "read-only" in
   (* NB call is new so backwards compat other-config- not required *)
   let other_config = read_map_params "other-config" params in
   let xenstore_data = read_map_params "xenstore-data" params in
   let sm_config = read_map_params "sm-config" params in
-  let location = List.assoc "location" params in
+  let location = Cli_args.get "location" params in
   let managed = get_bool_param params "managed" in
   let virtual_size = 0L and physical_utilisation = 0L in
   let metadata_of_pool = Ref.null in
@@ -2122,13 +2112,13 @@ let vdi_introduce printer rpc session_id params =
 
 let vdi_resize _printer rpc session_id params =
   let vdi =
-    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let new_size =
-    Record_util.bytes_of_string "disk-size" (List.assoc "disk-size" params)
+    Record_util.bytes_of_string "disk-size" (Cli_args.get "disk-size" params)
   in
   let online =
-    List.mem_assoc "online" params && List.assoc "online" params = "true"
+    Cli_args.exists "online" params && Cli_args.get "online" params = "true"
   in
   if online then
     Client.VDI.resize_online ~rpc ~session_id ~vdi ~size:new_size
@@ -2137,29 +2127,29 @@ let vdi_resize _printer rpc session_id params =
 
 let vdi_generate_config printer rpc session_id params =
   let vdi =
-    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let host =
     Client.Host.get_by_uuid ~rpc ~session_id
-      ~uuid:(List.assoc "host-uuid" params)
+      ~uuid:(Cli_args.get "host-uuid" params)
   in
   printer
     (Cli_printer.PList [Client.VDI.generate_config ~rpc ~session_id ~host ~vdi])
 
 let vdi_copy printer rpc session_id params =
   let vdi =
-    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let base_vdi =
-    if List.mem_assoc "base-vdi-uuid" params then
+    if Cli_args.exists "base-vdi-uuid" params then
       Client.VDI.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "base-vdi-uuid" params)
+        ~uuid:(Cli_args.get "base-vdi-uuid" params)
     else
       Ref.null
   in
   let sr, into_vdi =
     match
-      (List.mem_assoc "sr-uuid" params, List.mem_assoc "into-vdi-uuid" params)
+      (Cli_args.exists "sr-uuid" params, Cli_args.exists "into-vdi-uuid" params)
     with
     | false, false | true, true ->
         failwith
@@ -2168,13 +2158,13 @@ let vdi_copy printer rpc session_id params =
            the blocks into this VDI)"
     | true, false ->
         ( Client.SR.get_by_uuid ~rpc ~session_id
-            ~uuid:(List.assoc "sr-uuid" params)
+            ~uuid:(Cli_args.get "sr-uuid" params)
         , Ref.null
         )
     | false, true ->
         ( Ref.null
         , Client.VDI.get_by_uuid ~rpc ~session_id
-            ~uuid:(List.assoc "into-vdi-uuid" params)
+            ~uuid:(Cli_args.get "into-vdi-uuid" params)
         )
   in
   let newvdi = Client.VDI.copy ~rpc ~session_id ~vdi ~sr ~base_vdi ~into_vdi in
@@ -2183,11 +2173,11 @@ let vdi_copy printer rpc session_id params =
 
 let vdi_pool_migrate printer rpc session_id params =
   let vdi =
-    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   and sr =
-    Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "sr-uuid" params)
+    Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "sr-uuid" params)
   and options =
-    match List.assoc_opt "dest-img-format" params with
+    match Cli_args.get_opt "dest-img-format" params with
     | Some v ->
         [("dest-img-format", v)]
     | None ->
@@ -2199,15 +2189,11 @@ let vdi_pool_migrate printer rpc session_id params =
 
 let vdi_clone printer rpc session_id params =
   let vdi =
-    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let driver_params = read_map_params "driver-params" params in
-  let name_label =
-    try Some (List.assoc "new-name-label" params) with Not_found -> None
-  in
-  let name_description =
-    try Some (List.assoc "new-name-description" params) with Not_found -> None
-  in
+  let name_label = Cli_args.get_opt "new-name-label" params in
+  let name_description = Cli_args.get_opt "new-name-description" params in
   let newvdi = Client.VDI.clone ~rpc ~session_id ~vdi ~driver_params in
   Option.iter
     (fun x -> Client.VDI.set_name_label ~rpc ~session_id ~self:newvdi ~value:x)
@@ -2222,7 +2208,7 @@ let vdi_clone printer rpc session_id params =
 
 let vdi_snapshot printer rpc session_id params =
   let vdi =
-    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let driver_params = read_map_params "driver-params" params in
   let newvdi = Client.VDI.snapshot ~rpc ~session_id ~vdi ~driver_params in
@@ -2231,55 +2217,55 @@ let vdi_snapshot printer rpc session_id params =
 
 let vdi_destroy _printer rpc session_id params =
   let vdi =
-    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   Client.VDI.destroy ~rpc ~session_id ~self:vdi
 
 let vdi_forget _printer rpc session_id params =
   let vdi =
-    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   Client.VDI.forget ~rpc ~session_id ~vdi
 
 let vdi_update _printer rpc session_id params =
   let vdi =
-    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   Client.VDI.update ~rpc ~session_id ~vdi
 
 let vdi_unlock _printer rpc session_id params =
   let vdi =
-    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   fail_without_force params ;
   Client.VDI.force_unlock ~rpc ~session_id ~vdi
 
 let vdi_enable_cbt _printer rpc session_id params =
   let vdi =
-    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   Client.VDI.enable_cbt ~rpc ~session_id ~self:vdi
 
 let vdi_disable_cbt _printer rpc session_id params =
   let vdi =
-    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   Client.VDI.disable_cbt ~rpc ~session_id ~self:vdi
 
 let vdi_data_destroy _printer rpc session_id params =
   let vdi =
-    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   Client.VDI.data_destroy ~rpc ~session_id ~self:vdi
 
 let vdi_list_changed_blocks socket _ rpc session_id params =
   let vdi_from =
     Client.VDI.get_by_uuid ~rpc ~session_id
-      ~uuid:(List.assoc "vdi-from-uuid" params)
+      ~uuid:(Cli_args.get "vdi-from-uuid" params)
   in
   let vdi_to =
     Client.VDI.get_by_uuid ~rpc ~session_id
-      ~uuid:(List.assoc "vdi-to-uuid" params)
+      ~uuid:(Cli_args.get "vdi-to-uuid" params)
   in
   let bitmap =
     Client.VDI.list_changed_blocks ~rpc ~session_id ~vdi_from ~vdi_to
@@ -2288,7 +2274,7 @@ let vdi_list_changed_blocks socket _ rpc session_id params =
 
 let diagnostic_vdi_status printer rpc session_id params =
   let vdi =
-    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let vdi_r = vdi_record rpc session_id vdi in
   let vdi_fields =
@@ -2427,7 +2413,7 @@ let print_vm_host_report printer rpc session_id vm_ref =
 
 let diagnostic_vm_status printer rpc session_id params =
   let vm =
-    Client.VM.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VM.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let vm_r = vm_record rpc session_id vm in
   let vm_fields =
@@ -2485,20 +2471,20 @@ let diagnostic_vm_status printer rpc session_id params =
 
 let vbd_create printer rpc session_id params =
   let vM =
-    Client.VM.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "vm-uuid" params)
+    Client.VM.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "vm-uuid" params)
   in
-  let empty = not (List.mem_assoc "vdi-uuid" params) in
+  let empty = not (Cli_args.exists "vdi-uuid" params) in
   let vDI =
     if empty then
       Ref.null
     else
       Client.VDI.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "vdi-uuid" params)
+        ~uuid:(Cli_args.get "vdi-uuid" params)
   in
   let bootable = get_bool_param params "bootable" in
   let mode =
-    if List.mem_assoc "mode" params then
-      match String.lowercase_ascii (List.assoc "mode" params) with
+    if Cli_args.exists "mode" params then
+      match String.lowercase_ascii (Cli_args.get "mode" params) with
       | "ro" ->
           `RO
       | "rw" ->
@@ -2510,8 +2496,8 @@ let vbd_create printer rpc session_id params =
       `RW
   in
   let _type =
-    if List.mem_assoc "type" params then
-      match String.lowercase_ascii (List.assoc "type" params) with
+    if Cli_args.exists "type" params then
+      match String.lowercase_ascii (Cli_args.get "type" params) with
       | "cd" ->
           `CD
       | "disk" ->
@@ -2531,7 +2517,7 @@ let vbd_create printer rpc session_id params =
     failwith "Empty VBDs can only be made for type=CD" ;
   let vbd =
     Client.VBD.create ~rpc ~session_id ~vM ~vDI
-      ~userdevice:(List.assoc "device" params)
+      ~userdevice:(Cli_args.get "device" params)
       ~bootable ~mode ~_type ~unpluggable ~empty ~qos_algorithm_type:""
       ~qos_algorithm_params:[] ~other_config:[] ~device:""
       ~currently_attached:false
@@ -2541,37 +2527,37 @@ let vbd_create printer rpc session_id params =
 
 let vbd_destroy _printer rpc session_id params =
   let self =
-    Client.VBD.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VBD.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   Client.VBD.destroy ~rpc ~session_id ~self
 
 let vbd_eject _printer rpc session_id params =
   let vbd =
-    Client.VBD.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VBD.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   Client.VBD.eject ~rpc ~session_id ~vbd
 
 let vbd_insert _printer rpc session_id params =
   let vbd =
-    Client.VBD.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VBD.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
-  let uuid = List.assoc "vdi-uuid" params in
+  let uuid = Cli_args.get "vdi-uuid" params in
   let vdi = Client.VDI.get_by_uuid ~rpc ~session_id ~uuid in
   Client.VBD.insert ~rpc ~session_id ~vbd ~vdi
 
 let vbd_plug _printer rpc session_id params =
   let vbd =
-    Client.VBD.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VBD.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   Client.VBD.plug ~rpc ~session_id ~self:vbd
 
 let vbd_unplug _printer rpc session_id params =
   let vbd =
-    Client.VBD.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VBD.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let timeout =
-    if List.mem_assoc "timeout" params then
-      try float_of_string (List.assoc "timeout" params)
+    if Cli_args.exists "timeout" params then
+      try float_of_string (Cli_args.get "timeout" params)
       with _ ->
         failwith "Failed to parse parameter 'timeout': expecting a float"
     else
@@ -2601,27 +2587,27 @@ let vbd_unplug _printer rpc session_id params =
 
 let vbd_pause printer rpc session_id params =
   let vbd =
-    Client.VBD.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VBD.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let token = Client.VBD.pause ~rpc ~session_id ~self:vbd in
   printer (Cli_printer.PList [token])
 
 let vbd_unpause _printer rpc session_id params =
   let vbd =
-    Client.VBD.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VBD.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
-  let token = List.assoc "token" params in
+  let token = Cli_args.get "token" params in
   Client.VBD.unpause ~rpc ~session_id ~self:vbd ~token
 
 (* SR scan *)
 let sr_scan _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let sr = Client.SR.get_by_uuid ~rpc ~session_id ~uuid in
   Client.SR.scan ~rpc ~session_id ~sr
 
 let parse_host_uuid ?(default_master = true) rpc session_id params =
-  if List.mem_assoc "host-uuid" params then
-    let uuid = List.assoc "host-uuid" params in
+  if Cli_args.exists "host-uuid" params then
+    let uuid = Cli_args.get "host-uuid" params in
     Client.Host.get_by_uuid ~rpc ~session_id ~uuid
   else
     let hosts = Client.Host.get_all ~rpc ~session_id in
@@ -2634,18 +2620,18 @@ let parse_host_uuid ?(default_master = true) rpc session_id params =
 (* SR create destroy list param-list param-get param-set param-add param-remove *)
 
 let sr_create fd _printer rpc session_id params =
-  let name_label = List.assoc "name-label" params in
-  let name_description = Listext.assoc_default "name-description" params "" in
+  let name_label = Cli_args.get "name-label" params in
+  let name_description = Cli_args.get_default "name-description" params "" in
   let shared = get_bool_param params "shared" in
   let host = parse_host_uuid ~default_master:shared rpc session_id params in
   let physical_size =
     try
       Record_util.bytes_of_string "physical-size"
-        (List.assoc "physical-size" params)
+        (Cli_args.get "physical-size" params)
     with _ -> 0L
   in
-  let _type = List.assoc "type" params in
-  let content_type = Listext.assoc_default "content-type" params "" in
+  let _type = Cli_args.get "type" params in
+  let content_type = Cli_args.get_default "content-type" params "" in
   let device_config = read_map_params "device-config" params in
   (* If the device-config parameter is of the form k-filename=v, then we assume the
      	   key is 'k' and the value is stored in a file named 'v' *)
@@ -2676,11 +2662,11 @@ let sr_create fd _printer rpc session_id params =
   marshal fd (Command (Print sr_uuid))
 
 let sr_introduce printer rpc session_id params =
-  let name_label = List.assoc "name-label" params in
-  let name_description = Listext.assoc_default "name-description" params "" in
-  let _type = List.assoc "type" params in
-  let content_type = Listext.assoc_default "content-type" params "" in
-  let uuid = List.assoc "uuid" params in
+  let name_label = Cli_args.get "name-label" params in
+  let name_description = Cli_args.get_default "name-description" params "" in
+  let _type = Cli_args.get "type" params in
+  let content_type = Cli_args.get_default "content-type" params "" in
+  let uuid = Cli_args.get "uuid" params in
   let shared = get_bool_param params "shared" in
   let sm_config = read_map_params "sm-config" params in
   let _ =
@@ -2694,7 +2680,7 @@ type probe_result = Raw of string (* SMAPIv1 adapters return arbitrary data *)
 
 let sr_probe printer rpc session_id params =
   let host = parse_host_uuid rpc session_id params in
-  let _type = List.assoc "type" params in
+  let _type = Cli_args.get "type" params in
   let device_config = read_map_params "device-config" params in
   let sm_config = read_map_params "sm-config" params in
   let txt =
@@ -2713,7 +2699,7 @@ let sr_probe printer rpc session_id params =
 
 let sr_probe_ext printer rpc session_id params =
   let host = parse_host_uuid rpc session_id params in
-  let _type = List.assoc "type" params in
+  let _type = Cli_args.get "type" params in
   let device_config = read_map_params "device-config" params in
   let sm_config = read_map_params "sm-config" params in
   let results =
@@ -2792,54 +2778,39 @@ let sr_probe_ext printer rpc session_id params =
   )
 
 let sr_destroy _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let sr = Client.SR.get_by_uuid ~rpc ~session_id ~uuid in
   Client.SR.destroy ~rpc ~session_id ~sr
 
 let sr_forget _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let sr = Client.SR.get_by_uuid ~rpc ~session_id ~uuid in
   Client.SR.forget ~rpc ~session_id ~sr
 
 let sr_update _printer rpc session_id params =
   let sr =
-    Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   Client.SR.update ~rpc ~session_id ~sr
 
 let sr_enable_database_replication _printer rpc session_id params =
   let sr =
-    Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   Client.SR.enable_database_replication ~rpc ~session_id ~sr
 
 let sr_disable_database_replication _printer rpc session_id params =
   let sr =
-    Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   Client.SR.disable_database_replication ~rpc ~session_id ~sr
 
 (* PIF destroy* list param-list param-get param-set param-add param-remove *)
 
 let pbd_create printer rpc session_id params =
-  let host_uuid = List.assoc "host-uuid" params in
-  let sr_uuid = List.assoc "sr-uuid" params in
-  (* Ack! We're supposed to use the format device-config:key=value but we need to match device-config-key=value for *)
-  (* backwards compatability *)
-  let len = String.length "device-config:" in
-  let filter_params =
-    List.filter
-      (fun (p, _) ->
-        Astring.String.is_prefix ~affix:"device-config" p
-        && String.length p > len
-      )
-      params
-  in
-  let device_config =
-    List.map
-      (fun (k, v) -> (String.sub k len (String.length k - len), v))
-      filter_params
-  in
+  let host_uuid = Cli_args.get "host-uuid" params in
+  let sr_uuid = Cli_args.get "sr-uuid" params in
+  let device_config = read_map_params "device-config" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
   let sR = Client.SR.get_by_uuid ~rpc ~session_id ~uuid:sr_uuid in
   let pbd =
@@ -2849,27 +2820,27 @@ let pbd_create printer rpc session_id params =
   printer (Cli_printer.PList [uuid])
 
 let pbd_destroy _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let pbd = Client.PBD.get_by_uuid ~rpc ~session_id ~uuid in
   Client.PBD.destroy ~rpc ~session_id ~self:pbd
 
 let pbd_plug _printer rpc session_id params =
   let pbd =
-    Client.PBD.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.PBD.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   Client.PBD.plug ~rpc ~session_id ~self:pbd
 
 let pbd_unplug _printer rpc session_id params =
   let pbd =
-    Client.PBD.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.PBD.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   Client.PBD.unplug ~rpc ~session_id ~self:pbd
 
 let vif_create printer rpc session_id params =
-  let device = List.assoc "device" params in
-  let network_uuid = List.assoc "network-uuid" params in
-  let vm_uuid = List.assoc "vm-uuid" params in
-  let mac = Listext.assoc_default "mac" params "" in
+  let device = Cli_args.get "device" params in
+  let network_uuid = Cli_args.get "network-uuid" params in
+  let vm_uuid = Cli_args.get "vm-uuid" params in
+  let mac = Cli_args.get_default "mac" params "" in
   let mAC =
     if mac = "random" then
       Record_util.random_mac_local ()
@@ -2891,17 +2862,17 @@ let vif_create printer rpc session_id params =
   printer (Cli_printer.PList [uuid])
 
 let vif_destroy _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let vif = Client.VIF.get_by_uuid ~rpc ~session_id ~uuid in
   Client.VIF.destroy ~rpc ~session_id ~self:vif
 
 let vif_plug _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let vif = Client.VIF.get_by_uuid ~rpc ~session_id ~uuid in
   Client.VIF.plug ~rpc ~session_id ~self:vif
 
 let vif_unplug _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let vif = Client.VIF.get_by_uuid ~rpc ~session_id ~uuid in
   let force = get_bool_param params "force" in
   ( if force then
@@ -2913,33 +2884,35 @@ let vif_unplug _printer rpc session_id params =
 
 let vif_configure_ipv4 _printer rpc session_id params =
   let vif =
-    Client.VIF.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VIF.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let mode =
-    Record_util.vif_ipv4_configuration_mode_of_string (List.assoc "mode" params)
+    Record_util.vif_ipv4_configuration_mode_of_string
+      (Cli_args.get "mode" params)
   in
-  let address = Listext.assoc_default "address" params "" in
-  let gateway = Listext.assoc_default "gateway" params "" in
+  let address = Cli_args.get_default "address" params "" in
+  let gateway = Cli_args.get_default "gateway" params "" in
   if mode = `Static && address = "" then
     failwith "Required parameter not found: address" ;
   Client.VIF.configure_ipv4 ~rpc ~session_id ~self:vif ~mode ~address ~gateway
 
 let vif_configure_ipv6 _printer rpc session_id params =
   let vif =
-    Client.VIF.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VIF.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let mode =
-    Record_util.vif_ipv6_configuration_mode_of_string (List.assoc "mode" params)
+    Record_util.vif_ipv6_configuration_mode_of_string
+      (Cli_args.get "mode" params)
   in
-  let address = Listext.assoc_default "address" params "" in
-  let gateway = Listext.assoc_default "gateway" params "" in
+  let address = Cli_args.get_default "address" params "" in
+  let gateway = Cli_args.get_default "gateway" params "" in
   if mode = `Static && address = "" then
     failwith "Required parameter not found: address" ;
   Client.VIF.configure_ipv6 ~rpc ~session_id ~self:vif ~mode ~address ~gateway
 
 let vif_move _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
-  let network_uuid = List.assoc "network-uuid" params in
+  let uuid = Cli_args.get "uuid" params in
+  let network_uuid = Cli_args.get "network-uuid" params in
   let vif = Client.VIF.get_by_uuid ~rpc ~session_id ~uuid in
   let network =
     Client.Network.get_by_uuid ~rpc ~session_id ~uuid:network_uuid
@@ -2947,15 +2920,15 @@ let vif_move _printer rpc session_id params =
   Client.VIF.move ~rpc ~session_id ~self:vif ~network
 
 let net_create printer rpc session_id params =
-  let network = List.assoc "name-label" params in
-  let descr = Listext.assoc_default "name-description" params "" in
+  let network = Cli_args.get "name-label" params in
+  let descr = Cli_args.get_default "name-description" params "" in
   let mTU =
-    if List.mem_assoc "MTU" params then
-      Int64.of_string (List.assoc "MTU" params)
+    if Cli_args.exists "MTU" params then
+      Int64.of_string (Cli_args.get "MTU" params)
     else
       1500L
   in
-  let bridge = Listext.assoc_default "bridge" params "" in
+  let bridge = Cli_args.get_default "bridge" params "" in
   let managed = get_bool_param params ~default:true "managed" in
   let net =
     Client.Network.create ~rpc ~session_id ~name_label:network
@@ -2966,24 +2939,26 @@ let net_create printer rpc session_id params =
 
 let net_destroy _printer rpc session_id params =
   let network =
-    Client.Network.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.Network.get_by_uuid ~rpc ~session_id
+      ~uuid:(Cli_args.get "uuid" params)
   in
   ignore (Client.Network.destroy ~rpc ~session_id ~self:network)
 
 let net_attach _printer rpc session_id params =
   let network =
-    Client.Network.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.Network.get_by_uuid ~rpc ~session_id
+      ~uuid:(Cli_args.get "uuid" params)
   in
   let host =
     Client.Host.get_by_uuid ~rpc ~session_id
-      ~uuid:(List.assoc "host-uuid" params)
+      ~uuid:(Cli_args.get "host-uuid" params)
   in
   let () = Client.Network.attach ~rpc ~session_id ~network ~host in
   ()
 
 let vm_create printer rpc session_id params =
-  let name_label = List.assoc "name-label" params in
-  let name_description = Listext.assoc_default "name-description" params "" in
+  let name_label = Cli_args.get "name-label" params in
+  let name_description = Cli_args.get_default "name-description" params "" in
   let ( ** ) = Int64.mul in
   let mib = 1024L ** 1024L in
   let memory_max = 256L ** mib in
@@ -3013,7 +2988,7 @@ let vm_create printer rpc session_id params =
   printer (Cli_printer.PList [uuid])
 
 let vm_destroy _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let vm = Client.VM.get_by_uuid ~rpc ~session_id ~uuid in
   if Client.VM.get_is_control_domain ~rpc ~session_id ~self:vm then
     raise
@@ -3219,7 +3194,7 @@ let event_wait_gen rpc session_id classname record_matches =
 (* We're done. Unregister and finish *)
 
 let event_wait _printer rpc session_id params =
-  let classname = List.assoc "class" params in
+  let classname = Cli_args.get "class" params in
   let filter_params = params_except ["class"] params in
   (* Each filter_params is a key value pair:
      	   (key, value) if the user entered "key=value"
@@ -3278,7 +3253,7 @@ let select_vms ?(include_control_vms = false) ?(include_template_vms = false)
       params
   in
   let vm_name_or_ref =
-    try Some (List.assoc "vm" params |> escape_quotes) with _ -> None
+    try Some (Cli_args.get "vm" params |> escape_quotes) with _ -> None
   in
   let params, expr =
     match vm_name_or_ref with
@@ -3286,7 +3261,7 @@ let select_vms ?(include_control_vms = false) ?(include_template_vms = false)
         (params, "true")
     | Some v ->
         ( (* try matching vm=<name or uuid> *)
-          List.remove_assoc "vm" params
+          Cli_args.remove "vm" params
         , Printf.sprintf
             "(field \"uuid\"=\"%s\") or (field \"name__label\"=\"%s\")" v v
         )
@@ -3303,8 +3278,8 @@ let select_vms ?(include_control_vms = false) ?(include_template_vms = false)
   in
   (* Filter on everything on the cmd line except params=... *)
   let filter_params =
-    List.filter
-      (fun (p, _) ->
+    Cli_args.filter
+      (fun p ->
         let p' =
           try
             let i = String.index p ':' in
@@ -3316,11 +3291,12 @@ let select_vms ?(include_control_vms = false) ?(include_template_vms = false)
       params
   in
   (* Filter all the records *)
-  List.fold_left filter_records_on_fields all_recs filter_params
+  List.fold_left filter_records_on_fields all_recs
+    (Cli_args.to_pairs filter_params)
 
 let select_hosts rpc session_id params ignore_params =
   let host_name_or_ref =
-    try Some (List.assoc "host" params |> escape_quotes) with _ -> None
+    try Some (Cli_args.get "host" params |> escape_quotes) with _ -> None
   in
   let params, expr =
     match host_name_or_ref with
@@ -3328,7 +3304,7 @@ let select_hosts rpc session_id params ignore_params =
         (params, "true")
     | Some v ->
         ( (* try matching host=<name or uuid> *)
-          List.remove_assoc "host" params
+          Cli_args.remove "host" params
         , Printf.sprintf
             "(field \"uuid\"=\"%s\") or (field \"hostname\"=\"%s\") or (field \
              \"name__label\"=\"%s\")"
@@ -3346,19 +3322,20 @@ let select_hosts rpc session_id params ignore_params =
       hosts
   in
   let filter_params =
-    List.filter
-      (fun (p, _) ->
+    Cli_args.filter
+      (fun p ->
         let stem = List.hd (String.split_on_char ':' p) in
         not (List.mem stem (stdparams @ ignore_params))
       )
       params
   in
   (* Filter all the records *)
-  List.fold_left filter_records_on_fields all_recs filter_params
+  List.fold_left filter_records_on_fields all_recs
+    (Cli_args.to_pairs filter_params)
 
 let select_srs rpc session_id params ignore_params =
   let sr_name_or_ref =
-    try Some (List.assoc "sr" params |> escape_quotes) with _ -> None
+    try Some (Cli_args.get "sr" params |> escape_quotes) with _ -> None
   in
   let params, expr =
     match sr_name_or_ref with
@@ -3366,7 +3343,7 @@ let select_srs rpc session_id params ignore_params =
         (params, "true")
     | Some v ->
         ( (* try matching sr=<name or uuid> *)
-          List.remove_assoc "sr" params
+          Cli_args.remove "sr" params
         , Printf.sprintf
             "(field \"uuid\"=\"%s\") or (field \"name__label\"=\"%s\")" v v
         )
@@ -3382,15 +3359,16 @@ let select_srs rpc session_id params ignore_params =
       srs
   in
   let filter_params =
-    List.filter
-      (fun (p, _) ->
+    Cli_args.filter
+      (fun p ->
         let stem = List.hd (String.split_on_char ':' p) in
         not (List.mem stem (stdparams @ ignore_params))
       )
       params
   in
   (* Filter all the records *)
-  List.fold_left filter_records_on_fields all_recs filter_params
+  List.fold_left filter_records_on_fields all_recs
+    (Cli_args.to_pairs filter_params)
 
 exception Multiple_failure of (string * string) list
 
@@ -3453,7 +3431,7 @@ let do_multiple op set =
 let do_vm_op ?(include_control_vms = false) ?(include_template_vms = false)
     printer rpc session_id op params ?(multiple = true) ignore_params =
   let msg_prio =
-    try Int64.of_string (List.assoc "message-priority" params) with _ -> 5L
+    try Int64.of_string (Cli_args.get "message-priority" params) with _ -> 5L
   in
   let op = wrap_op printer msg_prio rpc session_id op in
   try
@@ -3556,8 +3534,8 @@ let vm_compute_memory_overhead printer rpc session_id params =
     )
 
 let vm_memory_dynamic_range_set printer rpc session_id params =
-  let min = Record_util.bytes_of_string "min" (List.assoc "min" params)
-  and max = Record_util.bytes_of_string "max" (List.assoc "max" params) in
+  let min = Record_util.bytes_of_string "min" (Cli_args.get "min" params)
+  and max = Record_util.bytes_of_string "max" (Cli_args.get "max" params) in
   ignore
     (do_vm_op ~include_control_vms:true ~include_template_vms:true printer rpc
        session_id
@@ -3569,8 +3547,8 @@ let vm_memory_dynamic_range_set printer rpc session_id params =
     )
 
 let vm_memory_static_range_set printer rpc session_id params =
-  let min = Record_util.bytes_of_string "min" (List.assoc "min" params)
-  and max = Record_util.bytes_of_string "max" (List.assoc "max" params) in
+  let min = Record_util.bytes_of_string "min" (Cli_args.get "min" params)
+  and max = Record_util.bytes_of_string "max" (Cli_args.get "max" params) in
   ignore
     (do_vm_op ~include_control_vms:true ~include_template_vms:true printer rpc
        session_id
@@ -3582,7 +3560,7 @@ let vm_memory_static_range_set printer rpc session_id params =
     )
 
 let vm_memory_limits_set printer rpc session_id params =
-  let extract key = Record_util.bytes_of_string key (List.assoc key params) in
+  let extract key = Record_util.bytes_of_string key (Cli_args.get key params) in
   let static_min = extract "static-min"
   and static_max = extract "static-max"
   and dynamic_min = extract "dynamic-min"
@@ -3600,7 +3578,7 @@ let vm_memory_limits_set printer rpc session_id params =
 
 let vm_memory_set printer rpc session_id params =
   let value =
-    Record_util.bytes_of_string "memory" (List.assoc "memory" params)
+    Record_util.bytes_of_string "memory" (Cli_args.get "memory" params)
   in
   ignore
     (do_vm_op ~include_control_vms:true ~include_template_vms:true printer rpc
@@ -3613,7 +3591,7 @@ let vm_memory_set printer rpc session_id params =
 
 let vm_memory_target_set printer rpc session_id params =
   let target =
-    Record_util.bytes_of_string "target" (List.assoc "target" params)
+    Record_util.bytes_of_string "target" (Cli_args.get "target" params)
   in
   ignore
     (do_vm_op ~include_control_vms:true printer rpc session_id
@@ -3651,20 +3629,20 @@ let args_file fd ((k, v) as p) =
       p
 
 let vm_call_plugin fd printer rpc session_id params =
-  let vm_uuid = List.assoc "vm-uuid" params in
+  let vm_uuid = Cli_args.get "vm-uuid" params in
   let vm = Client.VM.get_by_uuid ~rpc ~session_id ~uuid:vm_uuid in
-  let plugin = List.assoc "plugin" params in
-  let fn = List.assoc "fn" params in
+  let plugin = Cli_args.get "plugin" params in
+  let fn = Cli_args.get "fn" params in
   let args = read_map_params "args" params in
   let args = List.map (args_file fd) args in
   let result = Client.VM.call_plugin ~rpc ~session_id ~vm ~plugin ~fn ~args in
   printer (Cli_printer.PList [result])
 
 let vm_call_host_plugin fd printer rpc session_id params =
-  let vm_uuid = List.assoc "vm-uuid" params in
+  let vm_uuid = Cli_args.get "vm-uuid" params in
   let vm = Client.VM.get_by_uuid ~rpc ~session_id ~uuid:vm_uuid in
-  let plugin = List.assoc "plugin" params in
-  let fn = List.assoc "fn" params in
+  let plugin = Cli_args.get "plugin" params in
+  let fn = Cli_args.get "fn" params in
   let args = read_map_params "args" params in
   let args = List.map (args_file fd) args in
   let result =
@@ -3700,7 +3678,7 @@ let vm_data_source_record printer rpc session_id params =
     (do_vm_op ~include_control_vms:true printer rpc session_id ~multiple:false
        (fun vm ->
          let vm = vm.getref () in
-         let data_source = List.assoc "data-source" params in
+         let data_source = Cli_args.get "data-source" params in
          Client.VM.record_data_source ~rpc ~session_id ~self:vm ~data_source
        )
        params ["data-source"]
@@ -3711,7 +3689,7 @@ let vm_data_source_query printer rpc session_id params =
     (do_vm_op ~include_control_vms:true printer rpc session_id ~multiple:false
        (fun vm ->
          let self = vm.getref () in
-         let data_source = List.assoc "data-source" params in
+         let data_source = Cli_args.get "data-source" params in
          let value =
            Client.VM.query_data_source ~rpc ~session_id ~self ~data_source
          in
@@ -3725,7 +3703,7 @@ let vm_data_source_forget printer rpc session_id params =
     (do_vm_op ~include_control_vms:true printer rpc session_id ~multiple:false
        (fun vm ->
          let self = vm.getref () in
-         let data_source = List.assoc "data-source" params in
+         let data_source = Cli_args.get "data-source" params in
          Client.VM.forget_data_source_archives ~rpc ~session_id ~self
            ~data_source
        )
@@ -3733,9 +3711,9 @@ let vm_data_source_forget printer rpc session_id params =
     )
 
 let vm_sysprep fd printer rpc session_id params =
-  let filename = List.assoc "filename" params in
+  let filename = Cli_args.get "filename" params in
   let timeout =
-    match List.assoc "timeout" params |> float_of_string with
+    match Cli_args.get "timeout" params |> float_of_string with
     | exception _ ->
         3.0 *. 60.0 (* default in the CLI, no default in the API *)
     | s when s < 0.0 ->
@@ -3778,7 +3756,7 @@ let sr_data_source_record _printer rpc session_id params =
     (do_sr_op rpc session_id ~multiple:false
        (fun sr ->
          let sr = sr.getref () in
-         let data_source = List.assoc "data-source" params in
+         let data_source = Cli_args.get "data-source" params in
          Client.SR.record_data_source ~rpc ~session_id ~sr ~data_source
        )
        params ["data-source"]
@@ -3789,7 +3767,7 @@ let sr_data_source_query printer rpc session_id params =
     (do_sr_op rpc session_id ~multiple:false
        (fun sr ->
          let sr = sr.getref () in
-         let data_source = List.assoc "data-source" params in
+         let data_source = Cli_args.get "data-source" params in
          let value =
            Client.SR.query_data_source ~rpc ~session_id ~sr ~data_source
          in
@@ -3803,7 +3781,7 @@ let sr_data_source_forget _printer rpc session_id params =
     (do_sr_op rpc session_id ~multiple:false
        (fun sr ->
          let sr = sr.getref () in
-         let data_source = List.assoc "data-source" params in
+         let data_source = Cli_args.get "data-source" params in
          Client.SR.forget_data_source_archives ~rpc ~session_id ~sr ~data_source
        )
        params ["data-source"]
@@ -3826,7 +3804,7 @@ let host_data_source_record _printer rpc session_id params =
     (do_host_op rpc session_id ~multiple:false
        (fun _ host ->
          let host = host.getref () in
-         let data_source = List.assoc "data-source" params in
+         let data_source = Cli_args.get "data-source" params in
          Client.Host.record_data_source ~rpc ~session_id ~host ~data_source
        )
        params ["data-source"]
@@ -3837,7 +3815,7 @@ let host_data_source_query printer rpc session_id params =
     (do_host_op rpc session_id ~multiple:false
        (fun _ host ->
          let host = host.getref () in
-         let data_source = List.assoc "data-source" params in
+         let data_source = Cli_args.get "data-source" params in
          let value =
            Client.Host.query_data_source ~rpc ~session_id ~host ~data_source
          in
@@ -3851,7 +3829,7 @@ let host_data_source_forget _printer rpc session_id params =
     (do_host_op rpc session_id ~multiple:false
        (fun _ host ->
          let host = host.getref () in
-         let data_source = List.assoc "data-source" params in
+         let data_source = Cli_args.get "data-source" params in
          Client.Host.forget_data_source_archives ~rpc ~session_id ~host
            ~data_source
        )
@@ -3909,10 +3887,10 @@ let host_refresh_server_certificate _printer rpc session_id params =
 
 let host_install_server_certificate fd _printer rpc session_id params =
   let certificate =
-    List.assoc "certificate" params |> get_file_or_fail fd "certificate"
+    Cli_args.get "certificate" params |> get_file_or_fail fd "certificate"
   in
   let private_key =
-    List.assoc "private-key" params |> get_file_or_fail fd "private key"
+    Cli_args.get "private-key" params |> get_file_or_fail fd "private key"
   in
   let certificate_chain =
     get_unique_param "certificate-chain" params
@@ -3956,7 +3934,7 @@ let host_get_thread_diagnostics printer rpc session_id params =
     )
 
 let host_sm_dp_destroy _printer rpc session_id params =
-  let dp = List.assoc "dp" params in
+  let dp = Cli_args.get "dp" params in
   let allow_leak = get_bool_param params "allow-leak" in
   ignore
     (do_host_op rpc session_id ~multiple:false
@@ -3969,7 +3947,7 @@ let host_sm_dp_destroy _printer rpc session_id params =
 
 let vm_memory_shadow_multiplier_set printer rpc session_id params =
   let multiplier =
-    try float_of_string (List.assoc "multiplier" params)
+    try float_of_string (Cli_args.get "multiplier" params)
     with _ ->
       failwith "Failed to parse parameter 'multiplier': expecting a float"
   in
@@ -4003,9 +3981,9 @@ let vm_start printer rpc session_id params =
        (fun vm ->
          let vm = vm.getref () in
          let task =
-           if List.mem_assoc "on" params then
+           if Cli_args.exists "on" params then
              let host =
-               get_host_by_name_or_id rpc session_id (List.assoc "on" params)
+               get_host_by_name_or_id rpc session_id (Cli_args.get "on" params)
              in
              Client.Async.VM.start_on ~rpc ~session_id ~vm
                ~host:(host.getref ()) ~start_paused ~force
@@ -4037,9 +4015,9 @@ let vm_resume printer rpc session_id params =
   ignore
     (do_vm_op printer rpc session_id
        (fun vm ->
-         if List.mem_assoc "on" params then
+         if Cli_args.exists "on" params then
            let host =
-             get_host_by_name_or_id rpc session_id (List.assoc "on" params)
+             get_host_by_name_or_id rpc session_id (Cli_args.get "on" params)
            in
            let task =
              Client.Async.VM.resume_on ~rpc ~session_id ~vm:(vm.getref ())
@@ -4107,8 +4085,8 @@ let vm_install_real printer rpc session_id template name description params =
     if Client.VM.get_is_a_snapshot ~rpc ~session_id ~self:template then
       if
         false
-        || List.mem_assoc "sr-name-label" params
-        || List.mem_assoc "sr-uuid" params
+        || Cli_args.exists "sr-name-label" params
+        || Cli_args.exists "sr-uuid" params
       then
         failwith
           "Do not use the sr-name-label or sr-uuid argument when installing \
@@ -4124,15 +4102,15 @@ let vm_install_real printer rpc session_id template name description params =
     | Some _ ->
         sr_ref
     | None ->
-        if List.mem_assoc "sr-uuid" params then
-          let uuid = List.assoc "sr-uuid" params in
+        if Cli_args.exists "sr-uuid" params then
+          let uuid = Cli_args.get "sr-uuid" params in
           Some (Client.SR.get_by_uuid ~rpc ~session_id ~uuid)
         else
           None
   in
   let sr_ref =
-    if List.mem_assoc "sr-name-label" params then
-      let name = List.assoc "sr-name-label" params in
+    if Cli_args.exists "sr-name-label" params then
+      let name = Cli_args.get "sr-name-label" params in
       match Client.SR.get_by_name_label ~rpc ~session_id ~label:name with
       | [] ->
           failwith "No SR with that name-label found"
@@ -4246,10 +4224,10 @@ let vm_install_real printer rpc session_id template name description params =
     (* stop install starting VMs *)
 
     (* copy BIOS strings if needed *)
-    ( if List.mem_assoc "copy-bios-strings-from" params then
+    ( if Cli_args.exists "copy-bios-strings-from" params then
         let host =
           Client.Host.get_by_uuid ~rpc ~session_id
-            ~uuid:(List.assoc "copy-bios-strings-from" params)
+            ~uuid:(Cli_args.get "copy-bios-strings-from" params)
         in
         Client.VM.copy_bios_strings ~rpc ~session_id ~vm:new_vm ~host
     ) ;
@@ -4264,10 +4242,10 @@ let vm_install_real printer rpc session_id template name description params =
 let vm_install printer rpc session_id params =
   (* Filter on everything on the cmd line except params=... *)
   let template =
-    if List.mem_assoc "template-uuid" params then
+    if Cli_args.exists "template-uuid" params then
       try
         Client.VM.get_by_uuid ~rpc ~session_id
-          ~uuid:(List.assoc "template-uuid" params)
+          ~uuid:(Cli_args.get "template-uuid" params)
       with _ -> failwith "Cannot find template"
     else
       let filter_params =
@@ -4297,21 +4275,21 @@ let vm_install printer rpc session_id params =
             failwith "More than one matching template found"
       in
       if
-        List.mem_assoc "template-name-label" params
-        || List.mem_assoc "template-name" params
+        Cli_args.exists "template-name-label" params
+        || Cli_args.exists "template-name" params
       then
         let template_name =
-          if List.mem_assoc "template-name-label" params then
-            List.assoc "template-name-label" params
+          if Cli_args.exists "template-name-label" params then
+            Cli_args.get "template-name-label" params
           else
-            List.assoc "template-name" params
+            Cli_args.get "template-name" params
         in
         find_by_name template_name
-      else if List.mem_assoc "template" params then
+      else if Cli_args.exists "template" params then
         try
           Client.VM.get_by_uuid ~rpc ~session_id
-            ~uuid:(List.assoc "template" params)
-        with _ -> find_by_name (List.assoc "template" params)
+            ~uuid:(Cli_args.get "template" params)
+        with _ -> find_by_name (Cli_args.get "template" params)
       else
         failwith
           "Template must be specified by parameter 'template-uuid', \
@@ -4319,7 +4297,7 @@ let vm_install printer rpc session_id params =
   in
   if not (Client.VM.get_is_a_template ~rpc ~session_id ~self:template) then
     failwith "Can only install from templates" ;
-  let new_name = List.assoc "new-name-label" params in
+  let new_name = Cli_args.get "new-name-label" params in
   let new_description = "Installed via xe CLI" in
   (* Client.VM.get_name_description ~rpc ~session_id template in *)
   vm_install_real printer rpc session_id template new_name new_description
@@ -4476,15 +4454,13 @@ let get_templateVM_by_uuid rpc session_id template_uuid =
   template_ref
 
 let template_uninstall fd printer rpc session_id params =
-  let uuid = List.assoc "template-uuid" params in
+  let uuid = Cli_args.get "template-uuid" params in
   let vm = get_templateVM_by_uuid rpc session_id uuid in
   vm_uninstall_common fd printer rpc session_id params [vm]
 
 let vm_clone_aux clone_op printer include_template_vms rpc session_id params =
-  let new_name = List.assoc "new-name-label" params in
-  let desc =
-    try Some (List.assoc "new-name-description" params) with _ -> None
-  in
+  let new_name = Cli_args.get "new-name-label" params in
+  let desc = Cli_args.get_opt "new-name-description" params in
   let new_vms =
     do_vm_op printer ~include_template_vms rpc session_id
       (fun vm -> clone_op ~rpc ~session_id ~vm:(vm.getref ()) ~new_name)
@@ -4509,7 +4485,7 @@ let vm_clone printer = vm_clone_aux Client.VM.clone printer true
 
 let vm_snapshot printer rpc session_id params =
   let ignore_vdis_uuids =
-    match List.assoc_opt "ignore-vdi-uuids" params with
+    match Cli_args.get_opt "ignore-vdi-uuids" params with
     | None ->
         []
     | Some x ->
@@ -4530,10 +4506,10 @@ let vm_snapshot_with_quiesce printer =
 let vm_checkpoint printer = vm_clone_aux Client.VM.checkpoint printer false
 
 let get_snapshot_uuid params =
-  if List.mem_assoc "snapshot-uuid" params then
-    List.assoc "snapshot-uuid" params
-  else if List.mem_assoc "uuid" params then
-    List.assoc "uuid" params
+  if Cli_args.exists "snapshot-uuid" params then
+    Cli_args.get "snapshot-uuid" params
+  else if Cli_args.exists "uuid" params then
+    Cli_args.get "uuid" params
   else
     raise (failwith "Required parameter not found: snapshot-uuid or uuid.")
 
@@ -4554,10 +4530,10 @@ let snapshot_revert _printer rpc session_id params =
   Client.VM.revert ~rpc ~session_id ~snapshot:snap_ref
 
 let snapshot_op op printer rpc session_id params =
-  let new_name = List.assoc "new-name-label" params in
+  let new_name = Cli_args.get "new-name-label" params in
   let desc =
-    if List.mem_assoc "new-name-description" params then
-      Some (List.assoc "new-name-description" params)
+    if Cli_args.exists "new-name-description" params then
+      Some (Cli_args.get "new-name-description" params)
     else
       None
   in
@@ -4576,8 +4552,9 @@ let snapshot_clone printer = snapshot_op Client.VM.clone printer
 
 let snapshot_copy printer rpc session_id params =
   let sr =
-    if List.mem_assoc "sr-uuid" params then
-      Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "sr-uuid" params)
+    if Cli_args.exists "sr-uuid" params then
+      Client.SR.get_by_uuid ~rpc ~session_id
+        ~uuid:(Cli_args.get "sr-uuid" params)
     else
       Ref.null
   in
@@ -4597,13 +4574,12 @@ let snapshot_uninstall fd printer rpc session_id params =
   vm_uninstall_common fd printer rpc session_id params [snap_ref]
 
 let vm_copy printer rpc session_id params =
-  let new_name = List.assoc "new-name-label" params in
-  let desc =
-    try Some (List.assoc "new-name-description" params) with _ -> None
-  in
+  let new_name = Cli_args.get "new-name-label" params in
+  let desc = Cli_args.get_opt "new-name-description" params in
   let sr =
-    if List.mem_assoc "sr-uuid" params then
-      Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "sr-uuid" params)
+    if Cli_args.exists "sr-uuid" params then
+      Client.SR.get_by_uuid ~rpc ~session_id
+        ~uuid:(Cli_args.get "sr-uuid" params)
     else
       Ref.null
   in
@@ -4678,7 +4654,9 @@ let vm_reboot printer rpc session_id params =
     )
 
 let vm_compute_maximum_memory printer rpc session_id params =
-  let total = Record_util.bytes_of_string "total" (List.assoc "total" params) in
+  let total =
+    Record_util.bytes_of_string "total" (Cli_args.get "total" params)
+  in
   let approximate = get_bool_param params "approximate" in
   ignore
     (do_vm_op printer rpc session_id
@@ -4742,28 +4720,28 @@ let vm_migrate_sxm_params =
 let vm_migrate printer rpc session_id params =
   (* Hack to match host-uuid and host-name for backwards compatibility *)
   let params =
-    List.map
-      (fun (k, v) ->
+    Cli_args.to_pairs params
+    |> List.map (fun (k, v) ->
         if k = "host-uuid" || k = "host-name" then
           ("host", v)
         else
           (k, v)
-      )
-      params
+    )
+    |> Cli_args.from_pairs
   in
   let compress =
     (* Avoid setting a default for the compress option here if none
        given; let the API decide if no option is given. Otherwise API and
        CLI could implement different defaults *)
     let key = "compress" in
-    match List.assoc_opt key params with Some v -> [(key, v)] | None -> []
+    match Cli_args.get_opt key params with Some v -> [(key, v)] | None -> []
   in
   let options =
     (* For each boolean option, take the value given on the command line or
        default to "false", then validate it and canonicalise it to
        "true"/"false". *)
     let bool_option key =
-      let raw = Option.value ~default:"false" (List.assoc_opt key params) in
+      let raw = Cli_args.get_opt key params |> Option.value ~default:"false" in
       (key, string_of_bool (bool_of_string key raw))
     in
     compress @ List.map bool_option ["force"; "live"; "copy"]
@@ -4778,7 +4756,7 @@ let vm_migrate printer rpc session_id params =
         (fun p -> Astring.String.is_prefix ~affix:p k)
         vm_migrate_sxm_params
     in
-    List.exists (fun (k, _) -> is_sxm_param k) params
+    List.exists is_sxm_param (Cli_args.keys params)
   in
   if use_sxm_migration then (
     printer
@@ -4788,16 +4766,16 @@ let vm_migrate printer rpc session_id params =
       ) ;
     if
       not
-        (List.mem_assoc "remote-master" params
-        && List.mem_assoc "remote-username" params
-        && List.mem_assoc "remote-password" params
+        (Cli_args.exists "remote-master" params
+        && Cli_args.exists "remote-username" params
+        && Cli_args.exists "remote-password" params
         )
     then
       failwith
         "Storage live migration requires remote-master, remote-username, and \
          remote-password to be specified. Please see 'xe help vm-migrate' for \
          help." ;
-    let ip = List.assoc "remote-master" params in
+    let ip = Cli_args.get "remote-master" params in
     let remote_rpc xml =
       let open Xmlrpc_client in
       let http = xmlrpc ~version:"1.0" "/" in
@@ -4808,8 +4786,8 @@ let vm_migrate printer rpc session_id params =
           )
         ~http xml
     in
-    let uname = List.assoc "remote-username" params in
-    let pwd = List.assoc "remote-password" params in
+    let uname = Cli_args.get "remote-username" params in
+    let pwd = Cli_args.get "remote-password" params in
     let remote_session =
       Client.Session.login_with_password ~rpc:remote_rpc ~uname ~pwd
         ~version:"1.3" ~originator:Xapi_version.xapi_user_agent
@@ -4824,7 +4802,7 @@ let vm_migrate printer rpc session_id params =
               x x x
           in
           let expr, fail_msg =
-            match List.assoc_opt "host" params with
+            match Cli_args.get_opt "host" params with
             | Some x ->
                 (expr_match x, Printf.sprintf "Failed to find host: %s" x)
             | None ->
@@ -4842,7 +4820,7 @@ let vm_migrate printer rpc session_id params =
               {|(field "bridge"="%s") or (field "name__label"="%s") or (field "uuid"="%s")|}
               x x x
           in
-          match List.assoc_opt "remote-network" params with
+          match Cli_args.get_opt "remote-network" params with
           | Some x -> (
             match remote Client.Network.get_all_where ~expr:(expr x) with
             | network :: _ ->
@@ -5024,13 +5002,12 @@ let vm_migrate printer rpc session_id params =
               overrides @ filtered_orig_list
         in
         let params =
-          List.filter
-            (fun (s, _) ->
-              if String.length s < 5 then
-                true
-              else
-                let start = String.sub s 0 4 in
-                start <> "vif:" && start <> "vdi:"
+          Cli_args.filter_out
+            (fun s ->
+              String.length s >= 5
+              &&
+              let start = String.sub s 0 4 in
+              start = "vif:" || start = "vdi:"
             )
             params
         in
@@ -5095,11 +5072,11 @@ let vm_migrate printer rpc session_id params =
         Client.Session.logout ~rpc:remote_rpc ~session_id:remote_session
       )
   ) else (
-    if not (List.mem_assoc "host" params) then
+    if not (Cli_args.exists "host" params) then
       failwith "No destination host specified" ;
     let host =
-      (get_host_by_name_or_id rpc session_id (List.assoc "host" params)).getref
-        ()
+      (get_host_by_name_or_id rpc session_id (Cli_args.get "host" params))
+        .getref ()
     in
     ignore
       (do_vm_op ~include_control_vms:true printer rpc session_id
@@ -5141,14 +5118,14 @@ let vm_disk_list_aux vm is_cd_list printer rpc session_id params =
   in
   (* Hack - convert 'vbd-params' to 'params' *)
   let params' =
-    List.map
-      (fun (a, b) ->
+    Cli_args.to_pairs params
+    |> List.map (fun (a, b) ->
         if a = "vbd-params" then
           ("params", b)
         else
           (a, b)
-      )
-      params
+    )
+    |> Cli_args.from_pairs
   in
   let selectedvbd =
     select_fields params' vbdrecords
@@ -5159,14 +5136,14 @@ let vm_disk_list_aux vm is_cd_list printer rpc session_id params =
       )
   in
   let params' =
-    List.map
-      (fun (a, b) ->
+    Cli_args.to_pairs params
+    |> List.map (fun (a, b) ->
         if a = "vdi-params" then
           ("params", b)
         else
           (a, b)
-      )
-      params
+    )
+    |> Cli_args.from_pairs
   in
   let rec doit vbds vdis n =
     match (vbds, vdis) with
@@ -5232,12 +5209,12 @@ let vm_crashdump_list printer rpc session_id params =
 let vm_disk_add printer rpc session_id params =
   (* Required params *)
   let vdi_size =
-    Record_util.bytes_of_string "disk-size" (List.assoc "disk-size" params)
+    Record_util.bytes_of_string "disk-size" (Cli_args.get "disk-size" params)
   in
-  let vbd_device = List.assoc "device" params in
+  let vbd_device = Cli_args.get "device" params in
   let sr =
-    if List.mem_assoc "sr-uuid" params then
-      let sr_uuid = List.assoc "sr-uuid" params in
+    if Cli_args.exists "sr-uuid" params then
+      let sr_uuid = Cli_args.get "sr-uuid" params in
       Client.SR.get_by_uuid ~rpc ~session_id ~uuid:sr_uuid
     else
       match get_default_sr_uuid rpc session_id with
@@ -5275,7 +5252,7 @@ let vm_disk_add printer rpc session_id params =
     )
 
 let vm_disk_remove printer rpc session_id params =
-  let device = List.assoc "device" params in
+  let device = Cli_args.get "device" params in
   let op vm =
     let vm = vm.getref () in
     let vm_record = Client.VM.get_record ~rpc ~session_id ~self:vm in
@@ -5295,7 +5272,7 @@ let vm_disk_remove printer rpc session_id params =
   ignore (do_vm_op printer rpc session_id op params ["device"])
 
 let vm_cd_remove printer rpc session_id params =
-  let disk_name = List.assoc "cd-name" params in
+  let disk_name = Cli_args.get "cd-name" params in
   let op vm =
     let vm_record = vm.record () in
     let vbd_to_remove =
@@ -5319,7 +5296,7 @@ let vm_cd_remove printer rpc session_id params =
   ignore (do_vm_op printer rpc session_id op params ["cd-name"])
 
 let vm_cd_add printer rpc session_id params =
-  let cd_name = List.assoc "cd-name" params in
+  let cd_name = Cli_args.get "cd-name" params in
   let vdis = Client.VDI.get_by_name_label ~rpc ~session_id ~label:cd_name in
   let vdis =
     List.filter
@@ -5333,7 +5310,7 @@ let vm_cd_add printer rpc session_id params =
   let vdi = List.nth vdis 0 in
   let op vm =
     create_vbd_and_plug rpc session_id (vm.getref ()) vdi
-      (List.assoc "device" params)
+      (Cli_args.get "device" params)
       false `RO `CD true "" []
   in
   ignore
@@ -5366,7 +5343,7 @@ let vm_cd_eject printer rpc session_id params =
   ignore (do_vm_op printer rpc session_id op params [])
 
 let vm_cd_insert printer rpc session_id params =
-  let cd_name = List.assoc "cd-name" params in
+  let cd_name = Cli_args.get "cd-name" params in
   let vdis = Client.VDI.get_by_name_label ~rpc ~session_id ~label:cd_name in
   let vdis =
     List.filter
@@ -5413,7 +5390,7 @@ let vm_cd_insert printer rpc session_id params =
   ignore (do_vm_op printer rpc session_id op params ["cd-name"])
 
 let host_careful_op op warnings fd _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid in
   let force = get_bool_param params "force" in
   let go () = ignore (op ~rpc ~session_id ~self:host) in
@@ -5454,13 +5431,13 @@ let host_declare_dead x =
 
 let host_license_add fd _printer rpc session_id params =
   let host =
-    if List.mem_assoc "host-uuid" params then
+    if Cli_args.exists "host-uuid" params then
       Client.Host.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "host-uuid" params)
+        ~uuid:(Cli_args.get "host-uuid" params)
     else
       get_host_from_session rpc session_id
   in
-  let license_file = List.assoc "license-file" params in
+  let license_file = Cli_args.get "license-file" params in
   match get_client_file fd license_file with
   | Some license -> (
       debug "Checking license [%s]" license ;
@@ -5478,9 +5455,9 @@ let host_license_add fd _printer rpc session_id params =
 
 let host_license_remove _printer rpc session_id params =
   let host =
-    if List.mem_assoc "host-uuid" params then
+    if Cli_args.exists "host-uuid" params then
       Client.Host.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "host-uuid" params)
+        ~uuid:(Cli_args.get "host-uuid" params)
     else
       get_host_from_session rpc session_id
   in
@@ -5488,9 +5465,9 @@ let host_license_remove _printer rpc session_id params =
 
 let host_license_view printer rpc session_id params =
   let host =
-    if List.mem_assoc "host-uuid" params then
+    if Cli_args.exists "host-uuid" params then
       Client.Host.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "host-uuid" params)
+        ~uuid:(Cli_args.get "host-uuid" params)
     else
       get_host_from_session rpc session_id
   in
@@ -5510,8 +5487,8 @@ let with_license_server_changes printer rpc session_id params hosts f =
       hosts
   in
   (* Set any new license server address across the pool. *)
-  ( if List.mem_assoc "license-server-address" params then
-      let address = List.assoc "license-server-address" params in
+  ( if Cli_args.exists "license-server-address" params then
+      let address = Cli_args.get "license-server-address" params in
       List.iter
         (fun host ->
           Client.Host.remove_from_license_server ~rpc ~session_id ~self:host
@@ -5522,8 +5499,8 @@ let with_license_server_changes printer rpc session_id params hosts f =
         hosts
   ) ;
   (* Set any new license server port across the pool. *)
-  ( if List.mem_assoc "license-server-port" params then
-      let port = List.assoc "license-server-port" params in
+  ( if Cli_args.exists "license-server-port" params then
+      let port = Cli_args.get "license-server-port" params in
       let port_int = try int_of_string port with _ -> -1 in
       if port_int < 0 || port_int > 65535 then
         printer
@@ -5567,13 +5544,13 @@ let with_license_server_changes printer rpc session_id params hosts f =
 
 let host_apply_edition printer rpc session_id params =
   let host =
-    if List.mem_assoc "host-uuid" params then
+    if Cli_args.exists "host-uuid" params then
       Client.Host.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "host-uuid" params)
+        ~uuid:(Cli_args.get "host-uuid" params)
     else
       get_host_from_session rpc session_id
   in
-  let edition = List.assoc "edition" params in
+  let edition = Cli_args.get "edition" params in
   with_license_server_changes printer rpc session_id params [host]
     (fun rpc session_id ->
       Client.Host.apply_edition ~rpc ~session_id ~host ~edition ~force:false
@@ -5586,13 +5563,13 @@ let host_all_editions printer rpc session_id _params =
 
 let host_evacuate _printer rpc session_id params =
   let network =
-    List.assoc_opt "network-uuid" params
+    Cli_args.get_opt "network-uuid" params
     |> Option.fold ~none:Ref.null ~some:(fun uuid ->
         Client.Network.get_by_uuid ~rpc ~session_id ~uuid
     )
   in
   let evacuate_batch_size =
-    match List.assoc_opt "batch-size" params with
+    match Cli_args.get_opt "batch-size" params with
     | Some x ->
         Scanf.sscanf x "%Lu%!" Fun.id
     | None ->
@@ -5609,7 +5586,7 @@ let host_evacuate _printer rpc session_id params =
     )
 
 let host_get_vms_which_prevent_evacuation printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid in
   let vms =
     Client.Host.get_vms_which_prevent_evacuation ~rpc ~session_id ~self:host
@@ -5628,7 +5605,7 @@ let host_get_vms_which_prevent_evacuation printer rpc session_id params =
   ignore (List.iter op vms)
 
 let host_retrieve_wlb_evacuate_recommendations printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid in
   let vms =
     Client.Host.retrieve_wlb_evacuate_recommendations ~rpc ~session_id
@@ -5654,13 +5631,13 @@ let host_update_firewalld_service_status _printer rpc session_id _params =
   ignore (Client.Host.update_firewalld_service_status ~rpc ~session_id)
 
 let vdi_import fd _printer rpc session_id params =
-  let filename = List.assoc "filename" params in
+  let filename = Cli_args.get "filename" params in
   let vdi =
-    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let format =
-    if List.mem_assoc "format" params then
-      "&format=" ^ List.assoc "format" params
+    if Cli_args.exists "format" params then
+      "&format=" ^ Cli_args.get "format" params
     else
       ""
   in
@@ -5681,19 +5658,19 @@ let vdi_import fd _printer rpc session_id params =
     )
 
 let vdi_export fd _printer rpc session_id params =
-  let filename = List.assoc "filename" params in
+  let filename = Cli_args.get "filename" params in
   let vdi =
-    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let format =
-    if List.mem_assoc "format" params then
-      "&format=" ^ List.assoc "format" params
+    if Cli_args.exists "format" params then
+      "&format=" ^ Cli_args.get "format" params
     else
       ""
   in
   let base =
-    if List.mem_assoc "base" params then
-      "&base=" ^ List.assoc "base" params
+    if Cli_args.exists "base" params then
+      "&base=" ^ Cli_args.get "base" params
     else
       ""
   in
@@ -5803,8 +5780,8 @@ let download_file_with_task fd rpc session_id filename uri query label task_name
     (fun () -> Client.Task.destroy ~rpc ~session_id ~self:task)
 
 let pool_retrieve_wlb_report fd _printer rpc session_id params =
-  let report = List.assoc "report" params in
-  let filename = Listext.assoc_default "filename" params "" in
+  let report = Cli_args.get "report" params in
+  let filename = Cli_args.get_default "filename" params "" in
   let other_params = params_except ["report"; "filename"] params in
   download_file_with_task fd rpc session_id filename Constants.wlb_report_uri
     (Printf.sprintf "report=%s%s%s" (Http.urlencode report)
@@ -5826,15 +5803,16 @@ let pool_retrieve_wlb_report fd _printer rpc session_id params =
     (Printf.sprintf "WLB report: %s" report)
 
 let pool_retrieve_wlb_diagnostics fd _printer rpc session_id params =
-  let filename = Listext.assoc_default "filename" params "" in
+  let filename = Cli_args.get_default "filename" params "" in
   download_file_with_task fd rpc session_id filename
     Constants.wlb_diagnostics_uri "" "WLB diagnostics download"
     "WLB diagnostics download"
 
 let vm_import fd _printer rpc session_id params =
   let sr =
-    if List.mem_assoc "sr-uuid" params then
-      Client.SR.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "sr-uuid" params)
+    if Cli_args.exists "sr-uuid" params then
+      Client.SR.get_by_uuid ~rpc ~session_id
+        ~uuid:(Cli_args.get "sr-uuid" params)
     else
       match Cli_util.get_default_sr_uuid rpc session_id with
       | Some uuid ->
@@ -5849,7 +5827,7 @@ let vm_import fd _printer rpc session_id params =
   let force = get_bool_param params "force" in
   let dry_run = get_bool_param params "dry-run" in
   let vdi_map = read_map_params "vdi" params in
-  if List.mem_assoc "url" params && List.mem_assoc "filename" params then (
+  if Cli_args.exists "url" params && Cli_args.exists "filename" params then (
     marshal fd
       (Command
          (PrintStderr
@@ -5860,13 +5838,13 @@ let vm_import fd _printer rpc session_id params =
     raise (ExitWithError 1)
   ) ;
   if Vpx_types.of_string _type <> Vpx_types.XenServer then
-    let username = List.assoc "host-username" params in
-    let password = List.assoc "host-password" params in
+    let username = Cli_args.get "host-username" params in
+    let password = Cli_args.get "host-password" params in
     let remote_config = read_map_params "remote-config" params in
     Client.VM.import_convert ~rpc ~session_id ~_type ~username ~password ~sr
       ~remote_config
-  else if List.mem_assoc "url" params then
-    let url = List.assoc "url" params in
+  else if Cli_args.exists "url" params then
+    let url = Cli_args.get "url" params in
     let vm_refs =
       Client.VM.import ~rpc ~session_id ~url ~sr ~full_restore ~force
     in
@@ -5875,7 +5853,7 @@ let vm_import fd _printer rpc session_id params =
     in
     marshal fd (Command (Print (String.concat "," uuids)))
   else
-    let filename = List.assoc "filename" params in
+    let filename = Cli_args.get "filename" params in
     if (not vm_metadata_only) && dry_run then (
       marshal fd
         (Command (PrintStderr "Only metadata import function support dry-run\n")) ;
@@ -5919,7 +5897,7 @@ let vm_import fd _printer rpc session_id params =
     let importtask =
       Option.map
         (fun uuid -> Client.Task.get_by_uuid ~rpc ~session_id ~uuid)
-        (List.assoc_opt "task-uuid" params)
+        (Cli_args.get_opt "task-uuid" params)
     in
     let result =
       track_http_operation ?use_existing_task:importtask fd rpc session_id
@@ -5938,9 +5916,9 @@ let vm_import fd _printer rpc session_id params =
     marshal fd (Command (Print (String.concat "," uuids)))
 
 let blob_get fd _printer rpc session_id params =
-  let blob_uuid = List.assoc "uuid" params in
+  let blob_uuid = Cli_args.get "uuid" params in
   let blob_ref = Client.Blob.get_by_uuid ~rpc ~session_id ~uuid:blob_uuid in
-  let filename = List.assoc "filename" params in
+  let filename = Cli_args.get "filename" params in
   let blobtask =
     Client.Task.create ~rpc ~session_id
       ~label:(Printf.sprintf "Obtaining blob, ref=%s" (Ref.string_of blob_ref))
@@ -6002,9 +5980,9 @@ let blob_get fd _printer rpc session_id params =
     (fun () -> Client.Task.destroy ~rpc ~session_id ~self:blobtask)
 
 let blob_put fd _printer rpc session_id params =
-  let blob_uuid = List.assoc "uuid" params in
+  let blob_uuid = Cli_args.get "uuid" params in
   let blob_ref = Client.Blob.get_by_uuid ~rpc ~session_id ~uuid:blob_uuid in
-  let filename = List.assoc "filename" params in
+  let filename = Cli_args.get "filename" params in
   let blobtask =
     Client.Task.create ~rpc ~session_id
       ~label:(Printf.sprintf "Blob PUT, ref=%s" (Ref.string_of blob_ref))
@@ -6066,19 +6044,19 @@ let blob_put fd _printer rpc session_id params =
     (fun () -> Client.Task.destroy ~rpc ~session_id ~self:blobtask)
 
 let blob_create printer rpc session_id params =
-  let name = List.assoc "name" params in
-  let mime_type = Listext.assoc_default "mime-type" params "" in
+  let name = Cli_args.get "name" params in
+  let mime_type = Cli_args.get_default "mime-type" params "" in
   let public = get_bool_param params "public" in
-  if List.mem_assoc "vm-uuid" params then
-    let uuid = List.assoc "vm-uuid" params in
+  if Cli_args.exists "vm-uuid" params then
+    let uuid = Cli_args.get "vm-uuid" params in
     let vm = Client.VM.get_by_uuid ~rpc ~session_id ~uuid in
     let blob =
       Client.VM.create_new_blob ~rpc ~session_id ~vm ~name ~mime_type ~public
     in
     let blob_uuid = Client.Blob.get_uuid ~rpc ~session_id ~self:blob in
     printer (Cli_printer.PList [blob_uuid])
-  else if List.mem_assoc "pool-uuid" params then
-    let uuid = List.assoc "pool-uuid" params in
+  else if Cli_args.exists "pool-uuid" params then
+    let uuid = Cli_args.get "pool-uuid" params in
     let pool = Client.Pool.get_by_uuid ~rpc ~session_id ~uuid in
     let blob =
       Client.Pool.create_new_blob ~rpc ~session_id ~pool ~name ~mime_type
@@ -6086,16 +6064,16 @@ let blob_create printer rpc session_id params =
     in
     let blob_uuid = Client.Blob.get_uuid ~rpc ~session_id ~self:blob in
     printer (Cli_printer.PList [blob_uuid])
-  else if List.mem_assoc "sr-uuid" params then
-    let uuid = List.assoc "sr-uuid" params in
+  else if Cli_args.exists "sr-uuid" params then
+    let uuid = Cli_args.get "sr-uuid" params in
     let sr = Client.SR.get_by_uuid ~rpc ~session_id ~uuid in
     let blob =
       Client.SR.create_new_blob ~rpc ~session_id ~sr ~name ~mime_type ~public
     in
     let blob_uuid = Client.Blob.get_uuid ~rpc ~session_id ~self:blob in
     printer (Cli_printer.PList [blob_uuid])
-  else if List.mem_assoc "host-uuid" params then
-    let uuid = List.assoc "host-uuid" params in
+  else if Cli_args.exists "host-uuid" params then
+    let uuid = Cli_args.get "host-uuid" params in
     let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid in
     let blob =
       Client.Host.create_new_blob ~rpc ~session_id ~host ~name ~mime_type
@@ -6103,8 +6081,8 @@ let blob_create printer rpc session_id params =
     in
     let blob_uuid = Client.Blob.get_uuid ~rpc ~session_id ~self:blob in
     printer (Cli_printer.PList [blob_uuid])
-  else if List.mem_assoc "network-uuid" params then
-    let uuid = List.assoc "network-uuid" params in
+  else if Cli_args.exists "network-uuid" params then
+    let uuid = Cli_args.get "network-uuid" params in
     let network = Client.Network.get_by_uuid ~rpc ~session_id ~uuid in
     let blob =
       Client.Network.create_new_blob ~rpc ~session_id ~network ~name ~mime_type
@@ -6177,14 +6155,14 @@ let export_common fd _printer rpc session_id params filename num ?task_uuid
 
 let get_compression_algorithm params =
   Option.bind
-    (List.assoc_opt "compress" params)
+    (Cli_args.get_opt "compress" params)
     Compression_algorithms.of_string
 
 let vm_export fd printer rpc session_id params =
-  let filename = List.assoc "filename" params in
+  let filename = Cli_args.get "filename" params in
   let compression = get_compression_algorithm params in
   let preserve_power_state = get_bool_param params "preserve-power-state" in
-  let task_uuid = List.assoc_opt "task-uuid" params in
+  let task_uuid = Cli_args.get_opt "task-uuid" params in
   let num = Atomic.make 1 in
   let op vm =
     export_common fd printer rpc session_id params filename num ?task_uuid
@@ -6203,10 +6181,10 @@ let vm_export fd printer rpc session_id params =
     )
 
 let vm_export_aux obj_type fd printer rpc session_id params =
-  let filename = List.assoc "filename" params in
+  let filename = Cli_args.get "filename" params in
   let compression = get_compression_algorithm params in
   let preserve_power_state = get_bool_param params "preserve-power-state" in
-  let uuid = List.assoc (obj_type ^ "-uuid") params in
+  let uuid = Cli_args.get (obj_type ^ "-uuid") params in
   let vm = Client.VM.get_by_uuid ~rpc ~session_id ~uuid in
   let is_template () = Client.VM.get_is_a_template ~rpc ~session_id ~self:vm in
   let is_snapshot () = Client.VM.get_is_a_snapshot ~rpc ~session_id ~self:vm in
@@ -6225,7 +6203,7 @@ let vm_export_aux obj_type fd printer rpc session_id params =
 let vm_copy_bios_strings printer rpc session_id params =
   let host =
     Client.Host.get_by_uuid ~rpc ~session_id
-      ~uuid:(List.assoc "host-uuid" params)
+      ~uuid:(Cli_args.get "host-uuid" params)
   in
   let op vm =
     Client.VM.copy_bios_strings ~rpc ~session_id ~vm:(vm.getref ()) ~host
@@ -6252,7 +6230,7 @@ let template_export fd printer = vm_export_aux "template" fd printer
 let snapshot_export fd printer = vm_export_aux "snapshot" fd printer
 
 let vm_vcpu_hotplug printer rpc session_id params =
-  let vcpus = List.assoc "new-vcpus" params in
+  let vcpus = Cli_args.get "new-vcpus" params in
   let nvcpu =
     try Int64.of_string vcpus
     with _ ->
@@ -6316,7 +6294,7 @@ let with_database_vdi rpc session_id params f =
 
 let vm_recover _printer rpc session_id params =
   let force = get_bool_param params "force" in
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   with_database_vdi rpc session_id params (fun database_session ->
       let vm = Client.VM.get_by_uuid ~rpc ~session_id:database_session ~uuid in
       Client.VM.recover ~rpc ~session_id:database_session ~self:vm
@@ -6324,7 +6302,7 @@ let vm_recover _printer rpc session_id params =
   )
 
 let vm_assert_can_be_recovered _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   with_database_vdi rpc session_id params (fun database_session ->
       let vm = Client.VM.get_by_uuid ~rpc ~session_id:database_session ~uuid in
       Client.VM.assert_can_be_recovered ~rpc ~session_id:database_session
@@ -6332,14 +6310,14 @@ let vm_assert_can_be_recovered _printer rpc session_id params =
   )
 
 let vm_set_uefi_mode printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
-  let mode = Record_util.vm_uefi_mode_of_string (List.assoc "mode" params) in
+  let uuid = Cli_args.get "uuid" params in
+  let mode = Record_util.vm_uefi_mode_of_string (Cli_args.get "mode" params) in
   let vm = Client.VM.get_by_uuid ~rpc ~session_id ~uuid in
   let result = Client.VM.set_uefi_mode ~rpc ~session_id ~self:vm ~mode in
   printer (Cli_printer.PMsg result)
 
 let vm_get_secureboot_readiness printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let vm = Client.VM.get_by_uuid ~rpc ~session_id ~uuid in
   let result = Client.VM.get_secureboot_readiness ~rpc ~session_id ~self:vm in
   printer
@@ -6378,16 +6356,17 @@ let cd_list printer rpc session_id params =
   printer (Cli_printer.PTable (List.map table cd_vdis))
 
 let validate_and_get_vlan params =
-  try Int64.of_string (List.assoc "vlan" params)
+  try Int64.of_string (Cli_args.get "vlan" params)
   with _ -> failwith "Failed to parse parameter 'vlan': expecting an integer"
 
 let vlan_create printer rpc session_id params =
   let network =
     Client.Network.get_by_uuid ~rpc ~session_id
-      ~uuid:(List.assoc "network-uuid" params)
+      ~uuid:(Cli_args.get "network-uuid" params)
   in
   let tagged_PIF =
-    Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "pif-uuid" params)
+    Client.PIF.get_by_uuid ~rpc ~session_id
+      ~uuid:(Cli_args.get "pif-uuid" params)
   in
   let vLAN = validate_and_get_vlan params in
   let vlan =
@@ -6401,10 +6380,11 @@ let vlan_create printer rpc session_id params =
 let pool_vlan_create printer rpc session_id params =
   let network =
     Client.Network.get_by_uuid ~rpc ~session_id
-      ~uuid:(List.assoc "network-uuid" params)
+      ~uuid:(Cli_args.get "network-uuid" params)
   in
   let pif =
-    Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "pif-uuid" params)
+    Client.PIF.get_by_uuid ~rpc ~session_id
+      ~uuid:(Cli_args.get "pif-uuid" params)
   in
   let vLAN = validate_and_get_vlan params in
   let vlan_pifs =
@@ -6418,7 +6398,7 @@ let pool_vlan_create printer rpc session_id params =
 
 let vlan_destroy _printer rpc session_id params =
   (* Rio allowed a PIF UUID to be provided; support this mechanism *)
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   try
     let vlan = Client.VLAN.get_by_uuid ~rpc ~session_id ~uuid in
     Client.VLAN.destroy ~rpc ~session_id ~self:vlan
@@ -6441,14 +6421,15 @@ let vlan_destroy _printer rpc session_id params =
 let tunnel_create printer rpc session_id params =
   let network =
     Client.Network.get_by_uuid ~rpc ~session_id
-      ~uuid:(List.assoc "network-uuid" params)
+      ~uuid:(Cli_args.get "network-uuid" params)
   in
   let pif =
-    Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "pif-uuid" params)
+    Client.PIF.get_by_uuid ~rpc ~session_id
+      ~uuid:(Cli_args.get "pif-uuid" params)
   in
   let protocol =
     Record_util.tunnel_protocol_of_string
-      (List.assoc_opt "protocol" params |> Option.value ~default:"gre")
+      (Cli_args.get_default "protocol" params "gre")
   in
   let tunnel =
     Client.Tunnel.create ~rpc ~session_id ~transport_PIF:pif ~network ~protocol
@@ -6458,7 +6439,7 @@ let tunnel_create printer rpc session_id params =
   printer (Cli_printer.PList [uuid])
 
 let tunnel_destroy _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let tunnel = Client.Tunnel.get_by_uuid ~rpc ~session_id ~uuid in
   Client.Tunnel.destroy ~rpc ~session_id ~self:tunnel
 
@@ -6502,7 +6483,8 @@ let diagnostic_net_stats printer rpc session_id params =
     ["method"; "uri"; "params"; "requests"; "connections"; "framed"]
   in
   let xapi_params =
-    List.filter (fun (k, _) -> List.mem k args_pass_to_api) params
+    Cli_args.to_pairs params
+    |> List.filter (fun (k, _) -> List.mem k args_pass_to_api)
   in
   ignore
     (do_host_op rpc session_id ~multiple:false
@@ -6636,11 +6618,11 @@ module Network_sriov = struct
   let create printer rpc session_id params =
     let pif =
       Client.PIF.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "pif-uuid" params)
+        ~uuid:(Cli_args.get "pif-uuid" params)
     in
     let network =
       Client.Network.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "network-uuid" params)
+        ~uuid:(Cli_args.get "network-uuid" params)
     in
     let sriov = Client.Network_sriov.create ~rpc ~session_id ~pif ~network in
     let uuid = Client.Network_sriov.get_uuid ~rpc ~session_id ~self:sriov in
@@ -6649,21 +6631,21 @@ module Network_sriov = struct
   let destroy _printer rpc session_id params =
     let sriov =
       Client.Network_sriov.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "uuid" params)
+        ~uuid:(Cli_args.get "uuid" params)
     in
     ignore (Client.Network_sriov.destroy ~rpc ~session_id ~self:sriov)
 end
 
 let pif_reconfigure_ip _printer rpc session_id params =
   let pif =
-    Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let mode =
-    Record_util.ip_configuration_mode_of_string (List.assoc "mode" params)
+    Record_util.ip_configuration_mode_of_string (Cli_args.get "mode" params)
   in
   let iP = assoc_default_ci "IP" params in
-  let netmask = Listext.assoc_default "netmask" params "" in
-  let gateway = Listext.assoc_default "gateway" params "" in
+  let netmask = Cli_args.get_default "netmask" params "" in
+  let gateway = Cli_args.get_default "gateway" params "" in
   let dNS = assoc_default_ci "DNS" params in
   let () =
     Client.PIF.reconfigure_ip ~rpc ~session_id ~self:pif ~mode ~iP ~netmask
@@ -6673,13 +6655,13 @@ let pif_reconfigure_ip _printer rpc session_id params =
 
 let pif_reconfigure_ipv6 _printer rpc session_id params =
   let pif =
-    Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let mode =
-    Record_util.ipv6_configuration_mode_of_string (List.assoc "mode" params)
+    Record_util.ipv6_configuration_mode_of_string (Cli_args.get "mode" params)
   in
   let iPv6 = assoc_default_ci "IPv6" params in
-  let gateway = Listext.assoc_default "gateway" params "" in
+  let gateway = Cli_args.get_default "gateway" params "" in
   let dNS = assoc_default_ci "DNS" params in
   let () =
     Client.PIF.reconfigure_ipv6 ~rpc ~session_id ~self:pif ~mode ~iPv6 ~gateway
@@ -6689,11 +6671,11 @@ let pif_reconfigure_ipv6 _printer rpc session_id params =
 
 let pif_set_primary_address_type _printer rpc session_id params =
   let pif =
-    Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let primary_address_type =
     Record_util.primary_address_type_of_string
-      (List.assoc "primary_address_type" params)
+      (Cli_args.get "primary_address_type" params)
   in
   let () =
     Client.PIF.set_primary_address_type ~rpc ~session_id ~self:pif
@@ -6703,59 +6685,59 @@ let pif_set_primary_address_type _printer rpc session_id params =
 
 let pif_unplug _printer rpc session_id params =
   let pif =
-    Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let () = Client.PIF.unplug ~rpc ~session_id ~self:pif in
   ()
 
 let pif_plug _printer rpc session_id params =
   let pif =
-    Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let () = Client.PIF.plug ~rpc ~session_id ~self:pif in
   ()
 
 let pif_scan _printer rpc session_id params =
-  let host_uuid = List.assoc "host-uuid" params in
+  let host_uuid = Cli_args.get "host-uuid" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
   let () = Client.PIF.scan ~rpc ~session_id ~host in
   ()
 
 let pif_introduce printer rpc session_id params =
-  let host_uuid = List.assoc "host-uuid" params in
+  let host_uuid = Cli_args.get "host-uuid" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
-  let mAC = Listext.assoc_default "mac" params "" in
-  let device = List.assoc "device" params in
+  let mAC = Cli_args.get_default "mac" params "" in
+  let device = Cli_args.get "device" params in
   let managed = get_bool_param params ~default:true "managed" in
   let pif = Client.PIF.introduce ~rpc ~session_id ~host ~mAC ~device ~managed in
   let uuid = Client.PIF.get_uuid ~rpc ~session_id ~self:pif in
   printer (Cli_printer.PList [uuid])
 
 let pif_forget _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let pif = Client.PIF.get_by_uuid ~rpc ~session_id ~uuid in
   let () = Client.PIF.forget ~rpc ~session_id ~self:pif in
   ()
 
 let pif_db_forget _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let pif = Client.PIF.get_by_uuid ~rpc ~session_id ~uuid in
   let () = Client.PIF.db_forget ~rpc ~session_id ~self:pif in
   ()
 
 let bond_create printer rpc session_id params =
-  let network_uuid = List.assoc "network-uuid" params in
-  let mAC = Listext.assoc_default "mac" params "" in
+  let network_uuid = Cli_args.get "network-uuid" params in
+  let mAC = Cli_args.get_default "mac" params "" in
   let network =
     Client.Network.get_by_uuid ~rpc ~session_id ~uuid:network_uuid
   in
-  let pifs = List.assoc "pif-uuids" params in
+  let pifs = Cli_args.get "pif-uuids" params in
   let uuids = String.split_on_char ',' pifs in
   let pifs =
     List.map (fun uuid -> Client.PIF.get_by_uuid ~rpc ~session_id ~uuid) uuids
   in
   let mode =
-    Record_util.bond_mode_of_string (Listext.assoc_default "mode" params "")
+    Record_util.bond_mode_of_string (Cli_args.get_default "mode" params "")
   in
   let properties = read_map_params "properties" params in
   let bond =
@@ -6766,15 +6748,15 @@ let bond_create printer rpc session_id params =
   printer (Cli_printer.PList [uuid])
 
 let bond_destroy _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let bond = Client.Bond.get_by_uuid ~rpc ~session_id ~uuid in
   Client.Bond.destroy ~rpc ~session_id ~self:bond
 
 let bond_set_mode _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let bond = Client.Bond.get_by_uuid ~rpc ~session_id ~uuid in
   let mode =
-    Record_util.bond_mode_of_string (Listext.assoc_default "mode" params "")
+    Record_util.bond_mode_of_string (Cli_args.get_default "mode" params "")
   in
   Client.Bond.set_mode ~rpc ~session_id ~self:bond ~value:mode
 
@@ -6845,7 +6827,7 @@ let host_power_on _printer rpc session_id params =
     )
 
 let host_prepare_for_poweroff _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid in
   Client.Host.prepare_for_poweroff ~rpc ~session_id ~host
 
@@ -6860,7 +6842,7 @@ let host_enable_local_storage_caching _printer rpc session_id params =
   ignore
     (do_host_op rpc session_id
        (fun _ host ->
-         let sr_uuid = List.assoc "sr-uuid" params in
+         let sr_uuid = Cli_args.get "sr-uuid" params in
          let sr = Client.SR.get_by_uuid ~rpc ~session_id ~uuid:sr_uuid in
          Client.Host.enable_local_storage_caching ~rpc ~session_id
            ~host:(host.getref ()) ~sr
@@ -6888,7 +6870,7 @@ let pool_disable_local_storage_caching _printer rpc session_id _params =
 
 let pool_apply_edition printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
-  let edition = List.assoc "edition" params in
+  let edition = Cli_args.get "edition" params in
   let hosts = Client.Host.get_all ~rpc ~session_id in
   with_license_server_changes printer rpc session_id params hosts
     (fun rpc session_id ->
@@ -6896,7 +6878,7 @@ let pool_apply_edition printer rpc session_id params =
   )
 
 let host_set_power_on_mode _printer rpc session_id params =
-  let power_on_mode = List.assoc "power-on-mode" params in
+  let power_on_mode = Cli_args.get "power-on-mode" params in
   let power_on_config = read_map_params "power-on-config" params in
   ignore
     (do_host_op rpc session_id
@@ -6911,26 +6893,30 @@ let host_set_power_on_mode _printer rpc session_id params =
 let host_crash_upload _printer rpc session_id params =
   let crash =
     Client.Host_crashdump.get_by_uuid ~rpc ~session_id
-      ~uuid:(List.assoc "uuid" params)
+      ~uuid:(Cli_args.get "uuid" params)
   in
-  let url = Listext.assoc_default "url" params "" in
+  let url = Cli_args.get_default "url" params "" in
   (* pass everything else in as an option *)
-  let options = List.filter (fun (k, _) -> k <> "uuid" && k <> "url") params in
+  let options =
+    Cli_args.to_pairs params
+    |> List.filter (fun (k, _) -> k <> "uuid" && k <> "url")
+  in
   Client.Host_crashdump.upload ~rpc ~session_id ~self:crash ~url ~options
 
 let host_crash_destroy _printer rpc session_id params =
   let crash =
     Client.Host_crashdump.get_by_uuid ~rpc ~session_id
-      ~uuid:(List.assoc "uuid" params)
+      ~uuid:(Cli_args.get "uuid" params)
   in
   Client.Host_crashdump.destroy ~rpc ~session_id ~self:crash
 
 let host_bugreport_upload _printer rpc session_id params =
   let op _ host =
-    let url = Listext.assoc_default "url" params "" in
+    let url = Cli_args.get_default "url" params "" in
     (* pass everything else in as an option *)
     let options =
-      List.filter (fun (k, _) -> k <> "host" && k <> "url") params
+      Cli_args.to_pairs params
+      |> List.filter (fun (k, _) -> k <> "host" && k <> "url")
     in
     Client.Host.bugreport_upload ~rpc ~session_id ~host:(host.getref ()) ~url
       ~options
@@ -6939,7 +6925,7 @@ let host_bugreport_upload _printer rpc session_id params =
 
 let host_backup fd _printer rpc session_id params =
   let op _ host =
-    let filename = List.assoc "file-name" params in
+    let filename = Cli_args.get "file-name" params in
     let prefix =
       let uuid = safe_get_field (field_lookup host.fields "uuid") in
       let someone =
@@ -6964,7 +6950,7 @@ let host_backup fd _printer rpc session_id params =
   ignore (do_host_op rpc session_id op params ["file-name"] ~multiple:false)
 
 let pool_dump_db fd _printer rpc session_id params =
-  let filename = List.assoc "file-name" params in
+  let filename = Cli_args.get "file-name" params in
   let make_command task_id =
     let master = get_master ~rpc ~session_id in
     let master_address =
@@ -6989,13 +6975,13 @@ let pool_dump_db fd _printer rpc session_id params =
   ignore (track_http_operation fd rpc session_id make_command "dump database")
 
 let pool_restore_db fd printer rpc session_id params =
-  let dry_run = List.mem_assoc "dry-run" params in
-  if (not (List.mem_assoc "force" params)) && not dry_run then
+  let dry_run = Cli_args.exists "dry-run" params in
+  if (not (Cli_args.exists "force" params)) && not dry_run then
     failwith
       "This operation will restore the database backup to this host, making it \
        the master. All slave hosts are assumed dead and they will be \
        forgotten. This operation must be forced (use --force)." ;
-  let filename = List.assoc "file-name" params in
+  let filename = Cli_args.get "file-name" params in
   let make_command task_id =
     let prefix = uri_of_someone rpc session_id Master in
     let uri =
@@ -7021,8 +7007,8 @@ let pool_restore_db fd printer rpc session_id params =
 
 let pool_enable_external_auth _printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
-  let auth_type = List.assoc "auth-type" params in
-  let service_name = List.assoc "service-name" params in
+  let auth_type = Cli_args.get "auth-type" params in
+  let service_name = Cli_args.get "service-name" params in
   let config = read_map_params "config" params in
   Client.Pool.enable_external_auth ~rpc ~session_id ~pool ~config ~service_name
     ~auth_type
@@ -7071,7 +7057,7 @@ let pool_get_cpu_features printer rpc session_id params =
   printer (Cli_printer.PTable [features])
 
 let pool_sync_bundle fd _printer rpc session_id params =
-  let filename_opt = List.assoc_opt "filename" params in
+  let filename_opt = Cli_args.get_opt "filename" params in
   match filename_opt with
   | Some filename ->
       let make_command task_id =
@@ -7109,7 +7095,7 @@ let pool_disable_ssh _printer rpc session_id params =
   Client.Pool.disable_ssh ~rpc ~session_id ~self:pool
 
 let host_restore fd _printer rpc session_id params =
-  let filename = List.assoc "file-name" params in
+  let filename = Cli_args.get "file-name" params in
   let op _ host =
     let prefix =
       let uuid = safe_get_field (field_lookup host.fields "uuid") in
@@ -7145,9 +7131,9 @@ let host_get_system_status_capabilities printer rpc session_id params =
     )
 
 let host_get_system_status fd _printer rpc session_id params =
-  let filename = List.assoc "filename" params in
-  let entries = Listext.assoc_default "entries" params "" in
-  let output = try List.assoc "output" params with _ -> "tar.bz2" in
+  let filename = Cli_args.get "filename" params in
+  let entries = Cli_args.get_default "entries" params "" in
+  let output = try Cli_args.get "output" params with _ -> "tar.bz2" in
   ( match output with
   | "tar.bz2" | "tar" | "zip" ->
       ()
@@ -7174,16 +7160,16 @@ let host_get_system_status fd _printer rpc session_id params =
   ignore (do_host_op rpc session_id op params ["filename"; "entries"; "output"])
 
 let host_set_hostname_live _printer rpc session_id params =
-  let host_uuid = List.assoc "host-uuid" params in
+  let host_uuid = Cli_args.get "host-uuid" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
-  let hostname = List.assoc "host-name" params in
+  let hostname = Cli_args.get "host-name" params in
   Client.Host.set_hostname_live ~rpc ~session_id ~host ~hostname
 
 let host_call_plugin fd printer rpc session_id params =
-  let host_uuid = List.assoc "host-uuid" params in
+  let host_uuid = Cli_args.get "host-uuid" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
-  let plugin = List.assoc "plugin" params in
-  let fn = List.assoc "fn" params in
+  let plugin = Cli_args.get "plugin" params in
+  let fn = Cli_args.get "fn" params in
   let args = read_map_params "args" params in
   let args = List.map (args_file fd) args in
   let result =
@@ -7192,46 +7178,46 @@ let host_call_plugin fd printer rpc session_id params =
   printer (Cli_printer.PList [result])
 
 let host_enable_external_auth _printer rpc session_id params =
-  if not (List.mem_assoc "force" params) then
+  if not (Cli_args.exists "force" params) then
     failwith
       "This operation is provided only to recover individual hosts that are \
        unable to access the external authentication service. This operation \
        must be forced (use --force)." ;
-  let host_uuid = List.assoc "host-uuid" params in
-  let auth_type = List.assoc "auth-type" params in
-  let service_name = List.assoc "service-name" params in
+  let host_uuid = Cli_args.get "host-uuid" params in
+  let auth_type = Cli_args.get "auth-type" params in
+  let service_name = Cli_args.get "service-name" params in
   let config = read_map_params "config" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
   Client.Host.enable_external_auth ~rpc ~session_id ~host ~config ~service_name
     ~auth_type
 
 let host_disable_external_auth _printer rpc session_id params =
-  if not (List.mem_assoc "force" params) then
+  if not (Cli_args.exists "force" params) then
     failwith
       "This operation is provided only to recover individual hosts that are \
        unable to access the external authentication service. This operation \
        must be forced (use --force)." ;
-  let host_uuid = List.assoc "host-uuid" params in
+  let host_uuid = Cli_args.get "host-uuid" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
   let config = read_map_params "config" params in
   Client.Host.disable_external_auth ~rpc ~session_id ~host ~config ~force:true
 
 let host_external_auth_set_ldaps _printer rpc session_id params =
-  let host_uuid = List.assoc "host-uuid" params in
+  let host_uuid = Cli_args.get "host-uuid" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
   let ldaps = get_bool_param params "ldaps" in
   let force = get_bool_param params ~default:false "force" in
   Client.Host.external_auth_set_ldaps ~rpc ~session_id ~host ~ldaps ~force
 
 let host_refresh_pack_info _printer rpc session_id params =
-  let host_uuid = List.assoc "host-uuid" params in
+  let host_uuid = Cli_args.get "host-uuid" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
   Client.Host.refresh_pack_info ~rpc ~session_id ~host
 
 let host_cpu_info printer rpc session_id params =
   let host =
-    if List.mem_assoc "uuid" params then
-      Client.Host.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    if Cli_args.exists "uuid" params then
+      Client.Host.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
     else
       get_host_from_session rpc session_id
   in
@@ -7240,8 +7226,8 @@ let host_cpu_info printer rpc session_id params =
 
 let host_get_cpu_features printer rpc session_id params =
   let host =
-    if List.mem_assoc "uuid" params then
-      Client.Host.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    if Cli_args.exists "uuid" params then
+      Client.Host.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
     else
       get_host_from_session rpc session_id
   in
@@ -7260,14 +7246,14 @@ let host_get_cpu_features printer rpc session_id params =
 
 let host_enable_display printer rpc session_id params =
   let host =
-    Client.Host.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.Host.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let result = Client.Host.enable_display ~rpc ~session_id ~host in
   printer (Cli_printer.PMsg (Record_util.host_display_to_string result))
 
 let host_disable_display printer rpc session_id params =
   let host =
-    Client.Host.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+    Client.Host.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
   let result = Client.Host.disable_display ~rpc ~session_id ~host in
   printer (Cli_printer.PMsg (Record_util.host_display_to_string result))
@@ -7283,7 +7269,7 @@ let set_update_vdi_name rpc session_id update_ref =
     ~value:(Printf.sprintf "Update: %s" update_name)
 
 let patch_upload fd _printer rpc session_id params =
-  let filename = List.assoc "file-name" params in
+  let filename = Cli_args.get "file-name" params in
   let make_command task_id =
     let prefix = uri_of_someone rpc session_id Master in
     let pools = Client.Pool.get_all ~rpc ~session_id in
@@ -7312,13 +7298,13 @@ let patch_upload fd _printer rpc session_id params =
   marshal fd (Command (Print patch_uuid))
 
 let update_upload fd _printer rpc session_id params =
-  let filename = List.assoc "file-name" params in
+  let filename = Cli_args.get "file-name" params in
   let make_command task_id =
     let prefix = uri_of_someone rpc session_id Master in
     let sr =
-      if List.mem_assoc "sr-uuid" params then
+      if Cli_args.exists "sr-uuid" params then
         Client.SR.get_by_uuid ~rpc ~session_id
-          ~uuid:(List.assoc "sr-uuid" params)
+          ~uuid:(Cli_args.get "sr-uuid" params)
       else
         match get_default_sr_uuid rpc session_id with
         | Some uuid ->
@@ -7354,23 +7340,23 @@ let update_upload fd _printer rpc session_id params =
   marshal fd (Command (Print update_uuid))
 
 let patch_clean _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let patch_ref = Client.Pool_patch.get_by_uuid ~rpc ~session_id ~uuid in
   Client.Pool_patch.clean ~rpc ~session_id ~self:patch_ref
 
 let patch_pool_clean _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let patch_ref = Client.Pool_patch.get_by_uuid ~rpc ~session_id ~uuid in
   Client.Pool_patch.pool_clean ~rpc ~session_id ~self:patch_ref
 
 let patch_destroy _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let patch_ref = Client.Pool_patch.get_by_uuid ~rpc ~session_id ~uuid in
   Client.Pool_patch.destroy ~rpc ~session_id ~self:patch_ref
 
 let patch_apply printer rpc session_id params =
-  let patch_uuid = List.assoc "uuid" params in
-  let host_uuid = List.assoc "host-uuid" params in
+  let patch_uuid = Cli_args.get "uuid" params in
+  let host_uuid = Cli_args.get "host-uuid" params in
   let patch_ref =
     Client.Pool_patch.get_by_uuid ~rpc ~session_id ~uuid:patch_uuid
   in
@@ -7381,8 +7367,8 @@ let patch_apply printer rpc session_id params =
   printer (Cli_printer.PList [result])
 
 let patch_precheck printer rpc session_id params =
-  let patch_uuid = List.assoc "uuid" params in
-  let host_uuid = List.assoc "host-uuid" params in
+  let patch_uuid = Cli_args.get "uuid" params in
+  let host_uuid = Cli_args.get "host-uuid" params in
   let patch_ref =
     Client.Pool_patch.get_by_uuid ~rpc ~session_id ~uuid:patch_uuid
   in
@@ -7393,7 +7379,7 @@ let patch_precheck printer rpc session_id params =
   printer (Cli_printer.PList [result])
 
 let patch_pool_apply _printer rpc session_id params =
-  let patch_uuid = List.assoc "uuid" params in
+  let patch_uuid = Cli_args.get "uuid" params in
   let patch_ref =
     Client.Pool_patch.get_by_uuid ~rpc ~session_id ~uuid:patch_uuid
   in
@@ -7402,8 +7388,8 @@ let patch_pool_apply _printer rpc session_id params =
 let host_logs_download fd _printer rpc session_id params =
   let op n host =
     let filename =
-      if List.mem_assoc "file-name" params then
-        List.assoc "file-name" params
+      if Cli_args.exists "file-name" params then
+        Cli_args.get "file-name" params
       else
         let tm = Unix.gmtime (Unix.time ()) in
         Printf.sprintf "logs-%d-%d-%dT%02d%02d%02dZ" (tm.Unix.tm_year + 1900)
@@ -7442,7 +7428,7 @@ let host_is_in_emergency_mode printer rpc session_id _params =
   printer (Cli_printer.PMsg (Printf.sprintf "%b" mode))
 
 let host_emergency_management_reconfigure _printer rpc session_id params =
-  let interface = List.assoc "interface" params in
+  let interface = Cli_args.get "interface" params in
   Client.Host.local_management_reconfigure ~rpc ~session_id ~interface
 
 let host_emergency_ha_disable _printer rpc session_id params =
@@ -7474,7 +7460,8 @@ let host_emergency_clear_mandatory_guidance _printer rpc session_id _params =
 
 let host_management_reconfigure _printer rpc session_id params =
   let pif =
-    Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "pif-uuid" params)
+    Client.PIF.get_by_uuid ~rpc ~session_id
+      ~uuid:(Cli_args.get "pif-uuid" params)
   in
   Client.Host.management_reconfigure ~rpc ~session_id ~pif
 
@@ -7485,32 +7472,32 @@ let host_signal_networking_change _printer rpc session_id _params =
   Client.Host.signal_networking_change ~rpc ~session_id
 
 let host_notify _printer rpc session_id params =
-  let ty = List.assoc "type" params in
-  let args = Listext.assoc_default "params" params "" in
+  let ty = Cli_args.get "type" params in
+  let args = Cli_args.get_default "params" params "" in
   Client.Host.notify ~rpc ~session_id ~ty ~params:args
 
 let host_syslog_reconfigure _printer rpc session_id params =
   let host =
     Client.Host.get_by_uuid ~rpc ~session_id
-      ~uuid:(List.assoc "host-uuid" params)
+      ~uuid:(Cli_args.get "host-uuid" params)
   in
   Client.Host.syslog_reconfigure ~rpc ~session_id ~host
 
 let host_send_debug_keys _printer rpc session_id params =
   let host =
     Client.Host.get_by_uuid ~rpc ~session_id
-      ~uuid:(List.assoc "host-uuid" params)
+      ~uuid:(Cli_args.get "host-uuid" params)
   in
-  let keys = List.assoc "keys" params in
+  let keys = Cli_args.get "keys" params in
   Client.Host.send_debug_keys ~rpc ~session_id ~host ~keys
 
 let task_cancel _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let task = Client.Task.get_by_uuid ~rpc ~session_id ~uuid in
   Client.Task.cancel ~rpc ~session_id ~task
 
 let subject_add printer rpc session_id params =
-  let subject_name = List.assoc "subject-name" params in
+  let subject_name = Cli_args.get "subject-name" params in
   (* let's try to resolve the subject_name to a subject_id using the external directory *)
   let subject_identifier =
     Client.Auth.get_subject_identifier ~rpc ~session_id ~subject_name
@@ -7527,21 +7514,21 @@ let subject_add printer rpc session_id params =
 
 let subject_remove _printer rpc session_id params =
   (* we are removing by subject-uuid *)
-  let subject_uuid = List.assoc "subject-uuid" params in
+  let subject_uuid = Cli_args.get "subject-uuid" params in
   let subject =
     Client.Subject.get_by_uuid ~rpc ~session_id ~uuid:subject_uuid
   in
   Client.Subject.destroy ~rpc ~session_id ~self:subject
 
 let subject_role_common rpc session_id params =
-  let role_uuid = Listext.assoc_default "role-uuid" params "" in
-  let role_name = Listext.assoc_default "role-name" params "" in
+  let role_uuid = Cli_args.get_default "role-uuid" params "" in
+  let role_name = Cli_args.get_default "role-name" params "" in
   if role_uuid = "" && role_name = "" then
     failwith "Required parameter not found: role-uuid or role-name"
   else if role_uuid <> "" && role_name <> "" then
     failwith "Parameters role-uuid and role-name cannot be used together"
   else
-    let subject_uuid = List.assoc "uuid" params in
+    let subject_uuid = Cli_args.get "uuid" params in
     let role =
       if role_uuid <> "" then
         Client.Role.get_by_uuid ~rpc ~session_id ~uuid:role_uuid
@@ -7569,11 +7556,11 @@ let subject_role_remove _printer rpc session_id params =
   Client.Subject.remove_from_roles ~rpc ~session_id ~self:subject ~role
 
 let audit_log_get fd _printer rpc session_id params =
-  let filename = List.assoc "filename" params in
+  let filename = Cli_args.get "filename" params in
   let since =
-    if List.mem_assoc "since" params then
+    if Cli_args.exists "since" params then
       (* make sure since has a reasonable length *)
-      let unsanitized_since = List.assoc "since" params in
+      let unsanitized_since = Cli_args.get "since" params in
       if String.length unsanitized_since > 255 then
         String.sub unsanitized_since 0 255
       else
@@ -7615,7 +7602,7 @@ let session_subject_identifier_list printer rpc session_id _params =
   printer (Cli_printer.PTable all)
 
 let session_subject_identifier_logout _printer rpc session_id params =
-  let subject_identifier = List.assoc "subject-identifier" params in
+  let subject_identifier = Cli_args.get "subject-identifier" params in
   Client.Session.logout_subject_identifier ~rpc ~session_id ~subject_identifier
 
 let session_subject_identifier_logout_all _printer rpc session_id _params =
@@ -7630,21 +7617,21 @@ let session_subject_identifier_logout_all _printer rpc session_id _params =
     subject_identifiers
 
 let secret_create printer rpc session_id params =
-  let value = List.assoc "value" params in
+  let value = Cli_args.get "value" params in
   let other_config = read_map_params "other-config" params in
   let ref = Client.Secret.create ~rpc ~session_id ~value ~other_config in
   let uuid = Client.Secret.get_uuid ~rpc ~session_id ~self:ref in
   printer (Cli_printer.PList [uuid])
 
 let secret_destroy _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let ref = Client.Secret.get_by_uuid ~rpc ~session_id ~uuid in
   Client.Secret.destroy ~rpc ~session_id ~self:ref
 
 let vmss_create printer rpc session_id params =
   let get ?default param_name =
-    if List.mem_assoc param_name params then
-      List.assoc param_name params
+    if Cli_args.exists param_name params then
+      Cli_args.get param_name params
     else
       match default with
       | Some default_value ->
@@ -7652,7 +7639,7 @@ let vmss_create printer rpc session_id params =
       | None ->
           failwith ("No default value for parameter " ^ param_name)
   in
-  let name_label = List.assoc "name-label" params in
+  let name_label = Cli_args.get "name-label" params in
   let ty = Record_util.vmss_type_of_string (get "type") in
   let frequency = Record_util.vmss_frequency_of_string (get "frequency") in
   let schedule = read_map_params "schedule" params in
@@ -7670,15 +7657,15 @@ let vmss_create printer rpc session_id params =
   printer (Cli_printer.PList [uuid])
 
 let vmss_destroy _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let ref = Client.VMSS.get_by_uuid ~rpc ~session_id ~uuid in
   Client.VMSS.destroy ~rpc ~session_id ~self:ref
 
 let vm_appliance_create printer rpc session_id params =
-  let name_label = List.assoc "name-label" params in
+  let name_label = Cli_args.get "name-label" params in
   let name_description =
-    if List.mem_assoc "name-description" params then
-      List.assoc "name-description" params
+    if Cli_args.exists "name-description" params then
+      Cli_args.get "name-description" params
     else
       ""
   in
@@ -7689,18 +7676,18 @@ let vm_appliance_create printer rpc session_id params =
   printer (Cli_printer.PList [uuid])
 
 let vm_appliance_destroy _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let ref = Client.VM_appliance.get_by_uuid ~rpc ~session_id ~uuid in
   Client.VM_appliance.destroy ~rpc ~session_id ~self:ref
 
 let vm_appliance_start _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let paused = get_bool_param params "paused" in
   let ref = Client.VM_appliance.get_by_uuid ~rpc ~session_id ~uuid in
   Client.VM_appliance.start ~rpc ~session_id ~self:ref ~paused
 
 let vm_appliance_shutdown _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let force = get_bool_param params "force" in
   let ref = Client.VM_appliance.get_by_uuid ~rpc ~session_id ~uuid in
   if force then
@@ -7710,7 +7697,7 @@ let vm_appliance_shutdown _printer rpc session_id params =
 
 let vm_appliance_recover _printer rpc session_id params =
   let force = get_bool_param params "force" in
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   with_database_vdi rpc session_id params (fun database_session ->
       let appliance =
         Client.VM_appliance.get_by_uuid ~rpc ~session_id:database_session ~uuid
@@ -7720,7 +7707,7 @@ let vm_appliance_recover _printer rpc session_id params =
   )
 
 let vm_appliance_assert_can_be_recovered _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   with_database_vdi rpc session_id params (fun database_session ->
       let appliance =
         Client.VM_appliance.get_by_uuid ~rpc ~session_id:database_session ~uuid
@@ -7730,10 +7717,8 @@ let vm_appliance_assert_can_be_recovered _printer rpc session_id params =
   )
 
 let gpu_group_create printer rpc session_id params =
-  let name_label = List.assoc "name-label" params in
-  let name_description =
-    try List.assoc "name-description" params with Not_found -> ""
-  in
+  let name_label = Cli_args.get "name-label" params in
+  let name_description = Cli_args.get_default "name-description" params "" in
   let gpu_group =
     Client.GPU_group.create ~rpc ~session_id ~name_label ~name_description
       ~other_config:[]
@@ -7742,13 +7727,13 @@ let gpu_group_create printer rpc session_id params =
   printer (Cli_printer.PList [uuid])
 
 let gpu_group_destroy _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let gpu_group = Client.GPU_group.get_by_uuid ~rpc ~session_id ~uuid in
   Client.GPU_group.destroy ~rpc ~session_id ~self:gpu_group
 
 let gpu_group_get_remaining_capacity printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
-  let vgpu_type_uuid = List.assoc "vgpu-type-uuid" params in
+  let uuid = Cli_args.get "uuid" params in
+  let vgpu_type_uuid = Cli_args.get "vgpu-type-uuid" params in
   let gpu_group = Client.GPU_group.get_by_uuid ~rpc ~session_id ~uuid in
   let vgpu_type =
     Client.VGPU_type.get_by_uuid ~rpc ~session_id ~uuid:vgpu_type_uuid
@@ -7761,21 +7746,21 @@ let gpu_group_get_remaining_capacity printer rpc session_id params =
 
 let vgpu_create printer rpc session_id params =
   let device =
-    if List.mem_assoc "device" params then
-      List.assoc "device" params
+    if Cli_args.exists "device" params then
+      Cli_args.get "device" params
     else
       "0"
   in
-  let gpu_group_uuid = List.assoc "gpu-group-uuid" params in
-  let vm_uuid = List.assoc "vm-uuid" params in
+  let gpu_group_uuid = Cli_args.get "gpu-group-uuid" params in
+  let vm_uuid = Cli_args.get "vm-uuid" params in
   let vM = Client.VM.get_by_uuid ~rpc ~session_id ~uuid:vm_uuid in
   let gPU_group =
     Client.GPU_group.get_by_uuid ~rpc ~session_id ~uuid:gpu_group_uuid
   in
   let _type =
-    if List.mem_assoc "vgpu-type-uuid" params then
+    if Cli_args.exists "vgpu-type-uuid" params then
       Client.VGPU_type.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "vgpu-type-uuid" params)
+        ~uuid:(Cli_args.get "vgpu-type-uuid" params)
     else
       Ref.null
   in
@@ -7787,16 +7772,16 @@ let vgpu_create printer rpc session_id params =
   printer (Cli_printer.PList [uuid])
 
 let vgpu_destroy _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let vgpu = Client.VGPU.get_by_uuid ~rpc ~session_id ~uuid in
   Client.VGPU.destroy ~rpc ~session_id ~self:vgpu
 
 let dr_task_create printer rpc session_id params =
-  let _type = List.assoc "type" params in
+  let _type = Cli_args.get "type" params in
   let device_config = read_map_params "device-config" params in
   let whitelist =
-    if List.mem_assoc "sr-whitelist" params then
-      String.split_on_char ',' (List.assoc "sr-whitelist" params)
+    if Cli_args.exists "sr-whitelist" params then
+      String.split_on_char ',' (Cli_args.get "sr-whitelist" params)
     else
       []
   in
@@ -7807,31 +7792,31 @@ let dr_task_create printer rpc session_id params =
   printer (Cli_printer.PList [uuid])
 
 let dr_task_destroy _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let ref = Client.DR_task.get_by_uuid ~rpc ~session_id ~uuid in
   Client.DR_task.destroy ~rpc ~session_id ~self:ref
 
 let pgpu_enable_dom0_access printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let ref = Client.PGPU.get_by_uuid ~rpc ~session_id ~uuid in
   let result = Client.PGPU.enable_dom0_access ~rpc ~session_id ~self:ref in
   printer (Cli_printer.PMsg (Record_util.pci_dom0_access_to_string result))
 
 let pgpu_disable_dom0_access printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let ref = Client.PGPU.get_by_uuid ~rpc ~session_id ~uuid in
   let result = Client.PGPU.disable_dom0_access ~rpc ~session_id ~self:ref in
   printer (Cli_printer.PMsg (Record_util.pci_dom0_access_to_string result))
 
 let lvhd_enable_thin_provisioning _printer rpc session_id params =
-  let sr_uuid = List.assoc "sr-uuid" params in
+  let sr_uuid = Cli_args.get "sr-uuid" params in
   let initial_allocation =
     Record_util.bytes_of_string "initial-allocation"
-      (List.assoc "initial-allocation" params)
+      (Cli_args.get "initial-allocation" params)
   in
   let allocation_quantum =
     Record_util.bytes_of_string "allocation-quantum"
-      (List.assoc "allocation-quantum" params)
+      (Cli_args.get "allocation-quantum" params)
   in
   ignore
     (do_host_op rpc session_id
@@ -7846,30 +7831,28 @@ let lvhd_enable_thin_provisioning _printer rpc session_id params =
     )
 
 let pci_enable_dom0_access printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let ref = Client.PCI.get_by_uuid ~rpc ~session_id ~uuid in
   let result = Client.PCI.enable_dom0_access ~rpc ~session_id ~self:ref in
   printer (Cli_printer.PMsg (Record_util.pci_dom0_access_to_string result))
 
 let pci_disable_dom0_access printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let ref = Client.PCI.get_by_uuid ~rpc ~session_id ~uuid in
   let result = Client.PCI.disable_dom0_access ~rpc ~session_id ~self:ref in
   printer (Cli_printer.PMsg (Record_util.pci_dom0_access_to_string result))
 
 let get_dom0_access_status printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let ref = Client.PCI.get_by_uuid ~rpc ~session_id ~uuid in
   let result = Client.PCI.get_dom0_access_status ~rpc ~session_id ~self:ref in
   printer (Cli_printer.PMsg (Record_util.pci_dom0_access_to_string result))
 
 module PVS_site = struct
   let introduce printer rpc session_id params =
-    let name_label = List.assoc "name-label" params in
-    let name_description =
-      try List.assoc "name-description" params with Not_found -> ""
-    in
-    let pVS_uuid = try List.assoc "pvs-uuid" params with Not_found -> "" in
+    let name_label = Cli_args.get "name-label" params in
+    let name_description = Cli_args.get_default "name-description" params "" in
+    let pVS_uuid = Cli_args.get_default "pvs-uuid" params "" in
     let ref =
       Client.PVS_site.introduce ~rpc ~session_id ~name_label ~name_description
         ~pVS_uuid
@@ -7878,17 +7861,19 @@ module PVS_site = struct
     printer (Cli_printer.PList [uuid])
 
   let forget _printer rpc session_id params =
-    let uuid = List.assoc "uuid" params in
+    let uuid = Cli_args.get "uuid" params in
     let ref = Client.PVS_site.get_by_uuid ~rpc ~session_id ~uuid in
     Client.PVS_site.forget ~rpc ~session_id ~self:ref
 end
 
 module PVS_server = struct
   let introduce printer rpc session_id params =
-    let addresses = List.assoc "addresses" params |> String.split_on_char ',' in
-    let first_port = List.assoc "first-port" params |> Int64.of_string in
-    let last_port = List.assoc "last-port" params |> Int64.of_string in
-    let site_uuid = List.assoc "pvs-site-uuid" params in
+    let addresses =
+      Cli_args.get "addresses" params |> String.split_on_char ','
+    in
+    let first_port = Cli_args.get "first-port" params |> Int64.of_string in
+    let last_port = Cli_args.get "last-port" params |> Int64.of_string in
+    let site_uuid = Cli_args.get "pvs-site-uuid" params in
     let site = Client.PVS_site.get_by_uuid ~rpc ~session_id ~uuid:site_uuid in
     let ref =
       Client.PVS_server.introduce ~rpc ~session_id ~addresses ~first_port
@@ -7898,23 +7883,23 @@ module PVS_server = struct
     printer (Cli_printer.PList [uuid])
 
   let forget _printer rpc session_id params =
-    let uuid = List.assoc "uuid" params in
+    let uuid = Cli_args.get "uuid" params in
     let ref = Client.PVS_server.get_by_uuid ~rpc ~session_id ~uuid in
     Client.PVS_server.forget ~rpc ~session_id ~self:ref
 end
 
 module PVS_proxy = struct
   let create printer rpc session_id params =
-    let site_uuid = List.assoc "pvs-site-uuid" params in
+    let site_uuid = Cli_args.get "pvs-site-uuid" params in
     let site = Client.PVS_site.get_by_uuid ~rpc ~session_id ~uuid:site_uuid in
-    let vif_uuid = List.assoc "vif-uuid" params in
+    let vif_uuid = Cli_args.get "vif-uuid" params in
     let vIF = Client.VIF.get_by_uuid ~rpc ~session_id ~uuid:vif_uuid in
     let ref = Client.PVS_proxy.create ~rpc ~session_id ~site ~vIF in
     let uuid = Client.PVS_proxy.get_uuid ~rpc ~session_id ~self:ref in
     printer (Cli_printer.PList [uuid])
 
   let destroy _printer rpc session_id params =
-    let uuid = List.assoc "uuid" params in
+    let uuid = Cli_args.get "uuid" params in
     let ref = Client.PVS_proxy.get_by_uuid ~rpc ~session_id ~uuid in
     Client.PVS_proxy.destroy ~rpc ~session_id ~self:ref
 end
@@ -7924,14 +7909,14 @@ module PVS_cache_storage = struct
     ignore
       (do_host_op rpc session_id ~multiple:false
          (fun _ host ->
-           let sr_uuid = List.assoc "sr-uuid" params in
+           let sr_uuid = Cli_args.get "sr-uuid" params in
            let sR = Client.SR.get_by_uuid ~rpc ~session_id ~uuid:sr_uuid in
-           let site_uuid = List.assoc "pvs-site-uuid" params in
+           let site_uuid = Cli_args.get "pvs-site-uuid" params in
            let site =
              Client.PVS_site.get_by_uuid ~rpc ~session_id ~uuid:site_uuid
            in
            let size =
-             Record_util.bytes_of_string "size" (List.assoc "size" params)
+             Record_util.bytes_of_string "size" (Cli_args.get "size" params)
            in
            let ref =
              Client.PVS_cache_storage.create ~rpc ~session_id
@@ -7947,13 +7932,13 @@ module PVS_cache_storage = struct
       )
 
   let destroy _printer rpc session_id params =
-    let uuid = List.assoc "uuid" params in
+    let uuid = Cli_args.get "uuid" params in
     let ref = Client.PVS_cache_storage.get_by_uuid ~rpc ~session_id ~uuid in
     Client.PVS_cache_storage.destroy ~rpc ~session_id ~self:ref
 end
 
 let update_introduce printer rpc session_id params =
-  let vdi_uuid = List.assoc "vdi-uuid" params in
+  let vdi_uuid = Cli_args.get "vdi-uuid" params in
   let vdi_ref = Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:vdi_uuid in
   let update = Client.Pool_update.introduce ~rpc ~session_id ~vdi:vdi_ref in
   let uuid = Client.Pool_update.get_uuid ~rpc ~session_id ~self:update in
@@ -7969,7 +7954,7 @@ let livepatch_status_to_string state =
       "Ok: Patch can be applied, but a reboot will be required."
 
 let update_precheck printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let result =
     do_host_op rpc session_id
       (fun _ host ->
@@ -7983,7 +7968,7 @@ let update_precheck printer rpc session_id params =
   printer (Cli_printer.PList result_msg)
 
 let update_apply _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   ignore
     (do_host_op rpc session_id
        (fun _ host ->
@@ -7995,27 +7980,27 @@ let update_apply _printer rpc session_id params =
     )
 
 let update_pool_apply _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let ref = Client.Pool_update.get_by_uuid ~rpc ~session_id ~uuid in
   Client.Pool_update.pool_apply ~rpc ~session_id ~self:ref
 
 let update_pool_clean _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let ref = Client.Pool_update.get_by_uuid ~rpc ~session_id ~uuid in
   Client.Pool_update.pool_clean ~rpc ~session_id ~self:ref
 
 let update_destroy _printer rpc session_id params =
-  let uuid = List.assoc "uuid" params in
+  let uuid = Cli_args.get "uuid" params in
   let ref = Client.Pool_update.get_by_uuid ~rpc ~session_id ~uuid in
   Client.Pool_update.destroy ~rpc ~session_id ~self:ref
 
 let update_resync_host _printer rpc session_id params =
-  let uuid = List.assoc "host-uuid" params in
+  let uuid = Cli_args.get "host-uuid" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid in
   Client.Pool_update.resync_host ~rpc ~session_id ~host
 
 let host_apply_updates _printer rpc session_id params =
-  let hash = List.assoc "hash" params in
+  let hash = Cli_args.get "hash" params in
   ignore
     (do_host_op rpc session_id ~multiple:false
        (fun _ host ->
@@ -8051,22 +8036,22 @@ let host_disable_ssh _printer rpc session_id params =
 module SDN_controller = struct
   let introduce printer rpc session_id params =
     let port =
-      if List.mem_assoc "tcp-port" params then
-        try Int64.of_string (List.assoc "tcp-port" params)
+      if Cli_args.exists "tcp-port" params then
+        try Int64.of_string (Cli_args.get "tcp-port" params)
         with _ -> failwith "port field should be an integer"
       else
         0L
     in
     let protocol =
-      if List.mem_assoc "protocol" params then
+      if Cli_args.exists "protocol" params then
         Record_util.sdn_controller_protocol_of_string
-          (List.assoc "protocol" params)
+          (Cli_args.get "protocol" params)
       else
         `ssl
     in
     let address =
-      if List.mem_assoc "address" params then
-        List.assoc "address" params
+      if Cli_args.exists "address" params then
+        Cli_args.get "address" params
       else
         ""
     in
@@ -8077,14 +8062,14 @@ module SDN_controller = struct
     printer (Cli_printer.PList [uuid])
 
   let forget _printer rpc session_id params =
-    let uuid = List.assoc "uuid" params in
+    let uuid = Cli_args.get "uuid" params in
     let ref = Client.SDN_controller.get_by_uuid ~rpc ~session_id ~uuid in
     Client.SDN_controller.forget ~rpc ~session_id ~self:ref
 end
 
 module PUSB = struct
   let scan _printer rpc session_id params =
-    let host_uuid = List.assoc "host-uuid" params in
+    let host_uuid = Cli_args.get "host-uuid" params in
     let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
     Client.PUSB.scan ~rpc ~session_id ~host
 end
@@ -8092,11 +8077,12 @@ end
 module VUSB = struct
   let create printer rpc session_id params =
     let vM =
-      Client.VM.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "vm-uuid" params)
+      Client.VM.get_by_uuid ~rpc ~session_id
+        ~uuid:(Cli_args.get "vm-uuid" params)
     in
     let uSB_group =
       Client.USB_group.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "usb-group-uuid" params)
+        ~uuid:(Cli_args.get "usb-group-uuid" params)
     in
     let vusb =
       Client.VUSB.create ~rpc ~session_id ~vM ~uSB_group ~other_config:[]
@@ -8106,20 +8092,20 @@ module VUSB = struct
 
   let unplug _printer rpc session_id params =
     let vusb =
-      Client.VUSB.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+      Client.VUSB.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
     in
     Client.VUSB.unplug ~rpc ~session_id ~self:vusb
 
   let destroy _printer rpc session_id params =
     let vusb =
-      Client.VUSB.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+      Client.VUSB.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
     in
     ignore (Client.VUSB.destroy ~rpc ~session_id ~self:vusb)
 end
 
 module Cluster = struct
   let pool_create printer rpc session_id params =
-    let network_uuid = List.assoc "network-uuid" params in
+    let network_uuid = Cli_args.get "network-uuid" params in
     let cluster_stack =
       get_param params "cluster-stack"
         ~default:Constants.default_smapiv3_cluster_stack
@@ -8143,28 +8129,28 @@ module Cluster = struct
     printer (Cli_printer.PList [uuid])
 
   let pool_force_destroy _printer rpc session_id params =
-    let cluster_uuid = List.assoc "cluster-uuid" params in
+    let cluster_uuid = Cli_args.get "cluster-uuid" params in
     let cluster_ref =
       Client.Cluster.get_by_uuid ~rpc ~session_id ~uuid:cluster_uuid
     in
     Client.Cluster.pool_force_destroy ~rpc ~session_id ~self:cluster_ref
 
   let pool_destroy _printer rpc session_id params =
-    let cluster_uuid = List.assoc "cluster-uuid" params in
+    let cluster_uuid = Cli_args.get "cluster-uuid" params in
     let cluster_ref =
       Client.Cluster.get_by_uuid ~rpc ~session_id ~uuid:cluster_uuid
     in
     Client.Cluster.pool_destroy ~rpc ~session_id ~self:cluster_ref
 
   let pool_resync _printer rpc session_id params =
-    let cluster_uuid = List.assoc "cluster-uuid" params in
+    let cluster_uuid = Cli_args.get "cluster-uuid" params in
     let cluster_ref =
       Client.Cluster.get_by_uuid ~rpc ~session_id ~uuid:cluster_uuid
     in
     Client.Cluster.pool_resync ~rpc ~session_id ~self:cluster_ref
 
   let create printer rpc session_id params =
-    let pif_uuid = List.assoc "pif-uuid" params in
+    let pif_uuid = Cli_args.get "pif-uuid" params in
     let pIF = Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:pif_uuid in
     let cluster_stack =
       get_param params "cluster-stack"
@@ -8187,16 +8173,16 @@ module Cluster = struct
     printer (Cli_printer.PList [uuid])
 
   let destroy _printer rpc session_id params =
-    let uuid = List.assoc "uuid" params in
+    let uuid = Cli_args.get "uuid" params in
     let ref = Client.Cluster.get_by_uuid ~rpc ~session_id ~uuid in
     Client.Cluster.destroy ~rpc ~session_id ~self:ref
 end
 
 module Cluster_host = struct
   let create printer rpc session_id params =
-    let cluster_uuid = List.assoc "cluster-uuid" params in
-    let host_uuid = List.assoc "host-uuid" params in
-    let pif_uuid = List.assoc "pif-uuid" params in
+    let cluster_uuid = Cli_args.get "cluster-uuid" params in
+    let host_uuid = Cli_args.get "host-uuid" params in
+    let pif_uuid = Cli_args.get "pif-uuid" params in
     let cluster =
       Client.Cluster.get_by_uuid ~rpc ~session_id ~uuid:cluster_uuid
     in
@@ -8211,32 +8197,32 @@ module Cluster_host = struct
     printer (Cli_printer.PList [uuid])
 
   let enable _printer rpc session_id params =
-    let uuid = List.assoc "uuid" params in
+    let uuid = Cli_args.get "uuid" params in
     let ref = Client.Cluster_host.get_by_uuid ~rpc ~session_id ~uuid in
     Client.Cluster_host.enable ~rpc ~session_id ~self:ref
 
   let disable _printer rpc session_id params =
-    let uuid = List.assoc "uuid" params in
+    let uuid = Cli_args.get "uuid" params in
     let ref = Client.Cluster_host.get_by_uuid ~rpc ~session_id ~uuid in
     Client.Cluster_host.disable ~rpc ~session_id ~self:ref
 
   let destroy _printer rpc session_id params =
-    let uuid = List.assoc "uuid" params in
+    let uuid = Cli_args.get "uuid" params in
     let ref = Client.Cluster_host.get_by_uuid ~rpc ~session_id ~uuid in
     Client.Cluster_host.destroy ~rpc ~session_id ~self:ref
 
   let force_destroy _printer rpc session_id params =
-    let uuid = List.assoc "uuid" params in
+    let uuid = Cli_args.get "uuid" params in
     let ref = Client.Cluster_host.get_by_uuid ~rpc ~session_id ~uuid in
     Client.Cluster_host.force_destroy ~rpc ~session_id ~self:ref
 end
 
 module Repository = struct
   let introduce printer rpc session_id params =
-    let name_label = List.assoc "name-label" params in
+    let name_label = Cli_args.get "name-label" params in
     let name_description = get_param params "name-description" ~default:"" in
-    let binary_url = List.assoc "binary-url" params in
-    let source_url = List.assoc "source-url" params in
+    let binary_url = Cli_args.get "binary-url" params in
+    let source_url = Cli_args.get "source-url" params in
     let update = get_bool_param params "update" in
     let gpgkey_path = get_param params "gpgkey-path" ~default:"" in
     let ref =
@@ -8247,7 +8233,7 @@ module Repository = struct
     printer (Cli_printer.PList [uuid])
 
   let introduce_bundle printer rpc session_id params =
-    let name_label = List.assoc "name-label" params in
+    let name_label = Cli_args.get "name-label" params in
     let name_description = get_param params "name-description" ~default:"" in
     let ref =
       Client.Repository.introduce_bundle ~rpc ~session_id ~name_label
@@ -8257,11 +8243,11 @@ module Repository = struct
     printer (Cli_printer.PList [uuid])
 
   let introduce_remote_pool fd printer rpc session_id params =
-    let name_label = List.assoc "name-label" params in
+    let name_label = Cli_args.get "name-label" params in
     let name_description = get_param params "name-description" ~default:"" in
-    let binary_url = List.assoc "binary-url" params in
+    let binary_url = Cli_args.get "binary-url" params in
     let certificate =
-      List.assoc "certificate-file" params
+      Cli_args.get "certificate-file" params
       |> get_file_or_fail fd "certificate file"
     in
     let ref =
@@ -8274,31 +8260,31 @@ module Repository = struct
   let forget _printer rpc session_id params =
     let ref =
       Client.Repository.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "uuid" params)
+        ~uuid:(Cli_args.get "uuid" params)
     in
     Client.Repository.forget ~rpc ~session_id ~self:ref
 
   let set_gpgkey_path _printer rpc session_id params =
     let ref =
       Client.Repository.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "uuid" params)
+        ~uuid:(Cli_args.get "uuid" params)
     in
-    let gpgkey_path = List.assoc "gpgkey-path" params in
+    let gpgkey_path = Cli_args.get "gpgkey-path" params in
     Client.Repository.set_gpgkey_path ~rpc ~session_id ~self:ref
       ~value:gpgkey_path
 end
 
 module Driver_variant = struct
   let select _ rpc session_id params =
-    let uuid = List.assoc "uuid" params in
+    let uuid = Cli_args.get "uuid" params in
     let self = Client.Driver_variant.get_by_uuid ~rpc ~session_id ~uuid in
     Client.Driver_variant.select ~rpc ~session_id ~self
 end
 
 module Host_driver = struct
   let select _ rpc session_id params =
-    let driver_uuid = List.assoc "uuid" params in
-    let name = List.assoc "variant-name" params in
+    let driver_uuid = Cli_args.get "uuid" params in
+    let name = Cli_args.get "variant-name" params in
     let driver =
       Client.Host_driver.get_by_uuid ~rpc ~session_id ~uuid:driver_uuid
     in
@@ -8319,7 +8305,7 @@ module Host_driver = struct
 
   let deselect _ rpc session_id params =
     fail_without_force params ;
-    let uuid = List.assoc "uuid" params in
+    let uuid = Cli_args.get "uuid" params in
     let self = Client.Host_driver.get_by_uuid ~rpc ~session_id ~uuid in
     Client.Host_driver.deselect ~rpc ~session_id ~self
 
@@ -8336,7 +8322,7 @@ end
 
 module VTPM = struct
   let create printer rpc session_id params =
-    let vm_uuid = List.assoc "vm-uuid" params in
+    let vm_uuid = Cli_args.get "vm-uuid" params in
     let vM = Client.VM.get_by_uuid ~rpc ~session_id ~uuid:vm_uuid in
     let is_unique =
       get_bool_param params "is_unique" || get_bool_param params "is-unique"
@@ -8346,7 +8332,7 @@ module VTPM = struct
     printer (Cli_printer.PList [uuid])
 
   let destroy _ rpc session_id params =
-    let uuid = List.assoc "uuid" params in
+    let uuid = Cli_args.get "uuid" params in
     fail_without_force params ;
     let ref = Client.VTPM.get_by_uuid ~rpc ~session_id ~uuid in
     Client.VTPM.destroy ~rpc ~session_id ~self:ref
@@ -8354,7 +8340,7 @@ end
 
 module Observer = struct
   let create printer rpc session_id params =
-    let name_label = List.assoc "name-label" params in
+    let name_label = Cli_args.get "name-label" params in
     let hosts =
       get_set_param params "host-uuids"
       |> List.map (fun uuid -> Client.Host.get_by_uuid ~rpc ~session_id ~uuid)
@@ -8363,12 +8349,12 @@ module Observer = struct
     let enabled = get_bool_param params "enabled" in
     let attributes = get_map_param params "attributes" in
     let endpoints =
-      List.assoc_opt "endpoints" params
+      Cli_args.get_opt "endpoints" params
       |> Option.fold ~none:[Tracing.bugtool_name]
            ~some:(String.split_on_char ',')
     in
     let components =
-      List.assoc_opt "components" params
+      Cli_args.get_opt "components" params
       |> Option.fold ~none:[] ~some:(String.split_on_char ',')
     in
     let observer =
@@ -8379,19 +8365,17 @@ module Observer = struct
     printer (Cli_printer.PList [uuid])
 
   let destroy _printer rpc session_id params =
-    let uuid = List.assoc "uuid" params in
+    let uuid = Cli_args.get "uuid" params in
     let self = Client.Observer.get_by_uuid ~rpc ~session_id ~uuid in
     Client.Observer.destroy ~rpc ~session_id ~self
 end
 
 module VM_group = struct
   let create printer rpc session_id params =
-    let name_label = List.assoc "name-label" params in
-    let name_description =
-      List.assoc_opt "name-description" params |> Option.value ~default:""
-    in
+    let name_label = Cli_args.get "name-label" params in
+    let name_description = Cli_args.get_default "name-description" params "" in
     let placement =
-      Record_util.vm_placement_policy_of_string (List.assoc "placement" params)
+      Record_util.vm_placement_policy_of_string (Cli_args.get "placement" params)
     in
     let ref =
       Client.VM_group.create ~rpc ~session_id ~name_label ~name_description
@@ -8403,7 +8387,7 @@ module VM_group = struct
   let destroy _printer rpc session_id params =
     let ref =
       Client.VM_group.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "uuid" params)
+        ~uuid:(Cli_args.get "uuid" params)
     in
     Client.VM_group.destroy ~rpc ~session_id ~self:ref
 end
@@ -8427,13 +8411,14 @@ module Caller = struct
 
   let destroy _printer rpc session_id params =
     let ref =
-      Client.Caller.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params)
+      Client.Caller.get_by_uuid ~rpc ~session_id
+        ~uuid:(Cli_args.get "uuid" params)
     in
     Client.Caller.destroy ~rpc ~session_id ~self:ref
 
   let query_usage printer rpc session_id params =
-    let uuid = List.assoc_opt "uuid" params in
-    let group = List.assoc_opt "group" params in
+    let uuid = Cli_args.get_opt "uuid" params in
+    let group = Cli_args.get_opt "group" params in
     let result =
       match (uuid, group) with
       | Some _, Some _ ->
@@ -8484,13 +8469,13 @@ module Rate_limit = struct
   let create printer rpc session_id params =
     let name_label = get_param params "name-label" ~default:"" in
     let name_description = get_param params "name-description" ~default:"" in
-    let burst_size = float_of_string (List.assoc "burst-size" params) in
-    let fill_rate = float_of_string (List.assoc "fill-rate" params) in
+    let burst_size = float_of_string (Cli_args.get "burst-size" params) in
+    let fill_rate = float_of_string (Cli_args.get "fill-rate" params) in
     let ref =
       Client.Rate_limit.create ~rpc ~session_id ~name_label ~name_description
         ~burst_size ~fill_rate
     in
-    ( match List.assoc_opt "caller-uuids" params with
+    ( match Cli_args.get_opt "caller-uuids" params with
     | None | Some "" ->
         ()
     | Some uuids ->
@@ -8507,45 +8492,45 @@ module Rate_limit = struct
   let destroy _printer rpc session_id params =
     let ref =
       Client.Rate_limit.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "uuid" params)
+        ~uuid:(Cli_args.get "uuid" params)
     in
     Client.Rate_limit.destroy ~rpc ~session_id ~self:ref
 
   let add_caller _printer rpc session_id params =
     let self =
       Client.Rate_limit.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "uuid" params)
+        ~uuid:(Cli_args.get "uuid" params)
     in
     let caller =
       Client.Caller.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "caller-uuid" params)
+        ~uuid:(Cli_args.get "caller-uuid" params)
     in
     Client.Rate_limit.add_caller ~rpc ~session_id ~self ~caller
 
   let remove_caller _printer rpc session_id params =
     let self =
       Client.Rate_limit.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "uuid" params)
+        ~uuid:(Cli_args.get "uuid" params)
     in
     let caller =
       Client.Caller.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "caller-uuid" params)
+        ~uuid:(Cli_args.get "caller-uuid" params)
     in
     Client.Rate_limit.remove_caller ~rpc ~session_id ~self ~caller
 
   let set_burst_size _printer rpc session_id params =
     let self =
       Client.Rate_limit.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "uuid" params)
+        ~uuid:(Cli_args.get "uuid" params)
     in
-    let value = float_of_string (List.assoc "value" params) in
+    let value = float_of_string (Cli_args.get "value" params) in
     Client.Rate_limit.set_burst_size ~rpc ~session_id ~self ~value
 
   let set_fill_rate _printer rpc session_id params =
     let self =
       Client.Rate_limit.get_by_uuid ~rpc ~session_id
-        ~uuid:(List.assoc "uuid" params)
+        ~uuid:(Cli_args.get "uuid" params)
     in
-    let value = float_of_string (List.assoc "value" params) in
+    let value = float_of_string (Cli_args.get "value" params) in
     Client.Rate_limit.set_fill_rate ~rpc ~session_id ~self ~value
 end

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -433,6 +433,7 @@ let stdparams =
   ; "all"
   ; "message-priority"
   ; "trace"
+  ; "report-ignored-params"
   ]
 
 let map_contents = Cli_args.map_contents

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -435,30 +435,25 @@ let stdparams =
   ; "trace"
   ]
 
+let map_contents = Cli_args.map_contents
+
 (* [params_except extra params] is the [(key, value)] pairs of [params] with the
    standard framework keys and [extra] removed. Used by commands that treat every
    remaining pair as data (map/set contents, event filters, report query
    strings); it is the boundary past which the command line is plain data rather
-   than tracked CLI arguments. *)
+   than tracked CLI arguments, so the returned entries are marked as read. *)
 let params_except extra params =
-  Cli_args.to_pairs params
-  |> List.filter (fun (k, _) -> not (List.mem k (extra @ stdparams)))
+  params
+  |> Cli_args.filter_out (fun k -> List.mem k (extra @ stdparams))
+  |> map_contents
 
 (* [override_param key value params] prepends [key=value], overriding whatever the
-   user supplied for [key] (subsequent lookups return [value]). *)
-let override_param = Cli_args.add
-
-(* [assoc_default_ci key params] looks up [key] in [params] ignoring the case of
-   the keys, defaulting to "". *)
-let assoc_default_ci key params =
-  let key = String.lowercase_ascii key in
-  Cli_args.to_pairs params
-  |> List.map (fun (k, v) -> (String.lowercase_ascii k, v))
-  |> fun params -> Listext.assoc_default key params ""
-
-(* This goes through the list of parameters, extracting any of the form map-name-key=value   *)
-(* where map-name is the name of a map in the class. These will be used to set the key-value *)
-(* pair in the map. Returns a list of params that didn't fit this form *)
+   user supplied for [key] (subsequent lookups return [value]). The synthetic
+   entry is marked read: it is never a parameter the user passed and forgot. *)
+let override_param key value params =
+  let params = Cli_args.add key value params in
+  Cli_args.mark_used key params ;
+  params
 
 let choose_params ?(key = "params") params defaults =
   if Cli_args.exists key params then
@@ -1518,7 +1513,7 @@ let pool_disable_binary_storage (_ : printer) rpc session_id (_ : params) =
   Client.Pool.disable_binary_storage ~rpc ~session_id
 
 let pool_ha_enable (_ : printer) rpc session_id params =
-  let configuration = Cli_args.to_pairs (Cli_maps.ha_config params) in
+  let configuration = map_contents (Cli_maps.ha_config params) in
   let uuids =
     Option.fold ~none:[] ~some:(String.split_on_char ',')
       (Cli_args.get_opt "heartbeat-sr-uuids" params)
@@ -1816,7 +1811,7 @@ let pool_deconfigure_wlb (_ : printer) rpc session_id (_ : params) =
   Client.Pool.deconfigure_wlb ~rpc ~session_id
 
 let pool_send_wlb_configuration (_ : printer) rpc session_id params =
-  let config = Cli_args.to_pairs (Cli_maps.config params) in
+  let config = map_contents (Cli_maps.config params) in
   Client.Pool.send_wlb_configuration ~rpc ~session_id ~config
 
 let pool_retrieve_wlb_configuration printer rpc session_id _params =
@@ -2046,8 +2041,8 @@ let vdi_create printer rpc session_id params =
       `user
   in
   let sharable = get_bool_param params "sharable" in
-  let sm_config = Cli_args.to_pairs (Cli_maps.sm_config params) in
-  let tags = Cli_args.keys (Cli_maps.tags params) in
+  let sm_config = map_contents (Cli_maps.sm_config params) in
+  let tags = Cli_args.keys (Cli_args.consume (Cli_maps.tags params)) in
   let vdi =
     Client.VDI.create ~rpc ~session_id ~name_label ~name_description:"" ~sR
       ~virtual_size ~_type:ty ~sharable ~read_only:false ~xenstore_data:[]
@@ -2074,9 +2069,9 @@ let vdi_introduce printer rpc session_id params =
   let sharable = get_bool_param params "sharable" in
   let read_only = get_bool_param params "read-only" in
   (* NB call is new so backwards compat other-config- not required *)
-  let other_config = Cli_args.to_pairs (Cli_maps.other_config params) in
-  let xenstore_data = Cli_args.to_pairs (Cli_maps.xenstore_data params) in
-  let sm_config = Cli_args.to_pairs (Cli_maps.sm_config params) in
+  let other_config = map_contents (Cli_maps.other_config params) in
+  let xenstore_data = map_contents (Cli_maps.xenstore_data params) in
+  let sm_config = map_contents (Cli_maps.sm_config params) in
   let location = Cli_args.get "location" params in
   let managed = get_bool_param params "managed" in
   let virtual_size = 0L and physical_utilisation = 0L in
@@ -2175,7 +2170,7 @@ let vdi_clone printer rpc session_id params =
   let vdi =
     Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
-  let driver_params = Cli_args.to_pairs (Cli_maps.driver_params params) in
+  let driver_params = map_contents (Cli_maps.driver_params params) in
   let name_label = Cli_args.get_opt "new-name-label" params in
   let name_description = Cli_args.get_opt "new-name-description" params in
   let newvdi = Client.VDI.clone ~rpc ~session_id ~vdi ~driver_params in
@@ -2194,7 +2189,7 @@ let vdi_snapshot printer rpc session_id params =
   let vdi =
     Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(Cli_args.get "uuid" params)
   in
-  let driver_params = Cli_args.to_pairs (Cli_maps.driver_params params) in
+  let driver_params = map_contents (Cli_maps.driver_params params) in
   let newvdi = Client.VDI.snapshot ~rpc ~session_id ~vdi ~driver_params in
   let newuuid = Client.VDI.get_uuid ~rpc ~session_id ~self:newvdi in
   printer (Cli_printer.PList [newuuid])
@@ -2616,7 +2611,7 @@ let sr_create fd _printer rpc session_id params =
   in
   let _type = Cli_args.get "type" params in
   let content_type = Cli_args.get_default "content-type" params "" in
-  let device_config = Cli_args.to_pairs (Cli_maps.device_config params) in
+  let device_config = map_contents (Cli_maps.device_config params) in
   (* If the device-config parameter is of the form k-filename=v, then we assume the
      	   key is 'k' and the value is stored in a file named 'v' *)
   let suffix = "-filename" in
@@ -2637,7 +2632,7 @@ let sr_create fd _printer rpc session_id params =
       )
       device_config
   in
-  let sm_config = Cli_args.to_pairs (Cli_maps.sm_config params) in
+  let sm_config = map_contents (Cli_maps.sm_config params) in
   let sr =
     Client.SR.create ~rpc ~session_id ~host ~device_config ~name_label
       ~name_description ~physical_size ~_type ~content_type ~shared ~sm_config
@@ -2652,7 +2647,7 @@ let sr_introduce printer rpc session_id params =
   let content_type = Cli_args.get_default "content-type" params "" in
   let uuid = Cli_args.get "uuid" params in
   let shared = get_bool_param params "shared" in
-  let sm_config = Cli_args.to_pairs (Cli_maps.sm_config params) in
+  let sm_config = map_contents (Cli_maps.sm_config params) in
   let _ =
     Client.SR.introduce ~rpc ~session_id ~uuid ~name_label ~name_description
       ~_type ~content_type ~shared ~sm_config
@@ -2665,8 +2660,8 @@ type probe_result = Raw of string (* SMAPIv1 adapters return arbitrary data *)
 let sr_probe printer rpc session_id params =
   let host = parse_host_uuid rpc session_id params in
   let _type = Cli_args.get "type" params in
-  let device_config = Cli_args.to_pairs (Cli_maps.device_config params) in
-  let sm_config = Cli_args.to_pairs (Cli_maps.sm_config params) in
+  let device_config = map_contents (Cli_maps.device_config params) in
+  let sm_config = map_contents (Cli_maps.sm_config params) in
   let txt =
     Client.SR.probe ~rpc ~session_id ~host ~_type ~device_config ~sm_config
   in
@@ -2684,8 +2679,8 @@ let sr_probe printer rpc session_id params =
 let sr_probe_ext printer rpc session_id params =
   let host = parse_host_uuid rpc session_id params in
   let _type = Cli_args.get "type" params in
-  let device_config = Cli_args.to_pairs (Cli_maps.device_config params) in
-  let sm_config = Cli_args.to_pairs (Cli_maps.sm_config params) in
+  let device_config = map_contents (Cli_maps.device_config params) in
+  let sm_config = map_contents (Cli_maps.sm_config params) in
   let results =
     Client.SR.probe_ext ~rpc ~session_id ~host ~device_config ~_type ~sm_config
   in
@@ -2794,7 +2789,7 @@ let sr_disable_database_replication _printer rpc session_id params =
 let pbd_create printer rpc session_id params =
   let host_uuid = Cli_args.get "host-uuid" params in
   let sr_uuid = Cli_args.get "sr-uuid" params in
-  let device_config = Cli_args.to_pairs (Cli_maps.device_config params) in
+  let device_config = map_contents (Cli_maps.device_config params) in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
   let sR = Client.SR.get_by_uuid ~rpc ~session_id ~uuid:sr_uuid in
   let pbd =
@@ -3275,8 +3270,7 @@ let select_vms ?(include_control_vms = false) ?(include_template_vms = false)
       params
   in
   (* Filter all the records *)
-  List.fold_left filter_records_on_fields all_recs
-    (Cli_args.to_pairs filter_params)
+  List.fold_left filter_records_on_fields all_recs (map_contents filter_params)
 
 let select_hosts rpc session_id params ignore_params =
   let host_name_or_ref =
@@ -3314,8 +3308,7 @@ let select_hosts rpc session_id params ignore_params =
       params
   in
   (* Filter all the records *)
-  List.fold_left filter_records_on_fields all_recs
-    (Cli_args.to_pairs filter_params)
+  List.fold_left filter_records_on_fields all_recs (map_contents filter_params)
 
 let select_srs rpc session_id params ignore_params =
   let sr_name_or_ref =
@@ -3351,8 +3344,7 @@ let select_srs rpc session_id params ignore_params =
       params
   in
   (* Filter all the records *)
-  List.fold_left filter_records_on_fields all_recs
-    (Cli_args.to_pairs filter_params)
+  List.fold_left filter_records_on_fields all_recs (map_contents filter_params)
 
 exception Multiple_failure of (string * string) list
 
@@ -3617,7 +3609,7 @@ let vm_call_plugin fd printer rpc session_id params =
   let vm = Client.VM.get_by_uuid ~rpc ~session_id ~uuid:vm_uuid in
   let plugin = Cli_args.get "plugin" params in
   let fn = Cli_args.get "fn" params in
-  let args = Cli_args.to_pairs (Cli_maps.args params) in
+  let args = map_contents (Cli_maps.args params) in
   let args = List.map (args_file fd) args in
   let result = Client.VM.call_plugin ~rpc ~session_id ~vm ~plugin ~fn ~args in
   printer (Cli_printer.PList [result])
@@ -3627,7 +3619,7 @@ let vm_call_host_plugin fd printer rpc session_id params =
   let vm = Client.VM.get_by_uuid ~rpc ~session_id ~uuid:vm_uuid in
   let plugin = Cli_args.get "plugin" params in
   let fn = Cli_args.get "fn" params in
-  let args = Cli_args.to_pairs (Cli_maps.args params) in
+  let args = map_contents (Cli_maps.args params) in
   let args = List.map (args_file fd) args in
   let result =
     Client.VM.call_host_plugin ~rpc ~session_id ~vm ~plugin ~fn ~args
@@ -4702,17 +4694,10 @@ let vm_migrate_sxm_params =
   ]
 
 let vm_migrate printer rpc session_id params =
-  (* Hack to match host-uuid and host-name for backwards compatibility *)
-  let params =
-    Cli_args.to_pairs params
-    |> List.map (fun (k, v) ->
-        if k = "host-uuid" || k = "host-name" then
-          ("host", v)
-        else
-          (k, v)
-    )
-    |> Cli_args.from_pairs
-  in
+  (* Accept host-uuid and host-name as aliases of host, for backwards
+     compatibility. *)
+  Cli_args.rename_key ~from_:"host-uuid" ~to_:"host" params ;
+  Cli_args.rename_key ~from_:"host-name" ~to_:"host" params ;
   let compress =
     (* Avoid setting a default for the compress option here if none
        given; let the API decide if no option is given. Otherwise API and
@@ -4839,7 +4824,7 @@ let vm_migrate printer rpc session_id params =
               let net = remote Client.Network.get_by_uuid ~uuid:net_uuid in
               (vif, net)
             )
-            (Cli_args.to_pairs (Cli_maps.vif params))
+            (map_contents (Cli_maps.vif params))
         in
         let vdi_map =
           List.map
@@ -4850,7 +4835,7 @@ let vm_migrate printer rpc session_id params =
               let sr = remote Client.SR.get_by_uuid ~uuid:sr_uuid in
               (vdi, sr)
             )
-            (Cli_args.to_pairs (Cli_maps.vdi params))
+            (map_contents (Cli_maps.vdi params))
         in
         let vgpu_map =
           List.map
@@ -4863,7 +4848,7 @@ let vm_migrate printer rpc session_id params =
               in
               (vgpu, gpu_group)
             )
-            (Cli_args.to_pairs (Cli_maps.vgpu params))
+            (map_contents (Cli_maps.vgpu params))
         in
         let preferred_sr =
           (* The preferred SR is determined to be as the SR that the
@@ -5033,7 +5018,7 @@ let vm_migrate printer rpc session_id params =
               in
               (vdi, vdi_fmt)
             )
-            (Cli_args.to_pairs (Cli_maps.image_format params))
+            (map_contents (Cli_maps.image_format params))
         in
         let new_vm =
           do_vm_op ~include_control_vms:false ~include_template_vms:true printer
@@ -5789,7 +5774,7 @@ let vm_import fd _printer rpc session_id params =
   let vm_metadata_only = get_bool_param params "metadata" in
   let force = get_bool_param params "force" in
   let dry_run = get_bool_param params "dry-run" in
-  let vdi_map = Cli_args.to_pairs (Cli_maps.vdi params) in
+  let vdi_map = map_contents (Cli_maps.vdi params) in
   if Cli_args.exists "url" params && Cli_args.exists "filename" params then (
     marshal fd
       (Command
@@ -5803,7 +5788,7 @@ let vm_import fd _printer rpc session_id params =
   if Vpx_types.of_string _type <> Vpx_types.XenServer then
     let username = Cli_args.get "host-username" params in
     let password = Cli_args.get "host-password" params in
-    let remote_config = Cli_args.to_pairs (Cli_maps.remote_config params) in
+    let remote_config = map_contents (Cli_maps.remote_config params) in
     Client.VM.import_convert ~rpc ~session_id ~_type ~username ~password ~sr
       ~remote_config
   else if Cli_args.exists "url" params then
@@ -6446,8 +6431,9 @@ let diagnostic_net_stats printer rpc session_id params =
     ["method"; "uri"; "params"; "requests"; "connections"; "framed"]
   in
   let xapi_params =
-    Cli_args.to_pairs params
-    |> List.filter (fun (k, _) -> List.mem k args_pass_to_api)
+    params
+    |> Cli_args.filter (fun k -> List.mem k args_pass_to_api)
+    |> map_contents
   in
   ignore
     (do_host_op rpc session_id ~multiple:false
@@ -6606,10 +6592,10 @@ let pif_reconfigure_ip _printer rpc session_id params =
   let mode =
     Record_util.ip_configuration_mode_of_string (Cli_args.get "mode" params)
   in
-  let iP = assoc_default_ci "IP" params in
+  let iP = Cli_args.assoc_default_ci "IP" params in
   let netmask = Cli_args.get_default "netmask" params "" in
   let gateway = Cli_args.get_default "gateway" params "" in
-  let dNS = assoc_default_ci "DNS" params in
+  let dNS = Cli_args.assoc_default_ci "DNS" params in
   let () =
     Client.PIF.reconfigure_ip ~rpc ~session_id ~self:pif ~mode ~iP ~netmask
       ~gateway ~dNS
@@ -6623,9 +6609,9 @@ let pif_reconfigure_ipv6 _printer rpc session_id params =
   let mode =
     Record_util.ipv6_configuration_mode_of_string (Cli_args.get "mode" params)
   in
-  let iPv6 = assoc_default_ci "IPv6" params in
+  let iPv6 = Cli_args.assoc_default_ci "IPv6" params in
   let gateway = Cli_args.get_default "gateway" params "" in
-  let dNS = assoc_default_ci "DNS" params in
+  let dNS = Cli_args.assoc_default_ci "DNS" params in
   let () =
     Client.PIF.reconfigure_ipv6 ~rpc ~session_id ~self:pif ~mode ~iPv6 ~gateway
       ~dNS
@@ -6702,7 +6688,7 @@ let bond_create printer rpc session_id params =
   let mode =
     Record_util.bond_mode_of_string (Cli_args.get_default "mode" params "")
   in
-  let properties = Cli_args.to_pairs (Cli_maps.properties params) in
+  let properties = map_contents (Cli_maps.properties params) in
   let bond =
     Client.Bond.create ~rpc ~session_id ~network ~members:pifs ~mAC ~mode
       ~properties
@@ -6842,7 +6828,7 @@ let pool_apply_edition printer rpc session_id params =
 
 let host_set_power_on_mode _printer rpc session_id params =
   let power_on_mode = Cli_args.get "power-on-mode" params in
-  let power_on_config = Cli_args.to_pairs (Cli_maps.power_on_config params) in
+  let power_on_config = map_contents (Cli_maps.power_on_config params) in
   ignore
     (do_host_op rpc session_id
        (fun _ host ->
@@ -6861,8 +6847,9 @@ let host_crash_upload _printer rpc session_id params =
   let url = Cli_args.get_default "url" params "" in
   (* pass everything else in as an option *)
   let options =
-    Cli_args.to_pairs params
-    |> List.filter (fun (k, _) -> k <> "uuid" && k <> "url")
+    params
+    |> Cli_args.filter_out (fun k -> k = "uuid" || k = "url")
+    |> map_contents
   in
   Client.Host_crashdump.upload ~rpc ~session_id ~self:crash ~url ~options
 
@@ -6878,8 +6865,9 @@ let host_bugreport_upload _printer rpc session_id params =
     let url = Cli_args.get_default "url" params "" in
     (* pass everything else in as an option *)
     let options =
-      Cli_args.to_pairs params
-      |> List.filter (fun (k, _) -> k <> "host" && k <> "url")
+      params
+      |> Cli_args.filter_out (fun k -> k = "host" || k = "url")
+      |> map_contents
     in
     Client.Host.bugreport_upload ~rpc ~session_id ~host:(host.getref ()) ~url
       ~options
@@ -6972,13 +6960,13 @@ let pool_enable_external_auth _printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
   let auth_type = Cli_args.get "auth-type" params in
   let service_name = Cli_args.get "service-name" params in
-  let config = Cli_args.to_pairs (Cli_maps.config params) in
+  let config = map_contents (Cli_maps.config params) in
   Client.Pool.enable_external_auth ~rpc ~session_id ~pool ~config ~service_name
     ~auth_type
 
 let pool_disable_external_auth _printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
-  let config = Cli_args.to_pairs (Cli_maps.config params) in
+  let config = map_contents (Cli_maps.config params) in
   Client.Pool.disable_external_auth ~rpc ~session_id ~pool ~config
 
 let pool_external_auth_set_ldaps _printer rpc session_id params =
@@ -7133,7 +7121,7 @@ let host_call_plugin fd printer rpc session_id params =
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
   let plugin = Cli_args.get "plugin" params in
   let fn = Cli_args.get "fn" params in
-  let args = Cli_args.to_pairs (Cli_maps.args params) in
+  let args = map_contents (Cli_maps.args params) in
   let args = List.map (args_file fd) args in
   let result =
     Client.Host.call_plugin ~rpc ~session_id ~host ~plugin ~fn ~args
@@ -7149,7 +7137,7 @@ let host_enable_external_auth _printer rpc session_id params =
   let host_uuid = Cli_args.get "host-uuid" params in
   let auth_type = Cli_args.get "auth-type" params in
   let service_name = Cli_args.get "service-name" params in
-  let config = Cli_args.to_pairs (Cli_maps.config params) in
+  let config = map_contents (Cli_maps.config params) in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
   Client.Host.enable_external_auth ~rpc ~session_id ~host ~config ~service_name
     ~auth_type
@@ -7162,7 +7150,7 @@ let host_disable_external_auth _printer rpc session_id params =
        must be forced (use --force)." ;
   let host_uuid = Cli_args.get "host-uuid" params in
   let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:host_uuid in
-  let config = Cli_args.to_pairs (Cli_maps.config params) in
+  let config = map_contents (Cli_maps.config params) in
   Client.Host.disable_external_auth ~rpc ~session_id ~host ~config ~force:true
 
 let host_external_auth_set_ldaps _printer rpc session_id params =
@@ -7581,7 +7569,7 @@ let session_subject_identifier_logout_all _printer rpc session_id _params =
 
 let secret_create printer rpc session_id params =
   let value = Cli_args.get "value" params in
-  let other_config = Cli_args.to_pairs (Cli_maps.other_config params) in
+  let other_config = map_contents (Cli_maps.other_config params) in
   let ref = Client.Secret.create ~rpc ~session_id ~value ~other_config in
   let uuid = Client.Secret.get_uuid ~rpc ~session_id ~self:ref in
   printer (Cli_printer.PList [uuid])
@@ -7605,7 +7593,7 @@ let vmss_create printer rpc session_id params =
   let name_label = Cli_args.get "name-label" params in
   let ty = Record_util.vmss_type_of_string (get "type") in
   let frequency = Record_util.vmss_frequency_of_string (get "frequency") in
-  let schedule = Cli_args.to_pairs (Cli_maps.schedule params) in
+  let schedule = map_contents (Cli_maps.schedule params) in
   (* optional parameters with default values *)
   let name_description = get "name-description" ~default:"" in
   let enabled = get_bool_param ~default:true params "enabled" in
@@ -7741,7 +7729,7 @@ let vgpu_destroy _printer rpc session_id params =
 
 let dr_task_create printer rpc session_id params =
   let _type = Cli_args.get "type" params in
-  let device_config = Cli_args.to_pairs (Cli_maps.device_config params) in
+  let device_config = map_contents (Cli_maps.device_config params) in
   let whitelist =
     if Cli_args.exists "sr-whitelist" params then
       String.split_on_char ',' (Cli_args.get "sr-whitelist" params)

--- a/ocaml/xapi-cli-server/xapi_cli.ml
+++ b/ocaml/xapi-cli-server/xapi_cli.ml
@@ -410,7 +410,7 @@ let handler (req : Http.Request.t) (s : Unix.file_descr) _ =
   let session, args = parse_session_and_args str in
   try
     (* Unfortunately parse errors can happen preventing the '--trace' option from working *)
-    let cmd = parse_commandline ("xe" :: args) in
+    let cmd = parse_commandline ("xe", args) in
     match
       Backtrace.with_backtraces (fun () -> exec_command req cmd s session args)
     with

--- a/ocaml/xapi-cli-server/xapi_cli.ml
+++ b/ocaml/xapi-cli-server/xapi_cli.ml
@@ -96,11 +96,17 @@ let forward args s session =
 (* Check that keys are all present in cmd *)
 let check_required_keys cmd keylist = List.map (get_reqd_param cmd) keylist
 
-(* Whether this invocation asked for the ignored-parameter report:
-   report-ignored-params=warn, passed on the command line, via XE_EXTRA_ARGS, or
-   in ~/.xe. *)
+(* Whether this invocation asked for the ignored-parameter report. The
+   command-line value (also settable via XE_EXTRA_ARGS or ~/.xe) wins; when it
+   is absent, fall back to the report-ignored-params key in xapi.conf. *)
 let want_ignored_params_report params =
-  Cli_args.get_opt "report-ignored-params" params = Some "warn"
+  match Cli_args.get_opt "report-ignored-params" params with
+  | Some "warn" ->
+      true
+  | Some _ ->
+      false
+  | None ->
+      !Constants.cli_report_ignored_parameters = Constants.Warn
 
 (* Print, on stderr, one line per command-line parameter that the command never
    read -- only when the invocation asked for it. *)

--- a/ocaml/xapi-cli-server/xapi_cli.ml
+++ b/ocaml/xapi-cli-server/xapi_cli.ml
@@ -96,6 +96,22 @@ let forward args s session =
 (* Check that keys are all present in cmd *)
 let check_required_keys cmd keylist = List.map (get_reqd_param cmd) keylist
 
+(* Whether this invocation asked for the ignored-parameter report:
+   report-ignored-params=warn, passed on the command line, via XE_EXTRA_ARGS, or
+   in ~/.xe. *)
+let want_ignored_params_report params =
+  Cli_args.get_opt "report-ignored-params" params = Some "warn"
+
+(* Print, on stderr, one line per command-line parameter that the command never
+   read -- only when the invocation asked for it. *)
+let report_ignored_params printer cmd =
+  let params = get_params cmd in
+  if want_ignored_params_report params then
+    Cli_args.unused params
+    |> List.iter (fun k ->
+        printer (Cli_printer.PStderr ("Ignored parameter: " ^ k))
+    )
+
 let with_session ~local rpc u p session f =
   let session, logout =
     match (local, session) with
@@ -183,33 +199,34 @@ let do_rpcs req s username password minimal cmd session args =
       )
     else
       let printer, flush = Cli_printer.make_printer s minimal in
-      let flush_and_marshall () =
-        flush () ;
-        marshal s (Command (Exit 0))
+      let run () =
+        match cspec.implementation with
+        | No_fd f ->
+            with_session ~local:false rpc username password session
+              (fun session -> f printer rpc session (get_params cmd)
+            )
+        | No_fd_local_session f ->
+            with_session ~local:true rpc username password session
+              (fun session -> f printer rpc session (get_params cmd)
+            )
+        | With_fd f ->
+            with_session ~local:false rpc username password session
+              (fun session -> f s printer rpc session (get_params cmd)
+            )
+        | With_fd_local_session f ->
+            with_session ~local:true rpc username password session
+              (fun session -> f s printer rpc session (get_params cmd)
+            )
       in
-      match cspec.implementation with
-      | No_fd f ->
-          with_session ~local:false rpc username password session
-            (fun session ->
-              f printer rpc session (get_params cmd) ;
-              flush_and_marshall ()
-          )
-      | No_fd_local_session f ->
-          with_session ~local:true rpc username password session (fun session ->
-              f printer rpc session (get_params cmd) ;
-              flush_and_marshall ()
-          )
-      | With_fd f ->
-          with_session ~local:false rpc username password session
-            (fun session ->
-              f s printer rpc session (get_params cmd) ;
-              flush_and_marshall ()
-          )
-      | With_fd_local_session f ->
-          with_session ~local:true rpc username password session (fun session ->
-              f s printer rpc session (get_params cmd) ;
-              flush_and_marshall ()
-          )
+      (* Report the parameters the command ignored whether it succeeds or fails,
+         but before the terminating Exit so the client is still listening. On
+         success the Exit is sent afterwards; on failure it is the error path's
+         job. *)
+      Xapi_stdext_pervasives.Pervasiveext.finally run (fun () ->
+          report_ignored_params printer cmd
+      ) ;
+      flush () ;
+      marshal s (Command (Exit 0))
   with Unix.Unix_error (a, b, c) as e ->
     warn "Uncaught exception: Unix_error '%s' '%s' '%s'" (Unix.error_message a)
       b c ;
@@ -225,8 +242,12 @@ let uninteresting_cmd_postfixes = ["help"; "-get"; "-list"]
 
 let exec_command req cmd s session args =
   let params = get_params cmd in
-  (* Parameters consumed by the CLI framework itself, not by the command. *)
-  List.iter (fun k -> Cli_args.mark_used k params) Cli_args.reserved ;
+  (* Parameters consumed by the CLI framework itself, not by the command:
+     Cli_args.reserved, plus the global flags that only some commands read but
+     that are never a mistake to pass. *)
+  List.iter
+    (fun k -> Cli_args.mark_used k params)
+    (Cli_args.reserved @ ["trace"; "progress"]) ;
   let minimal =
     Cli_args.get_opt "minimal" params
     |> Option.fold ~none:false ~some:bool_of_string

--- a/ocaml/xapi-cli-server/xapi_cli.ml
+++ b/ocaml/xapi-cli-server/xapi_cli.ml
@@ -419,7 +419,7 @@ let handler (req : Http.Request.t) (s : Unix.file_descr) _ =
     | `Error (e, bt) ->
         exception_handler s e ;
         (* Command execution errors can use --trace *)
-        if Cli_operations.get_bool_param cmd.params "trace" then (
+        if Cli_operations.get_bool_param (get_params cmd) "trace" then (
           marshal s
             (Command
                (PrintStderr (Printf.sprintf "Raised %s\n" (Printexc.to_string e))

--- a/ocaml/xapi-cli-server/xapi_cli.ml
+++ b/ocaml/xapi-cli-server/xapi_cli.ml
@@ -94,9 +94,7 @@ let forward args s session =
   )
 
 (* Check that keys are all present in cmd *)
-let check_required_keys cmd keylist =
-  let (_ : (string * string) list) = get_params cmd in
-  List.map (get_reqd_param cmd) keylist
+let check_required_keys cmd keylist = List.map (get_reqd_param cmd) keylist
 
 let with_session ~local rpc u p session f =
   let session, logout =
@@ -228,11 +226,11 @@ let uninteresting_cmd_postfixes = ["help"; "-get"; "-list"]
 let exec_command req cmd s session args =
   let params = get_params cmd in
   let minimal =
-    List.assoc_opt "minimal" params
+    Cli_args.get_opt "minimal" params
     |> Option.fold ~none:false ~some:bool_of_string
   in
-  let u = try List.assoc "username" params with _ -> "" in
-  let p = try List.assoc "password" params with _ -> "" in
+  let u = try Cli_args.get "username" params with _ -> "" in
+  let p = try Cli_args.get "password" params with _ -> "" in
   (* Create a list of commands and their associated arguments which might be sensitive. *)
   let commands_and_params_to_hide =
     let starts affix = Astring.String.is_prefix ~affix in
@@ -295,7 +293,7 @@ let exec_command req cmd s session args =
               in
               k ^ "=" ^ v'
             )
-            params
+            (Cli_args.to_pairs params)
          )
       ) ;
     do_rpcs req s u p minimal cmd session args

--- a/ocaml/xapi-cli-server/xapi_cli.ml
+++ b/ocaml/xapi-cli-server/xapi_cli.ml
@@ -225,6 +225,8 @@ let uninteresting_cmd_postfixes = ["help"; "-get"; "-list"]
 
 let exec_command req cmd s session args =
   let params = get_params cmd in
+  (* Parameters consumed by the CLI framework itself, not by the command. *)
+  List.iter (fun k -> Cli_args.mark_used k params) Cli_args.reserved ;
   let minimal =
     Cli_args.get_opt "minimal" params
     |> Option.fold ~none:false ~some:bool_of_string
@@ -281,21 +283,7 @@ let exec_command req cmd s session args =
     let must_censor param_name =
       List.exists (fun filter -> filter param_name) param_filters
     in
-    do_log "xe %s %s" cmd_name
-      (String.concat " "
-         (List.map
-            (fun (k, v) ->
-              let v' =
-                if must_censor k then
-                  "(omitted)"
-                else
-                  v
-              in
-              k ^ "=" ^ v'
-            )
-            (Cli_args.to_pairs params)
-         )
-      ) ;
+    do_log "xe %s %s" cmd_name (Cli_args.log_args ~censor:must_censor params) ;
     do_rpcs req s u p minimal cmd session args
 
 let get_line str i =

--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -317,6 +317,13 @@ let owner_key = "owner"
 (* xapi-cli-server doesn't link xapi-globs *)
 let use_event_next = ref false
 
+(* What xe does with command-line parameters that the command never read.
+   Set from xapi.conf (see xapi_globs), read by the CLI server; lives here
+   because xapi-cli-server doesn't link xapi-globs. *)
+type cli_report_ignored_parameters = Off | Warn
+
+let cli_report_ignored_parameters = ref Off
+
 (* the time taken to wait before restarting in a different mode for pool eject/join operations *)
 let fuse_time = ref 10.
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1605,6 +1605,22 @@ let other_options =
     , (fun () -> string_of_bool !Constants.use_event_next)
     , "Use deprecated Event.next instead of Event.from"
     )
+  ; ( "report-ignored-params"
+    , Arg.String
+        (fun s ->
+          Constants.cli_report_ignored_parameters :=
+            match s with "warn" -> Warn | _ -> Off
+        )
+    , (fun () ->
+        match !Constants.cli_report_ignored_parameters with
+        | Off ->
+            "off"
+        | Warn ->
+            "warn"
+      )
+    , "What xe does with command-line parameters a command did not read: 'off' \
+       (default) or 'warn' to print them on stderr."
+    )
   ; ( "nvidia_multi_vgpu_enabled_driver_versions"
     , Arg.String
         (fun x ->

--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -86,6 +86,8 @@ let usage () =
     [ --minimal ]              Output only values in a comma-separated lists
     [ --traceparent <value> ]  Distributed tracing context
     [ --trace ]                Show task stacktrace on failure
+    [ report-ignored-params=off|warn ]
+                               Report parameters the command ignored (on stderr)
     [ <other arguments> ... ]  Command-specific options
 
 A full list of commands can be obtained by running

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -25,7 +25,7 @@ verify-cert () {
 }
 
 mli-files () {
-  N=455
+  N=454
   X="ocaml/tests"
   X+="|ocaml/quicktest"
   X+="|ocaml/message-switch/core_test"
@@ -154,4 +154,3 @@ ocamlyacc
 unixgetenv
 hashtblfind
 unnecessary-length
-

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -3,7 +3,7 @@
 set -e
 
 list-hd () {
-  N=241
+  N=240
   LIST_HD=$(git grep -r --count 'List.hd' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$LIST_HD" -eq "$N" ]; then
     echo "OK counted $LIST_HD List.hd usages"

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -93,6 +93,11 @@ igd-passthru-vendor-whitelist = 8086
 # Allow the use of custom UEFI certificates
 # allow-custom-uefi-certs = false
 
+# What xe does with command-line parameters a command did not read: 'off'
+# (default) or 'warn' to print them on stderr. A report-ignored-params value on
+# the xe command line (or in XE_EXTRA_ARGS / ~/.xe) overrides this.
+# report-ignored-params = off
+
 # Paths to utilities: ############################################
 
 search-path = @LIBEXECDIR@:@OPTDIR@/bin


### PR DESCRIPTION
## Before this PR

As reported in [this forum post](https://xcp-ng.org/forum/topic/12248/xe-sr-create-ignores-other-config-auto-scan-true-during-sr-creation),
a command like

```
$ xe sr-create name-label=my-iso-sr type=iso \
     device-config:location=192.0.2.1:/isos \
     other-config:auto-scan=true
<sr-uuid>
```

creates the SR, but neither acts on `other-config:auto-scan` nor reports that it
went ignored.

## After this PR

This PR changes no behaviour until the report is explicitly switched on, by
setting `report-ignored-params` to `warn` in one of two ways:

- **Server-side** — `report-ignored-params = warn` in `/etc/xapi.conf`.
- **Client-side** — `report-ignored-params=warn` on the `xe` invocation, or once
  in `XE_EXTRA_ARGS` / `~/.xe`.

A client-side value overrides the server-side one.

With reporting enabled, the command from the previous section writes one more
line:

```
Ignored parameter: other-config:auto-scan
```

The ignored parameters are reported on stderr, as diagnostic output usually is.
Because a successful command can have ignored parameters too, this breaks an
`xe` invariant — that a successful command writes nothing to stderr, which some
scripts rely on. That is why reporting is off by default.

The command's own output, on stdout, is unaffected.

`*-list` commands are also unchanged: they read every extra `key=value` as a
record filter (`xe vm-list power-state=running`), so an unrecognised one is
already a hard error, not an ignored parameter.

A parameter can be reported as ignored for two distinct reasons: the
command finished but genuinely never needed it, or the command aborted
prematurely and never got as far as reading it. For example:

```
$ xe vdi-create sr-uuid=00000000 name-label=disk1 virtual-size=8GiB \
     type=user sm-config:foo=bar report-ignored-params=warn
Ignored parameter: type
Ignored parameter: sm-config:foo
The uuid you supplied was invalid.
type: SR
uuid: 00000000
```

`vdi-create` reads `sr-uuid` first; because that UUID doesn't resolve, the
command is interrupted before even getting a chance to consume `type` and
`sm-config:foo`. They are thus reported as ignored because they were
ignored by this run of the command, although they would not have been by
another (successful) run.

## How it works

The report is built by tracking which parameters an `xe` command effectively
reads as it runs.

This is achieved by making the representation of the command line abstract. It
used to be a plain `(string * string) list`, read directly with `List.assoc`;
it is now `Cli_args.t`, whose entries are reachable only through the `Cli_args`
API. Each accessor — `get`, `get_opt`, `exists`, and so on — sets a `used` flag
on the entry it touched. After the command runs, `Cli_args.unused` lists the
parameters that were ignored.

## Design choices

**Complete over early.** The report lists exactly what the command left unread,
so it cannot exist until the command has finished. A check *before* execution
(against the declared parameter lists in `cli_frontend.ml`) would catch some
mistakes ahead of any side effect, but only some — it cannot tell that
`message-create` reads the first of `vm-uuid`, `host-uuid`, `sr-uuid`,
`pool-uuid` present, so `vm-uuid=X sr-uuid=Y` silently drops `sr-uuid`. The
after-the-fact report is the price of catching every case.

Errors caught before the command runs — a command line that does not parse, an
unknown command, a missing required parameter — thus produce no report.

**A mode rather than a switch.** `report-ignored-params` takes `off` or `warn`
for now. A stricter `error` — exit non-zero when a parameter was ignored even
though the command itself succeeded — could be added later as a third value,
without a new setting or a rename, and without disturbing the `off` / `warn`
already written on command lines and in `xapi.conf`.

**Injected parameters count as used.** Some commands add filter parameters the
user never typed — VM selection, for instance, adds `is-control-domain=false` so
control domains are not matched. Those injected parameters are marked as used. A
parameter the *user* passed for the same key is not, so in a command that forces
it, `is-control-domain=true` is still reported as ignored.

**`progress` is kept out of the report; `force` and `multiple` are not.**
Framework keys — `server`, `username`, `trace` and the rest — are marked as
used: the command does not read them, but the framework does, so they are not
ignored. `progress` is a real command parameter, and strict accuracy would
report it when a command does not honour it. But it only controls display — a
`progress` the command does not honour costs nothing more than a missing
progress bar — so it stays out of the report. `force` and `multiple` change what
the command does, and a `force` or `multiple` the command ignores can mean the
user misunderstood it, so both stay in.

## How to review

Best reviewed commit by commit.

**1–3 — `Cli_frontend` tidy-ups.** An interface for `Cli_frontend` — which also
documents `parse_commandline`'s type change — plus a simpler `parse_commandline`
and removal of the dead `rio_help`. Unrelated to the feature; done first so they
stay out of the later diffs.

**4–7 — preparation for commit 8.** The parts of the parameter-handling code
that are not a straight substitution: `params_except`, `override_param` and
`assoc_default_ci` become helpers, and the `vm_migrate` options block is
rewritten. Isolating them here lets commit 8 be purely mechanical, with nothing
subtle folded in.

**8 — route every parameter access through `Cli_args`.** The largest diff, and a
pure mechanical substitution — no behaviour change. `List.assoc "x" params`
becomes `Cli_args.get "x" params`, and so on, across `cli_operations.ml`,
`cli_frontend.ml` and `xapi_cli.ml`. The type is abstract; `op` in `cli_cmdtable`
now carries `string Cli_args.t` instead of `(string * string) list`.

**9–11 — map/set plumbing**, still no behaviour change:
- `Cli_args.view`: a lens onto the `prefix:key=value` map/set entries (and the
  old `prefix-key=value` form).
- `Cli_maps`: one named view per map/set parameter, and the one place that lists
  them all.
- an optional `~key` for `choose_params` / `select_fields`, so `vm_disk_list_aux`
  stops rebuilding the parameter list just to rename `vbd-params` / `vdi-params`.

**12 — track reads.** Adds the `used` flag and the marking rules from *Design
choices*. Wholesale consumers call `Cli_args.consume`. `vm_migrate`'s parameter
aliasing switches to `Cli_args.rename_key`, which edits entries in place; the old
code round-tripped through `to_pairs` / `from_pairs` and lost the tracking.
`Cli_args.unused` is defined here but not yet called, so nothing observable
changes.

**13 — unit tests** for the tracking engine (`ocaml/tests/test_cli_args.ml`, in
`suite_alcotest`): which accessors mark, marking seen through a view or a derived
structure, prefix stripping, `consume` / `mark_used` / `rename_key`, and that
`unused` returns exactly the untouched keys.

**14 — the report.** `report_ignored_params` calls `unused` and prints, from a
`finally` around the command in `do_rpcs`, so it fires whether the command
succeeded or failed. Gated on `report-ignored-params=warn` on the invocation
(also settable via `XE_EXTRA_ARGS` / `~/.xe`).

**15 — add `xapi.conf` as a second place to switch it on.** Adds the
`report-ignored-params` key to `xapi.conf` as a fallback, consulted only when the
parameter is absent from the invocation.
