### PR TITLE
Get rid of 3 uses of physical equality

### DIFF
--- a/ocaml/forkexecd/src/child.ml
+++ b/ocaml/forkexecd/src/child.ml
@@ -223,7 +223,7 @@ let run state comms_sock fd_sock fd_sock_path =
         ([Unix.stdin; Unix.stdout; Unix.stderr] @ fds) ;
 
       (* Distance ourselves from our parent process: *)
-      if Unix.setsid () == -1 then failwith "Unix.setsid failed" ;
+      if Unix.setsid () = -1 then failwith "Unix.setsid failed" ;
 
       (* And exec *)
       try Unix.execve name (Array.of_list args) (Array.of_list state.env)

--- a/ocaml/libs/backtrace/lib/backtrace.ml
+++ b/ocaml/libs/backtrace/lib/backtrace.ml
@@ -130,7 +130,7 @@ let frame_of_slot slot =
         }
 
 let frame_eq a b =
-  a.process == b.process
+  String.equal a.process b.process
   && a.line = b.line
   && a.chars_start = b.chars_start
   && a.chars_end = b.chars_end

--- a/ocaml/libs/vhd/vhd_format/f.ml
+++ b/ocaml/libs/vhd/vhd_format/f.ml
@@ -2679,6 +2679,9 @@ functor
           coalesce_request (Some (`Copy (h, ofs, len))) (next ())
       | Cons (`Copy (h, ofs, len), next), Some (`Copy (h', ofs', len'))
         when coalesced_sectors ** Int64.of_int sector_size <= sync_limit ->
+          (* Only merge copies that read from the same open handle [h], i.e. the
+             same source file. Physical equality is deliberate here; a false
+             negative merely skips a coalescing opportunity. *)
           if ofs ++ len = ofs' && h == h' then
             coalesce_request ~coalesced_sectors:(coalesced_sectors ++ 1L)
               (Some (`Copy (h, ofs, len ++ len')))

--- a/ocaml/networkd/test/network_test_lacp_properties.ml
+++ b/ocaml/networkd/test/network_test_lacp_properties.ml
@@ -59,23 +59,20 @@ module OVS_Cli_test = struct
     String.concat " " args
 end
 
-(* XXX TODO write this test *)
 let test_lacp_aggregation_key_vsctl arg () =
   let module Ovs = Ovs.Make (OVS_Cli_test) in
   let bond = "bond0"
   and ifaces = ["eth0"; "eth1"]
   and bridge = "xapi1"
   and props = [("mode", "lacp"); ("lacp-aggregation-key", arg)]
-  (* other-config:lacp-aggregation-key=42 *)
-  and answer = "other-config:lacp-aggregation-key=" ^ arg in
+  and answer = Printf.sprintf "other-config:lacp-aggregation-key=\"%s\"" arg in
   Ovs.create_bond bond ifaces bridge props |> ignore ;
-  List.iter print_endline !OVS_Cli_test.vsctl_output ;
-  print_endline answer ;
-  (* todo: pass -> replace with bool *)
-  Alcotest.(
-    check pass "lacp_aggregation_key is passed to ovs-vsctl command" true
-      (List.exists (fun s -> String.trim s == answer) !OVS_Cli_test.vsctl_output)
-  )
+  Alcotest.(check bool)
+    "lacp_aggregation_key is passed to ovs-vsctl command" true
+    (List.exists
+       (fun s -> String.equal (String.trim s) answer)
+       !OVS_Cli_test.vsctl_output
+    )
 
 (* Test case for bond_create with default lacp-{time,aggregation-key} settings.
    This should not call ovs-vsctl with unfinished key=value arguments. So we

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -44,7 +44,7 @@ mli-files () {
 }
 
 structural-equality () {
-  N=8
+  N=7
   EQ=$(git grep -r --count ' == ' -- '**/*.ml' ':!ocaml/sdk-gen/**/*.ml' | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$EQ" -eq "$N" ]; then
     echo "OK counted $EQ usages of ' == '"

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -44,7 +44,7 @@ mli-files () {
 }
 
 structural-equality () {
-  N=10
+  N=8
   EQ=$(git grep -r --count ' == ' -- '**/*.ml' ':!ocaml/sdk-gen/**/*.ml' | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$EQ" -eq "$N" ]; then
     echo "OK counted $EQ usages of ' == '"


### PR DESCRIPTION
Removes three `==` comparisons and documents one that stays, taking the
`quality-gate.sh` count from 10 to 7.

- `child.ml`: `Unix.setsid () == -1` compares two `int`s — use `=`.
- `network_test_lacp_properties.ml`: `String.trim s == answer` compares
  freshly allocated strings and is always `false`; the test also asserted
  through Alcotest's `pass` (never fails), so it went unnoticed. Finished with
  `check bool` + `String.equal`.
- `backtrace.ml`: `frame_eq` compared `.process` with `==`, which only works
  because every frame shares the same `!my_name` string — use `String.equal`,
  like the adjacent `.filename` check.
- `f.ml`: comment explaining why the `h == h'` guard in `coalesce_request` is
  deliberately physical (same open handle ⇒ same source file).

The 7 remaining uses are deliberate: fast paths, cycle detection, and identity
comparisons on values that can't be compared structurally.
