### PR TITLE
CA-430692: RPU: host-evacuate fails for VMs restarted after the coord…

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -313,6 +313,18 @@ let compute_evacuation_plan_no_wlb ~__context ~host ?(ignore_ha = false) () =
       )
       target_hosts
   in
+  (* During upgrade/update, migrate to upgraded/updated hosts only. *)
+  let target_hosts =
+    if Helpers.rolling_upgrade_in_progress ~__context then
+      List.filter
+        (fun target ->
+          Helpers.Checks.RPU.host_has_highest_version_in_pool ~__context
+            ~host:(Helpers.LocalObject target)
+        )
+        target_hosts
+    else
+      target_hosts
+  in
   debug "evacuation target hosts are [%s]"
     (String.concat "; "
        (List.map (fun h -> Db.Host.get_hostname ~__context ~self:h) target_hosts)


### PR DESCRIPTION
…inator upgrade

During a Rolling Pool Upgrade (RPU), the host.evacuate may plan to migrate a VM to a not-upgraded host. But this may fail because the VM may have (re)started on the host during the upgrade, hence have inherited new pool level configurations from the upgraded coordinator host. One observed configuration is pool.cpu_info which contains the CPU feature set.

Generally, it is safe to migrate the VMs to only upgraded hosts to avoid such compatibility issues. For the specific CPU feature set, the whole story is something like: Xapi proposes a CPU feature set for a VM according to the pool.cpu_info. Xen actually determines which features can be used for the VM domain. The problem is currently the CPU feature set written to the VM.last_boot_CPU_flags by Xenopsd when VM has started is not the one Xen uses actually. Instead it is still the pool.cpu_info. The VM.last_boot_CPU_flags will be used for compatibility check before migration. This should be another fix. But migrating VMs to only upgraded hosts in host.evacuate is still desired to avoid potential compatibility issues.

Note the Helpers.rolling_upgrade_in_progress is for both upgrade and update. And HA is required to be disabled during upgrade and update. So it's no impact on that work flow.