### PR TITLE
Update GitHub workflows

### DIFF
--- a/.github/workflows/codechecker.yml
+++ b/.github/workflows/codechecker.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -47,11 +47,11 @@ jobs:
         run: opam exec -- make compile_commands.json
 
       - name: Upload compile commands json
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: ${{ github.workspace }}/compile_commands.json
 
-      - uses: whisperity/codechecker-analysis-action@v1
+      - uses: whisperity/codechecker-analysis-action@c1fbda08799d91447c007e18db31e423ee37fccd
         id: codechecker
         with:
           ctu: true
@@ -59,7 +59,7 @@ jobs:
           analyze-output: "codechecker_results"
 
       - name: Upload CodeChecker report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: codechecker_results
           path: "${{ steps.codechecker.outputs.result-html-dir }}"
@@ -71,7 +71,7 @@ jobs:
         run: report-converter "codechecker_results" --type cppcheck --output codechecker.sarif --export sarif
 
       - name: Upload CodeChecker SARIF report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: codechecker_sarif
           path: codechecker.sarif

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
           ocaml-compiler: ${{ steps.dotenv.outputs.ocaml_version_full }}
           opam-repositories: |
             xs-opam: ${{ steps.dotenv.outputs.repository }}
-          dune-cache: true
+          cache: true
           opam-pin: false
           cache-prefix: v3-${{ steps.system-info.outputs.name }}-${{ steps.system-info.outputs.release }}
         env:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -40,7 +40,7 @@ jobs:
           ocaml-compiler: ${{ steps.dotenv.outputs.ocaml_version_full }}
           opam-repositories: |
             xs-opam: ${{ steps.dotenv.outputs.repository }}
-          dune-cache: true
+          cache: true
           opam-pin: false
 
       - name: Install ocamlformat

--- a/.github/workflows/generate-and-build-sdks.yml
+++ b/.github/workflows/generate-and-build-sdks.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -33,7 +33,7 @@ jobs:
         run: opam exec -- make sdk
 
       - name: Store C SDK source
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: SDK_Source_C
           path: |
@@ -41,25 +41,25 @@ jobs:
             !_build/install/default/share/c/dune
 
       - name: Store C# SDK source
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: SDK_Source_CSharp
           path: _build/install/default/share/csharp/*
 
       - name: Store PowerShell SDK source
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: SDK_Source_PowerShell
           path: _build/install/default/share/powershell/*
 
       - name: Store Java SDK source
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: SDK_Source_Java
           path: _build/install/default/share/java/*
 
       - name: Store Go SDK source
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: SDK_Artifacts_Go
           path: |
@@ -102,7 +102,7 @@ jobs:
         run: make -C source
 
       - name: Store C SDK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: SDK_Artifacts_C
           path: |
@@ -150,7 +150,7 @@ jobs:
           INPUTS_XAPI_VERSION: ${{ inputs.xapi_version }}
 
       - name: Store Java SDK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: SDK_Artifacts_Java
           path: target/*
@@ -201,7 +201,7 @@ jobs:
           --verbosity=normal
 
       - name: Store C# SDK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: SDK_Binaries_CSharp
           path: source/src/bin/Release/XenServer.NET.${{ env.XAPI_VERSION_NUMBER }}-prerelease-unsigned.nupkg
@@ -275,7 +275,7 @@ jobs:
           ForEach-Object -Process { Copy-Item -Verbose $_.FullName -Destination "output" }
 
       - name: Store PowerShell SDK (.NET ${{ matrix.dotnet }})
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: SDK_Binaries_XenServerPowerShell_NET${{ matrix.dotnet }}
           path: output/**/*

--- a/.github/workflows/go-ci/action.yml
+++ b/.github/workflows/go-ci/action.yml
@@ -3,12 +3,12 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version: '1.22.2'
-    
+
     - name: Lint for Go SDK
-      uses: golangci/golangci-lint-action@v4
+      uses: golangci/golangci-lint-action@v6
       with:
         version: v1.57.2
         working-directory: ${{ github.workspace }}/_build/install/default/share/go/src

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -32,15 +32,15 @@ jobs:
         python-version: ["3.11"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # To check which files changed: origin/master..HEAD
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{matrix.python-version}}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         name: Setup cache for running pre-commit fast
         with:
           path: ~/.cache/pre-commit
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Use python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 
@@ -34,7 +34,7 @@ jobs:
           make python
 
       - name: Store python distribution artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: XenAPI
           path: python3/examples/dist/

--- a/.github/workflows/sdk-ci/action.yml
+++ b/.github/workflows/sdk-ci/action.yml
@@ -3,7 +3,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '^3.12'
 

--- a/.github/workflows/setup-xapi-environment/action.yml
+++ b/.github/workflows/setup-xapi-environment/action.yml
@@ -58,7 +58,7 @@ runs:
         ocaml-compiler: ${{ inputs.ocaml_version }}
         opam-repositories: |
           xs-opam: ${{ steps.dotenv.outputs.repository }}
-        dune-cache: true
+        cache: true
         opam-pin: false
         cache-prefix: v3-${{ steps.system-info.outputs.name }}-${{ steps.system-info.outputs.release }}
       env:

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
             fetch-depth: 0
             persist-credentials: false


### PR DESCRIPTION
This PR updates a few things in GitHub workflows, to get read of a few warnings and errors in GitHub workflow runs.

The first commit updates a few versions of actions while the second uses `cache` rather than `dune-cache` in the `setup-ocaml` action, as `dune-cache` will become obsolete in v4 of the action and already yields a warning.

Among the references to actions that are updated by the first commit, two of them deserve a special mention:

1. golangci/golangci-lint-action is updated from v4 to v6, while the latest version is v9. This is because, from v7 onward, the action calls a different version of golangci-lint, which caused an error. With the commit in its current state the version of the linter which is called is kept.

2. whisperity/codechecker-analysis-action is updated from v1 (broken, failing on a GPG error) to the latest master. The hash of the latest commit of master is stored in the workflow to make sure builds are reproducible.